### PR TITLE
feat: add Jenkins map-key completions

### DIFF
--- a/groovy-jenkins/src/main/resources/jenkins-stubs-metadata.json
+++ b/groovy-jenkins/src/main/resources/jenkins-stubs-metadata.json
@@ -32,6 +32,50 @@
         }
       },
       "documentation": "Shell Script step - Execute a shell command"
+    },
+    "echo": {
+      "plugin": "workflow-basic-steps:1000.v2f5c09b_74cf6",
+      "parameters": {
+        "message": {
+          "type": "String",
+          "required": true,
+          "documentation": "Message to print"
+        }
+      },
+      "documentation": "Print a message to the build log"
+    },
+    "git": {
+      "plugin": "git:5.2.1",
+      "parameters": {
+        "url": {
+          "type": "String",
+          "required": true,
+          "documentation": "Repository URL"
+        },
+        "branch": {
+          "type": "String",
+          "required": false,
+          "documentation": "Branch or ref to checkout"
+        },
+        "credentialsId": {
+          "type": "String",
+          "required": false,
+          "documentation": "Credentials ID for authentication"
+        },
+        "changelog": {
+          "type": "boolean",
+          "required": false,
+          "default": "true",
+          "documentation": "Include changelog"
+        },
+        "poll": {
+          "type": "boolean",
+          "required": false,
+          "default": "true",
+          "documentation": "Enable SCM polling"
+        }
+      },
+      "documentation": "Checkout from Git"
     }
   },
   "globalVariables": {

--- a/groovy-jenkins/src/test/kotlin/com/github/albertocavalcante/groovyjenkins/metadata/BundledJenkinsMetadataLoaderTest.kt
+++ b/groovy-jenkins/src/test/kotlin/com/github/albertocavalcante/groovyjenkins/metadata/BundledJenkinsMetadataLoaderTest.kt
@@ -64,6 +64,21 @@ class BundledJenkinsMetadataLoaderTest {
     }
 
     @Test
+    fun `should load metadata for echo and git steps`() {
+        val metadata = BundledJenkinsMetadataLoader().load()
+
+        val echo = metadata.getStep("echo")
+        assertNotNull(echo)
+        assertEquals("workflow-basic-steps:1000.v2f5c09b_74cf6", echo.plugin)
+        assertTrue(echo.parameters.containsKey("message"))
+
+        val git = metadata.getStep("git")
+        assertNotNull(git)
+        assertEquals("git:5.2.1", git.plugin)
+        assertTrue(git.parameters.keys.containsAll(listOf("url", "branch", "credentialsId")))
+    }
+
+    @Test
     fun `should load global variable metadata`() {
         // RED: Testing global variables like 'env', 'params', 'currentBuild'
         val loader = BundledJenkinsMetadataLoader()

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/JenkinsStepCompletionProvider.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/JenkinsStepCompletionProvider.kt
@@ -35,4 +35,22 @@ object JenkinsStepCompletionProvider {
             }
         }
     }
+
+    fun getBundledParameterCompletions(stepName: String, existingKeys: Set<String>): List<CompletionItem> {
+        val metadata = bundledMetadata ?: return emptyList()
+        val step = metadata.getStep(stepName) ?: return emptyList()
+
+        return step.parameters
+            .filterKeys { key -> key !in existingKeys }
+            .map { (key, param) ->
+                CompletionItem().apply {
+                    label = "$key:"
+                    kind = CompletionItemKind.Property
+                    detail = param.type
+                    documentation = param.documentation?.let {
+                        Either.forRight(MarkupContent(MarkupKind.MARKDOWN, it))
+                    }
+                }
+            }
+    }
 }

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/JenkinsBundledCompletionTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/JenkinsBundledCompletionTest.kt
@@ -64,6 +64,27 @@ class JenkinsBundledCompletionTest {
         assertTrue(sh.detail?.contains("workflow-durable-task-step") == true)
     }
 
+    @Test
+    fun `jenkinsfile should suggest map keys for bundled steps`() = runBlocking {
+        val uri = "file:///tmp/jenkins-test/Jenkinsfile"
+        val content = """
+            node {
+              sh(
+                
+              )
+            }
+        """.trimIndent()
+
+        openDocument(uri, content)
+
+        // Position inside the sh map literal area
+        val items = requestCompletionsAt(uri, Position(2, 4))
+
+        val returnStdout = items.find { it.label == "returnStdout:" }
+        assertNotNull(returnStdout, "Should suggest returnStdout map key for sh")
+        assertEquals(CompletionItemKind.Property, returnStdout.kind)
+    }
+
     private suspend fun openDocument(uri: String, content: String) {
         val textDoc = TextDocumentItem().apply {
             this.uri = uri


### PR DESCRIPTION
## Summary
- expand bundled Jenkins metadata with echo and git parameters
- surface bundled parameter map keys in Jenkinsfiles (e.g., sh returnStdout/returnStatus)
- add integration tests covering Jenkins map-key completions

## Testing
- make test
- ./gradlew :groovy-jenkins:test :groovy-lsp:test --tests "*JenkinsBundledCompletionTest"