### PR TITLE
feat: add Kotlin LSP installer script for VS Code compatible editors

### DIFF
--- a/tools/editor/install-kotlin-lsp
+++ b/tools/editor/install-kotlin-lsp
@@ -1,0 +1,131 @@
+#!/bin/bash
+set -e
+
+# -----------------------------------------------------------------------------
+# tools/editor/install-kotlin-lsp - Install Kotlin LSP extension for VS Code compatible editors
+# -----------------------------------------------------------------------------
+# This script installs the Kotlin LSP VSIX extension for any VS Code compatible
+# editor (code, cursor, agy, etc.). It caches the VSIX file to avoid repeated
+# downloads.
+#
+# Usage:
+#   tools/editor/install-kotlin-lsp              # Uses 'code' by default
+#   tools/editor/install-kotlin-lsp cursor       # Uses 'cursor' instead
+#   tools/editor/install-kotlin-lsp agy          # Uses 'agy' instead
+# -----------------------------------------------------------------------------
+
+# Resolve paths
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+DEVCONTAINER_DIR="$ROOT_DIR/.devcontainer"
+CACHE_DIR="$DEVCONTAINER_DIR/cache"
+JSON_FILE="$DEVCONTAINER_DIR/devcontainer.json"
+
+# Determine editor command (default: code)
+EDITOR_CMD="${1:-code}"
+
+# Check if editor is available
+if ! command -v "$EDITOR_CMD" &> /dev/null; then
+    echo "❌ Error: '$EDITOR_CMD' command not found."
+    echo "   Please install $EDITOR_CMD or specify a different editor."
+    exit 1
+fi
+
+# Check dependencies
+if ! command -v jq &> /dev/null; then
+    echo "❌ Error: 'jq' is not installed. Please install it to run this script."
+    exit 1
+fi
+
+# Read configuration from devcontainer.json
+# Strip comments before parsing JSON
+VERSION=$(grep -v '^[[:space:]]*//' "$JSON_FILE" | jq -r '.build.args.KOTLIN_LSP_VERSION')
+CHECKSUM=$(grep -v '^[[:space:]]*//' "$JSON_FILE" | jq -r '.build.args.KOTLIN_LSP_SHA256')
+
+if [ "$VERSION" == "null" ] || [ "$CHECKSUM" == "null" ]; then
+    echo "❌ Error: Could not extract KOTLIN_LSP_VERSION or KOTLIN_LSP_SHA256 from $JSON_FILE"
+    exit 1
+fi
+
+FILENAME="kotlin-${VERSION}.vsix"
+FILE_PATH="$CACHE_DIR/$FILENAME"
+URL="https://download-cdn.jetbrains.com/kotlin-lsp/${VERSION}/${FILENAME}"
+
+echo "🔍 Kotlin LSP Version: $VERSION"
+echo "🎯 Editor: $EDITOR_CMD"
+echo "📦 Cache Location: $FILE_PATH"
+
+# -----------------------------------------------------------------------------
+# Step 1: Ensure VSIX is cached
+# -----------------------------------------------------------------------------
+
+if [ -f "$FILE_PATH" ]; then
+    echo "✅ Found cached VSIX file."
+    echo "   Verifying checksum..."
+    CURRENT_SUM=$(sha256sum "$FILE_PATH" | awk '{print $1}')
+    if [ "$CURRENT_SUM" == "$CHECKSUM" ]; then
+        echo "✅ Cache is valid."
+    else
+        echo "⚠️  Checksum mismatch! Cached file is invalid."
+        echo "   Expected: $CHECKSUM"
+        echo "   Found:    $CURRENT_SUM"
+        echo "   Re-downloading..."
+        rm -f "$FILE_PATH"
+        FILE_PATH=""
+    fi
+fi
+
+if [ ! -f "$FILE_PATH" ]; then
+    echo "⬇️  Downloading from $URL..."
+    mkdir -p "$CACHE_DIR"
+    
+    # Capture curl exit code to warn about disk space
+    set +e
+    curl -fSL -o "$FILE_PATH" "$URL"
+    CURL_EXIT=$?
+    set -e
+    
+    if [ $CURL_EXIT -ne 0 ]; then
+        echo "❌ Download failed with exit code $CURL_EXIT."
+        if [ $CURL_EXIT -eq 56 ] || [ $CURL_EXIT -eq 23 ]; then
+            echo "⚠️  Possible Cause: Disk Full (ENOSPC)."
+            echo "   - Please check your available disk space."
+            echo "   - Try running: docker system prune -a"
+        fi
+        rm -f "$FILE_PATH"
+        exit $CURL_EXIT
+    fi
+    
+    # Verify checksum
+    echo "🔐 Verifying checksum..."
+    CURRENT_SUM=$(sha256sum "$FILE_PATH" | awk '{print $1}')
+    if [ "$CURRENT_SUM" == "$CHECKSUM" ]; then
+        echo "✅ Download successful and verified."
+    else
+        echo "❌ Download corrupted."
+        echo "   Expected: $CHECKSUM"
+        echo "   Found:    $CURRENT_SUM"
+        rm -f "$FILE_PATH"
+        exit 1
+    fi
+fi
+
+# -----------------------------------------------------------------------------
+# Step 2: Install extension using the specified editor
+# -----------------------------------------------------------------------------
+
+echo ""
+echo "📥 Installing Kotlin LSP extension to $EDITOR_CMD..."
+
+# The --install-extension flag is standard across all VS Code compatible editors
+# (code, cursor, agy, codium, etc.)
+"$EDITOR_CMD" --install-extension "$FILE_PATH"
+
+if [ $? -eq 0 ]; then
+    echo "✅ Successfully installed Kotlin LSP extension!"
+    echo ""
+    echo "🎉 You can now use Kotlin LSP with $EDITOR_CMD"
+else
+    echo "❌ Failed to install extension."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

This PR adds a new utility script to install the Kotlin LSP extension for any VS Code compatible editor (code, cursor, agy, etc.).

## Changes

- Created `tools/editor/install-kotlin-lsp` script
- Supports multiple editors with code as default
- Reuses `.devcontainer/cache/` to avoid repeated downloads
- Verifies SHA256 checksums from `devcontainer.json`
- Uses standard `--install-extension` flag across all editors

## Usage

```bash
# Use with default editor (code)
tools/editor/install-kotlin-lsp

# Use with cursor
tools/editor/install-kotlin-lsp cursor

# Use with agy
tools/editor/install-kotlin-lsp agy
```

## Features

- ✅ Cache-aware (uses `.devcontainer/cache/`)
- ✅ Checksum verification
- ✅ Configurable editor (code/cursor/agy/etc.)
- ✅ Standard `--install-extension` command
- ✅ Disk space error handling