### PR TITLE
feat: default to recursive ast visitor in lsp

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/compilation/GroovyCompilationService.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/compilation/GroovyCompilationService.kt
@@ -62,6 +62,7 @@ class GroovyCompilationService {
                 sourceRoots = workspaceManager.getSourceRoots(),
                 workspaceSources = workspaceManager.getWorkspaceSources(),
                 locatorCandidates = buildLocatorCandidates(uri, sourcePath),
+                useRecursiveVisitor = true,
             ),
         )
 


### PR DESCRIPTION
## Summary
- always request the recursive AST visitor in GroovyCompilationService
- ensures LSP paths use the recursive visitor by default

## Testing
- make build