### PR TITLE
chore: migrate to gradle version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,12 +2,12 @@ import org.gradle.api.tasks.compile.GroovyCompile
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 
 plugins {
-    kotlin("jvm") version "2.2.21" apply false
-    id("com.gradleup.shadow") version "9.2.2" apply false
-    id("io.gitlab.arturbosch.detekt") version "1.23.8"
-    id("com.diffplug.spotless") version "8.1.0"
-    id("org.jetbrains.kotlinx.kover") version "0.9.3"
-    id("org.sonarqube") version "7.1.0.6387"
+    alias(libs.plugins.kotlin.jvm) apply false
+    alias(libs.plugins.shadow) apply false
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.spotless)
+    alias(libs.plugins.kover)
+    alias(libs.plugins.sonarqube)
     application
 }
 
@@ -39,11 +39,6 @@ subprojects {
         mavenCentral()
         mavenLocal()
         maven { url = uri("https://repo.gradle.org/gradle/libs-releases") }
-    }
-
-    dependencies {
-        // Add detekt-formatting plugin to the detekt configuration for all subprojects
-        "detektPlugins"("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.8")
     }
 
     // Code Quality Configuration

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,86 @@
+[versions]
+kotlin = "2.2.21"
+detekt = "1.23.8"
+spotless = "8.1.0"
+kover = "0.9.3"
+sonarqube = "7.1.0.6387"
+shadow = "9.2.2"
+gitHooks = "2.1.5"
+
+groovy = "4.0.29"
+lsp4j = "0.24.0"
+codenarc = "3.6.0-groovy-4.0"
+gmetrics = "2.1.0"
+gradleTooling = "9.2.1"
+coroutines = "1.10.2"
+collectionsImmutable = "0.4.0"
+slf4j = "2.0.17"
+logback = "1.5.21"
+rewriteGroovy = "8.67.0"
+
+junit = "5.14.0"
+junitPlatform = "1.11.0"
+assertj = "3.27.6"
+mockk = "1.14.6"
+spock = "2.3-groovy-4.0"
+
+jackson = "2.17.3"
+jsonPath = "2.9.0"
+
+[libraries]
+# Plugins (libraries for plugins block)
+detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
+
+# Groovy
+groovy-core = { module = "org.apache.groovy:groovy", version.ref = "groovy" }
+groovy-ant = { module = "org.apache.groovy:groovy-ant", version.ref = "groovy" }
+groovy-console = { module = "org.apache.groovy:groovy-console", version.ref = "groovy" }
+groovy-json = { module = "org.apache.groovy:groovy-json", version.ref = "groovy" }
+
+# LSP
+lsp4j = { module = "org.eclipse.lsp4j:org.eclipse.lsp4j", version.ref = "lsp4j" }
+lsp4j-jsonrpc = { module = "org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc", version.ref = "lsp4j" }
+
+# Code Quality & Analysis
+codenarc = { module = "org.codenarc:CodeNarc", version.ref = "codenarc" }
+gmetrics = { module = "org.gmetrics:GMetrics-Groovy4", version.ref = "gmetrics" }
+rewrite-groovy = { module = "org.openrewrite:rewrite-groovy", version.ref = "rewriteGroovy" }
+
+# Gradle Tooling
+gradle-tooling-api = { module = "org.gradle:gradle-tooling-api", version.ref = "gradleTooling" }
+
+# Kotlin
+kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+kotlin-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "collectionsImmutable" }
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+
+# Logging
+slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+
+# Testing
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatform" }
+assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+spock-core = { module = "org.spockframework:spock-core", version.ref = "spock" }
+json-path = { module = "com.jayway.jsonpath:json-path", version.ref = "jsonPath" }
+
+# Jackson
+jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }
+jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml" } # Version managed by BOM
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind" } # Version managed by BOM
+jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin" } # Version managed by BOM
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
+sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
+gitHooks = { id = "org.danilopianini.gradle-pre-commit-git-hooks", version.ref = "gitHooks" }
+

