### PR TITLE
fix: bundle groovy-macro to resolve AbstractMethodError

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ groovy-ant = { module = "org.apache.groovy:groovy-ant", version.ref = "groovy" }
 groovy-console = { module = "org.apache.groovy:groovy-console", version.ref = "groovy" }
 groovy-json = { module = "org.apache.groovy:groovy-json", version.ref = "groovy" }
 groovy-groovydoc = { module = "org.apache.groovy:groovy-groovydoc", version.ref = "groovy" }
+groovy-macro = { module = "org.apache.groovy:groovy-macro", version.ref = "groovy" }
 
 # LSP
 lsp4j = { module = "org.eclipse.lsp4j:org.eclipse.lsp4j", version.ref = "lsp4j" }

--- a/groovy-parser/build.gradle.kts
+++ b/groovy-parser/build.gradle.kts
@@ -14,6 +14,7 @@ java {
 
 dependencies {
     api(libs.groovy.core)
+    implementation(libs.groovy.macro)
 
     implementation(libs.kotlin.collections.immutable)
     implementation(libs.slf4j.api)


### PR DESCRIPTION
### Description
Resolves a `java.lang.AbstractMethodError` that occurs when the `MacroCallTransformingVisitor` is loaded from a user's project classpath (which may have an older or incompatible version of Groovy) instead of the LSP's classpath.

### Changes
- Adds `groovy-macro` to the `libs.versions.toml` catalog.
- Adds `groovy-macro` as an implementation dependency to `groovy-parser`.

### Verification
- Verified that `MacroCallTransformingVisitor` is now present in the shadow jar using `jar -tf`.
- Ran unit tests to ensure no regressions.