### PR TITLE
feat: surface bundled Jenkins step completions

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/JenkinsStepCompletionProvider.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/JenkinsStepCompletionProvider.kt
@@ -1,0 +1,38 @@
+package com.github.albertocavalcante.groovylsp.providers.completion
+
+import com.github.albertocavalcante.groovyjenkins.metadata.BundledJenkinsMetadataLoader
+import org.eclipse.lsp4j.CompletionItem
+import org.eclipse.lsp4j.CompletionItemKind
+import org.eclipse.lsp4j.MarkupContent
+import org.eclipse.lsp4j.MarkupKind
+import org.eclipse.lsp4j.jsonrpc.messages.Either
+import org.slf4j.LoggerFactory
+
+/**
+ * Provides Jenkins step completions backed by bundled metadata.
+ */
+object JenkinsStepCompletionProvider {
+    private val logger = LoggerFactory.getLogger(JenkinsStepCompletionProvider::class.java)
+
+    private val bundledMetadata by lazy {
+        runCatching { BundledJenkinsMetadataLoader().load() }
+            .onFailure { logger.warn("Failed to load bundled Jenkins metadata", it) }
+            .getOrNull()
+    }
+
+    fun getBundledStepCompletions(): List<CompletionItem> {
+        val metadata = bundledMetadata ?: return emptyList()
+
+        return metadata.steps.values.map { step ->
+            val documentationText = step.documentation ?: "Jenkins pipeline step"
+            CompletionItem().apply {
+                label = step.name
+                kind = CompletionItemKind.Function
+                detail = "Jenkins step (${step.plugin})"
+                documentation = Either.forRight(
+                    MarkupContent(MarkupKind.MARKDOWN, documentationText),
+                )
+            }
+        }
+    }
+}

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/services/GroovyTextDocumentService.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/services/GroovyTextDocumentService.kt
@@ -7,6 +7,7 @@ import com.github.albertocavalcante.groovylsp.dsl.completion.GroovyCompletions
 import com.github.albertocavalcante.groovylsp.providers.SignatureHelpProvider
 import com.github.albertocavalcante.groovylsp.providers.codeaction.CodeActionProvider
 import com.github.albertocavalcante.groovylsp.providers.completion.CompletionProvider
+import com.github.albertocavalcante.groovylsp.providers.completion.JenkinsStepCompletionProvider
 import com.github.albertocavalcante.groovylsp.providers.definition.DefinitionProvider
 import com.github.albertocavalcante.groovylsp.providers.definition.DefinitionTelemetrySink
 import com.github.albertocavalcante.groovylsp.providers.references.ReferenceProvider
@@ -248,7 +249,14 @@ class GroovyTextDocumentService(
                 content,
             )
 
-            val allCompletions = basicCompletions + contextualCompletions
+            val isJenkinsFile = compilationService.workspaceManager.isJenkinsFile(uri)
+            val jenkinsCompletions = if (isJenkinsFile) {
+                JenkinsStepCompletionProvider.getBundledStepCompletions()
+            } else {
+                emptyList()
+            }
+
+            val allCompletions = basicCompletions + contextualCompletions + jenkinsCompletions
 
             logger.debug("Returning ${allCompletions.size} completions")
             Either.forLeft(allCompletions)

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/JenkinsBundledCompletionTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/JenkinsBundledCompletionTest.kt
@@ -1,0 +1,91 @@
+package com.github.albertocavalcante.groovylsp
+
+import kotlinx.coroutines.runBlocking
+import org.eclipse.lsp4j.CompletionItemKind
+import org.eclipse.lsp4j.CompletionParams
+import org.eclipse.lsp4j.InitializeParams
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.TextDocumentItem
+import org.eclipse.lsp4j.WorkspaceFolder
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class JenkinsBundledCompletionTest {
+
+    private var serverHandle: TestLanguageServerHandle? = null
+
+    @BeforeEach
+    fun setup() {
+        val runner = TestLanguageServerRunner()
+        serverHandle = runner.startInMemoryServer()
+
+        // Initialize the server with a workspace folder so Jenkins file detection works
+        val initParams = InitializeParams().apply {
+            workspaceFolders = listOf(WorkspaceFolder("file:///tmp/jenkins-test", "jenkins-test"))
+        }
+        serverHandle!!.server.initialize(initParams).get()
+        serverHandle!!.server.initialized(org.eclipse.lsp4j.InitializedParams())
+    }
+
+    @AfterEach
+    fun cleanup() {
+        serverHandle?.stop()
+    }
+
+    @Test
+    fun `jenkinsfile should include bundled jenkins step completions`() = runBlocking {
+        val uri = "file:///tmp/jenkins-test/Jenkinsfile"
+        val content = """
+            pipeline {
+              agent any
+              stages {
+                stage('Build') {
+                  steps {
+                    
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+
+        openDocument(uri, content)
+
+        // Position inside the empty steps block
+        val items = requestCompletionsAt(uri, Position(6, 8))
+
+        val sh = items.find { it.label == "sh" }
+        assertNotNull(sh, "Bundled Jenkins steps should surface 'sh' completion")
+        assertEquals(CompletionItemKind.Function, sh.kind)
+        assertTrue(sh.detail?.contains("workflow-durable-task-step") == true)
+    }
+
+    private suspend fun openDocument(uri: String, content: String) {
+        val textDoc = TextDocumentItem().apply {
+            this.uri = uri
+            languageId = "groovy"
+            version = 1
+            text = content
+        }
+
+        serverHandle!!.server.textDocumentService.didOpen(
+            org.eclipse.lsp4j.DidOpenTextDocumentParams().apply {
+                textDocument = textDoc
+            },
+        )
+    }
+
+    private suspend fun requestCompletionsAt(uri: String, position: Position): List<org.eclipse.lsp4j.CompletionItem> {
+        val params = CompletionParams().apply {
+            textDocument = TextDocumentIdentifier(uri)
+            this.position = position
+        }
+
+        val result = serverHandle!!.server.textDocumentService.completion(params).get()
+        return result.left
+    }
+}


### PR DESCRIPTION
## Summary
- add Jenkins step completion provider that loads bundled Jenkins metadata
- surface bundled Jenkins steps in Jenkinsfiles via GroovyTextDocumentService
- add integration test ensuring  completion appears in Jenkinsfiles

## Testing
- make build
- ./gradlew :groovy-lsp:test --tests "*JenkinsBundledCompletionTest"