### PR TITLE
refactor: drop legacy ast visitor accessor

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/compilation/GroovyCompilationService.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/compilation/GroovyCompilationService.kt
@@ -3,7 +3,6 @@ package com.github.albertocavalcante.groovylsp.compilation
 import com.github.albertocavalcante.groovylsp.cache.LRUCache
 import com.github.albertocavalcante.groovyparser.GroovyParserFacade
 import com.github.albertocavalcante.groovyparser.api.ParseRequest
-import com.github.albertocavalcante.groovyparser.ast.AstVisitor
 import com.github.albertocavalcante.groovyparser.ast.GroovyAstModel
 import com.github.albertocavalcante.groovyparser.ast.SymbolTable
 import com.github.albertocavalcante.groovyparser.ast.symbols.SymbolIndex
@@ -90,9 +89,6 @@ class GroovyCompilationService {
         getParseResult(uri)?.diagnostics?.map { it.toLspDiagnostic() } ?: emptyList()
 
     fun getAstModel(uri: URI): GroovyAstModel? = getParseResult(uri)?.astModel
-
-    @Deprecated("Use getAstModel instead")
-    fun getAstVisitor(uri: URI): AstVisitor? = getParseResult(uri)?.astVisitor
 
     fun getSymbolTable(uri: URI): SymbolTable? = getParseResult(uri)?.symbolTable
 


### PR DESCRIPTION
## Summary
- remove deprecated getAstVisitor from GroovyCompilationService now that consumers use astModel

## Testing
- ./gradlew :groovy-lsp:compileKotlin --no-daemon --console=plain