--- a/groovy-diagnostics/api/build.gradle.kts
+++ b/groovy-diagnostics/api/build.gradle.kts
@@ -9,5 +9,7 @@ java {
 }
 
 dependencies {
-    implementation("org.eclipse.lsp4j:org.eclipse.lsp4j:0.24.0")
+    implementation(libs.lsp4j)
+
+    detektPlugins(libs.detekt.formatting)
 }

--- a/groovy-diagnostics/codenarc/build.gradle.kts
+++ b/groovy-diagnostics/codenarc/build.gradle.kts
@@ -14,21 +14,23 @@ dependencies {
     implementation(project(":groovy-parser"))
 
     // LSP4J - Language Server Protocol implementation
-    implementation("org.eclipse.lsp4j:org.eclipse.lsp4j:0.24.0")
+    implementation(libs.lsp4j)
 
     // CodeNarc
-    implementation("org.codenarc:CodeNarc:3.6.0-groovy-4.0")
-    implementation("org.gmetrics:GMetrics-Groovy4:2.1.0")
-    implementation("org.apache.groovy:groovy:4.0.29")
-    implementation("org.apache.groovy:groovy-json:4.0.29")
+    implementation(libs.codenarc)
+    implementation(libs.gmetrics)
+    implementation(libs.groovy.core)
+    implementation(libs.groovy.json)
 
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
-    implementation("org.slf4j:slf4j-api:2.0.17")
+    implementation(libs.kotlin.coroutines.core)
+    implementation(libs.slf4j.api)
 
-    testImplementation(kotlin("test"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.14.0")
-    testImplementation("io.mockk:mockk:1.14.6")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+    detektPlugins(libs.detekt.formatting)
+
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlin.coroutines.test)
 }
 
 tasks.test {

--- a/groovy-formatter/build.gradle.kts
+++ b/groovy-formatter/build.gradle.kts
@@ -12,13 +12,15 @@ java {
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
-    implementation("org.openrewrite:rewrite-groovy:8.67.0")
+    implementation(libs.kotlin.stdlib)
+    implementation(libs.rewrite.groovy)
 
-    testImplementation("org.junit.jupiter:junit-jupiter:5.14.0")
-    testImplementation("org.assertj:assertj-core:3.27.6")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.14.0")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.11.0")
+    detektPlugins(libs.detekt.formatting)
+
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.assertj.core)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 tasks.test {

--- a/groovy-lsp/build.gradle.kts
+++ b/groovy-lsp/build.gradle.kts
@@ -16,48 +16,48 @@ version =
 
 dependencies {
     // LSP4J - Language Server Protocol implementation
-    implementation("org.eclipse.lsp4j:org.eclipse.lsp4j:0.24.0")
-    implementation("org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.24.0")
+    implementation(libs.lsp4j)
+    implementation(libs.lsp4j.jsonrpc)
 
     // Groovy - For AST parsing and analysis
-    implementation("org.apache.groovy:groovy:4.0.29")
+    implementation(libs.groovy.core)
     // Add additional Groovy modules that might be needed for compilation
-    implementation("org.apache.groovy:groovy-ant:4.0.29")
-    implementation("org.apache.groovy:groovy-console:4.0.29")
-    implementation("org.apache.groovy:groovy-json:4.0.29") // Required for CodeNarc JsonSlurper
+    implementation(libs.groovy.ant)
+    implementation(libs.groovy.console)
+    implementation(libs.groovy.json) // Required for CodeNarc JsonSlurper
 
     // CodeNarc - Static analysis for Groovy (Groovy 4.x compatible version)
     // CodeNarc is now a transitive dependency of the diagnostics module, but kept here for
     // backward compatibility if any direct usages remain during refactoring
-    implementation("org.codenarc:CodeNarc:3.6.0-groovy-4.0")
-    implementation("org.gmetrics:GMetrics-Groovy4:2.1.0") // Required for complexity rules
+    implementation(libs.codenarc)
+    implementation(libs.gmetrics) // Required for complexity rules
 
     // Gradle Tooling API - For dependency resolution
-    implementation("org.gradle:gradle-tooling-api:9.2.1")
+    implementation(libs.gradle.tooling.api)
 
     // Kotlin Coroutines
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+    implementation(libs.kotlin.coroutines.core)
 
     // Kotlin Immutable Collections for functional data structures
-    implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.4.0")
+    implementation(libs.kotlin.collections.immutable)
 
     // Logging
-    implementation("org.slf4j:slf4j-api:2.0.17")
-    implementation("ch.qos.logback:logback-classic:1.5.21")
+    implementation(libs.slf4j.api)
+    implementation(libs.logback.classic)
 
     // Testing - Kotlin/Java
-    testImplementation(kotlin("test"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.14.0")
-    testImplementation("org.assertj:assertj-core:3.27.6")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
-    testImplementation("io.mockk:mockk:1.14.6")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.kotlin.coroutines.test)
+    testImplementation(libs.mockk)
+    testRuntimeOnly(libs.junit.platform.launcher)
 
     // Testing - Groovy (Spock Framework) - JUnit 5 platform native
-    testImplementation("org.spockframework:spock-core:2.3-groovy-4.0")
+    testImplementation(libs.spock.core)
 
     // Code Quality Tools
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.8")
+    detektPlugins(libs.detekt.formatting)
 
     // Local Modules
     implementation(project(":groovy-formatter"))

--- a/groovy-parser/build.gradle.kts
+++ b/groovy-parser/build.gradle.kts
@@ -12,14 +12,16 @@ java {
 }
 
 dependencies {
-    api("org.apache.groovy:groovy:4.0.29")
+    api(libs.groovy.core)
 
-    implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.4.0")
-    implementation("org.slf4j:slf4j-api:2.0.17")
+    implementation(libs.kotlin.collections.immutable)
+    implementation(libs.slf4j.api)
 
-    testImplementation(kotlin("test"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.14.0")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+    detektPlugins(libs.detekt.formatting)
+
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.kotlin.coroutines.test)
 }
 
 tasks.test {

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -12,6 +12,10 @@ repositories {
 // Ensure groovy-lsp is evaluated so we can access its tasks
 evaluationDependsOn(":groovy-lsp")
 
+dependencies {
+    "detektPlugins"(libs.detekt.formatting)
+}
+
 testing {
     suites {
         register<JvmTestSuite>("e2eTest") {
@@ -30,22 +34,22 @@ testing {
                 implementation(project(":groovy-lsp"))
                 implementation(project(":groovy-formatter"))
 
-                implementation("org.eclipse.lsp4j:org.eclipse.lsp4j:0.24.0")
-                implementation(platform("com.fasterxml.jackson:jackson-bom:2.17.3"))
-                implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
-                implementation("com.fasterxml.jackson.core:jackson-databind")
-                implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-                implementation("com.jayway.jsonpath:json-path:2.9.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
-                implementation("org.slf4j:slf4j-api:2.0.17")
-                implementation("ch.qos.logback:logback-classic:1.5.18")
+                implementation(libs.lsp4j)
+                implementation(platform(libs.jackson.bom))
+                implementation(libs.jackson.dataformat.yaml)
+                implementation(libs.jackson.databind)
+                implementation(libs.jackson.module.kotlin)
+                implementation(libs.json.path)
+                implementation(libs.kotlin.coroutines.core)
+                implementation(libs.slf4j.api)
+                implementation(libs.logback.classic)
 
-                implementation("org.jetbrains.kotlin:kotlin-test")
-                implementation("org.junit.jupiter:junit-jupiter:5.14.0")
-                implementation("org.assertj:assertj-core:3.26.3")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
-                implementation("io.mockk:mockk:1.14.6")
-                implementation("org.spockframework:spock-core:2.3-groovy-4.0")
+                implementation(libs.kotlin.test)
+                implementation(libs.junit.jupiter)
+                implementation(libs.assertj.core)
+                implementation(libs.kotlin.coroutines.test)
+                implementation(libs.mockk)
+                implementation(libs.spock.core)
             }
 
             targets {


### PR DESCRIPTION
Migrates project dependencies and plugins to use Gradle Version Catalog (libs.versions.toml). Refactors subprojects to use explicit dependencies instead of root injection.