### PR TITLE
chore(build): Force sequential test execution on GitHub Actions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.api.tasks.compile.GroovyCompile
 import org.gradle.language.base.plugins.LifecycleBasePlugin
+import org.gradle.api.tasks.testing.Test
 
 plugins {
     alias(libs.plugins.kotlin.jvm) apply false
@@ -162,6 +163,15 @@ subprojects {
     // Make check task depend on quality checks
     tasks.check {
         dependsOn("detekt", "spotlessCheck")
+    }
+
+    // Force sequential test execution on GitHub Actions to avoid resource contention/flakiness
+    afterEvaluate {
+        if (System.getenv("GITHUB_ACTIONS") == "true") {
+            tasks.withType<Test>().configureEach {
+                maxParallelForks = 1
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This PR configures unit tests to run sequentially on GitHub Actions by setting .\n\nPreviously, unit tests were configured to run in parallel based on available processors, which can lead to resource contention and flakiness in CI environments, especially on GitHub Actions. This change aligns unit test execution with the existing e2e test configuration, which already runs sequentially for stability.\n\nThe sequential execution is conditionally applied only when the  environment variable is set to "true", ensuring that local development environments are not affected.