### PR TITLE
docs: add troubleshooting guide for build issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 tools/ export-ignore
 
+

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,50 @@
+# Troubleshooting
+
+This guide contains common issues and solutions for building and developing the Groovy LSP.
+
+## Build Failures
+
+### Gradle Configuration Cache Issues
+
+**Symptoms:**
+- Build fails with `Spotless error! All target files must be within the project dir.`
+- Error message shows path mismatch (e.g., `/workspaces/...` vs `/Users/...`).
+- Occurs after switching environments (e.g., from Codespaces/Docker to local machine).
+
+**Cause:**
+Gradle's configuration cache may retain environment-specific paths (like the project root directory) from a previous build in a different environment. When you run the build in a new environment, these cached paths are invalid.
+
+**Solution:**
+
+1. **Stop the Gradle Daemon** to clear in-memory cache:
+   ```bash
+   ./gradlew --stop
+   ```
+
+2. **Clean build artifacts** and the local `.gradle` cache:
+   ```bash
+   rm -rf .gradle
+   find . -name "build" -type d -prune -exec rm -rf {} +
+   ```
+
+3. **Run build with configuration cache disabled** (once) to force a refresh:
+   ```bash
+   ./gradlew build --no-configuration-cache
+   ```
+
+4. **Resume normal building**:
+   ```bash
+   make build
+   ```
+
+### Lint/Formatting Issues
+
+**Symptoms:**
+- Build fails with `Spotless error!` or `Detekt error`.
+
+**Solution:**
+Run the auto-formatter to fix most issues automatically:
+```bash
+make format
+```
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -210,3 +210,4 @@ tasks.register("quality") {
     dependsOn(subprojects.map { it.tasks.named("quality") })
 }
 
+

--- a/tools/docker/factory-reset-docker-macos.sh
+++ b/tools/docker/factory-reset-docker-macos.sh
@@ -88,3 +88,4 @@ done
 echo ""
 log_success "Docker is reset and running! You can now rebuild your dev container."
 
+

--- a/tools/docker/prune-docker.sh
+++ b/tools/docker/prune-docker.sh
@@ -42,3 +42,4 @@ echo "✅ Cleanup complete."
 echo "If you still have issues, try 'docker system prune -a' (deletes all unused images)."
 echo "If you have severe corruption, use 'tools/docker/factory-reset-docker-macos.sh'."
 
+

--- a/tools/github-issues/README.md
+++ b/tools/github-issues/README.md
@@ -50,3 +50,4 @@ python3 issue_wizard.py
 
 
 
+


### PR DESCRIPTION
Adds a TROUBLESHOOTING.md guide to address Gradle Configuration Cache issues and lint failures. Also includes formatting fixes applied by 'make format'.