### PR TITLE
feat: improve java source navigation with accurate line numbers and javadoc hover

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/definition/DefinitionProvider.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/definition/DefinitionProvider.kt
@@ -88,8 +88,9 @@ class DefinitionProvider(
                         // Handle binary definition
                         val locationLink = LocationLink().apply {
                             targetUri = result.uri.toString()
-                            targetRange = org.eclipse.lsp4j.Range(Position(0, 0), Position(0, 0))
-                            targetSelectionRange = org.eclipse.lsp4j.Range(Position(0, 0), Position(0, 0))
+                            val range = result.range ?: org.eclipse.lsp4j.Range(Position(0, 0), Position(0, 0))
+                            targetRange = range
+                            targetSelectionRange = range
                             originSelectionRange = originNode.toLspRange()
                         }
                         logger.debug("Found binary definition link to ${locationLink.targetUri}")
@@ -216,7 +217,10 @@ class DefinitionProvider(
 
                     is DefinitionResolver.DefinitionResult.Binary -> {
                         val location =
-                            Location(result.uri.toString(), org.eclipse.lsp4j.Range(Position(0, 0), Position(0, 0)))
+                            Location(
+                                result.uri.toString(),
+                                result.range ?: org.eclipse.lsp4j.Range(Position(0, 0), Position(0, 0)),
+                            )
                         logger.debug("Found binary definition at ${location.uri}")
                         telemetrySink.report(
                             DefinitionTelemetryEvent(

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/services/GroovyTextDocumentService.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/services/GroovyTextDocumentService.kt
@@ -299,6 +299,7 @@ class GroovyTextDocumentService(
         val hoverProvider = com.github.albertocavalcante.groovylsp.providers.hover.HoverProvider(
             compilationService,
             documentProvider,
+            sourceNavigationService,
         )
         val hover = hoverProvider.provideHover(params.textDocument.uri, params.position)
 

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/sources/JavaSourceInspector.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/sources/JavaSourceInspector.kt
@@ -1,0 +1,73 @@
+package com.github.albertocavalcante.groovylsp.sources
+
+import com.github.albertocavalcante.groovylsp.documentation.DocExtractor
+import com.github.albertocavalcante.groovylsp.documentation.Documentation
+import com.github.albertocavalcante.groovyparser.GroovyParserFacade
+import com.github.albertocavalcante.groovyparser.api.ParseRequest
+import org.codehaus.groovy.ast.ModuleNode
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Service to inspect Java source files.
+ * Uses Groovy's parser to parse .java files and extract information like line numbers and Javadoc.
+ */
+class JavaSourceInspector {
+    private val logger = LoggerFactory.getLogger(JavaSourceInspector::class.java)
+    private val parser = GroovyParserFacade()
+
+    /**
+     * Result of inspecting a Java class in a source file.
+     */
+    data class InspectionResult(val lineNumber: Int, val documentation: Documentation)
+
+    /**
+     * Inspect a Java source file to find the definition of the given class.
+     *
+     * @param sourcePath Path to the .java file
+     * @param className Fully qualified class name
+     * @return InspectionResult containing line number and documentation, or null if not found
+     */
+    fun inspectClass(sourcePath: Path, className: String): InspectionResult? {
+        if (!Files.exists(sourcePath)) return null
+
+        try {
+            val content = Files.readString(sourcePath)
+            val uri = sourcePath.toUri()
+
+            // Parse the Java file as if it were Groovy (since Groovy is a superset)
+            // We use a minimal request as we just want structure
+            val parseResult = parser.parse(
+                ParseRequest(
+                    uri = uri,
+                    content = content,
+                    classpath = emptyList(),
+                    sourceRoots = emptyList(),
+                    workspaceSources = emptyList(),
+                    locatorCandidates = emptySet(),
+                ),
+            )
+
+            val ast = parseResult.ast as? ModuleNode ?: return null
+
+            // Find the class node.
+            // Extracted sources usually have the standard package structure.
+            val classNode = ast.classes.find {
+                it.name == className
+            } ?: ast.classes.find {
+                // Fallback: compare simple names if package mismatch causes issues
+                it.name.substringAfterLast('.') == className.substringAfterLast('.')
+            }
+
+            if (classNode != null && classNode.lineNumber > 0) {
+                // Extract Javadoc using our existing extractor
+                val doc = DocExtractor.extractDocumentation(content, classNode)
+                return InspectionResult(classNode.lineNumber, doc)
+            }
+        } catch (e: Exception) {
+            logger.warn("Failed to inspect Java source: $sourcePath", e)
+        }
+        return null
+    }
+}

--- a/tests/e2e/resources/scenarios/definition-jar.yaml
+++ b/tests/e2e/resources/scenarios/definition-jar.yaml
@@ -92,7 +92,7 @@ steps:
         - jsonPath: '$.items[0].range.start.line'
           expect:
             type: 'EQUALS'
-            value: 0
+            value: 6
 
   - shutdown: {}
   - exit: {}


### PR DESCRIPTION
This PR enhances the Java source navigation and hover capabilities:\n\n- **Accurate Line Numbers**: 'Go to Definition' now navigates to the exact line of the class definition in extracted Java source files, rather than line 1.\n- **Javadoc Hover**: Hovering over Java classes now displays the Javadoc extracted from the source file.\n\nChanges:\n- Added `JavaSourceInspector` to parse and inspect `.java` files.\n- Updated `SourceNavigationService` to return line numbers and documentation.\n- Updated `HoverProvider` to utilize source navigation for documentation fallback.