### PR TITLE
fix(formatter): preserve shebangs in Groovy scripts

### DIFF
--- a/groovy-formatter/src/main/kotlin/com/github/albertocavalcante/groovyformatter/OpenRewriteFormatter.kt
+++ b/groovy-formatter/src/main/kotlin/com/github/albertocavalcante/groovyformatter/OpenRewriteFormatter.kt
@@ -17,44 +17,101 @@ class OpenRewriteFormatter {
     private val recipe = AutoFormat()
 
     fun format(text: String): String {
-        if (text.isBlank()) {
-            return text
+        if (text.isBlank()) return text
+
+        // NOTE: Shebang extraction is a heuristic workaround. OpenRewrite's GroovyParser doesn't
+        // recognize shebangs because they're Unix shell directives, not Groovy syntax. We extract
+        // them before parsing to prevent mangling, then restore them after formatting.
+        //
+        // TODO: Monitor OpenRewrite releases. If they add native shebang support for script files,
+        // remove this pre/post-processing logic and rely on semantic parsing instead.
+        //
+        // Trade-off: This string-based approach works for 99% of cases but could theoretically
+        // fail if someone has a multi-line string that starts with "#!" as the first line (extremely
+        // unlikely in practice, as shebangs are always the actual first line of executable scripts).
+        val extraction = extractShebang(text)
+
+        // Handle shebang-only files (no content to format)
+        if (extraction.shebang != null && extraction.content.isBlank()) {
+            return extraction.shebang.trimEnd()
         }
 
-        val sourceFiles = parser.parse(text).collect(Collectors.toList())
-        if (sourceFiles.isEmpty()) {
-            return text
-        }
+        val sourceFiles = parser.parse(extraction.content).collect(Collectors.toList())
+        if (sourceFiles.isEmpty()) return text
 
-        val recipeRun = recipe.run(InMemoryLargeSourceSet(sourceFiles), executionContext)
-        val formattedSource = recipeRun.changeset.allResults
+        val formattedSource = recipe.run(InMemoryLargeSourceSet(sourceFiles), executionContext)
+            .changeset
+            .allResults
             .mapNotNull { it.after }
             .firstOrNull()
             ?: return text
+
         val normalizedSource = PostFormatWhitespaceCollapser().visit(formattedSource, Unit) as SourceFile
-        val normalizedText = normalizedSource.printAll()
         // TODO(#formatter-followup): move this token-level collapse into a dedicated OpenRewrite recipe once we upstream Groovy spacing fixes.
-        return MULTI_SPACE_WITHIN_TOKEN_REGEX.replace(normalizedText) { " " }
+        val formattedText = normalizedSource.printAll()
+            .let { MULTI_SPACE_WITHIN_TOKEN_REGEX.replace(it) { " " } }
+            .normalizeLineEndings()
+
+        // Restore shebang with normalized spacing (always one blank line)
+        return extraction.shebang?.let { shebang ->
+            "$shebang\n${formattedText.trimStart()}"
+        } ?: formattedText
     }
 
+    /**
+     * Result of shebang extraction with descriptive property names.
+     *
+     * @property shebang The extracted shebang line (null if not present), normalized to Unix line endings
+     * @property content The remaining script content after shebang extraction
+     */
+    private data class ShebangExtraction(val shebang: String?, val content: String)
+
+    /**
+     * Detects and extracts a shebang line from the beginning of the script.
+     *
+     * NOTE: This is a heuristic approach. Shebangs are Unix shell directives, not part of
+     * the Groovy language spec, so OpenRewrite's GroovyParser doesn't handle them. We work
+     * around this by extracting the shebang before parsing and restoring it after formatting.
+     *
+     * TODO: If OpenRewrite adds native shebang support for scripts in the future, remove this
+     * pre/post-processing and rely on the parser's semantic understanding.
+     *
+     * @param text The script text to analyze
+     * @return ShebangExtraction containing the shebang (if present) and remaining content
+     */
+    private fun extractShebang(text: String): ShebangExtraction = SHEBANG_REGEX.find(text)?.let { match ->
+        val normalizedShebang = match.value
+            .normalizeLineEndings()
+            .trimEnd('\n', '\r') + "\n"
+        val remainingContent = text.substring(match.value.length)
+        ShebangExtraction(normalizedShebang, remainingContent)
+    } ?: ShebangExtraction(null, text)
+
+    /**
+     * Normalizes line endings to Unix style (LF) for consistency.
+     */
+    private fun String.normalizeLineEndings(): String = replace("\r\n", "\n")
+
+    /**
+     * Visitor that collapses multiple consecutive spaces within code.
+     *
+     * TODO(#formatter-upstream): once OpenRewrite collapses redundant spaces for Groovy scripts, drop this visitor.
+     */
     private class PostFormatWhitespaceCollapser : GroovyIsoVisitor<Unit>() {
         override fun visitSpace(space: Space?, loc: Space.Location, p: Unit): Space {
             val actualSpace = space ?: return super.visitSpace(null, loc, p)
-            val whitespace = actualSpace.whitespace
-            val collapsedWhitespace =
-                if (whitespace.length > 1 && '\n' !in whitespace && space.comments.isEmpty()) {
-                    MULTIPLE_SPACES_REGEX.replace(whitespace, " ")
-                } else {
-                    whitespace
-                }
 
-            val updatedSpace = if (collapsedWhitespace != whitespace) {
-                actualSpace.withWhitespace(collapsedWhitespace)
+            val shouldCollapse = actualSpace.whitespace.length > 1 &&
+                '\n' !in actualSpace.whitespace &&
+                actualSpace.comments.isEmpty()
+
+            val updatedSpace = if (shouldCollapse) {
+                val collapsed = MULTIPLE_SPACES_REGEX.replace(actualSpace.whitespace, " ")
+                actualSpace.withWhitespace(collapsed)
             } else {
                 actualSpace
             }
 
-            // TODO(#formatter-upstream): once OpenRewrite collapses redundant spaces for Groovy scripts, drop this visitor.
             return super.visitSpace(updatedSpace, loc, p)
         }
 
@@ -65,5 +122,6 @@ class OpenRewriteFormatter {
 
     companion object {
         private val MULTI_SPACE_WITHIN_TOKEN_REGEX = Regex("(?<=\\S) {2,}(?=\\S)")
+        private val SHEBANG_REGEX = Regex("^#![^\\n]*(\\r?\\n)?")
     }
 }


### PR DESCRIPTION
## Summary

Fixes the shebang formatting bug where `#!/usr/bin/env groovy` was concatenated with the first import statement, removing the newline after the shebang directive.

### Problem
- OpenRewrite's GroovyParser doesn't recognize shebangs (they're Unix shell directives, not Groovy syntax)
- Input: `#!/usr/bin/env groovy\n\nimport Foo` → Output: `#!/usr/bin/env groovyimport Foo` ❌

### Solution
Implemented pre/post-processing wrapper:
- **Extract** shebang before parsing
- **Format** content without shebang using OpenRewrite
- **Restore** shebang with normalized spacing (one blank line)
- **Normalize** all line endings to Unix style (LF)

### Code Quality Improvements
**Implementation:**
- ✅ Introduced `ShebangExtraction` data class replacing `Pair<String?, String>` for clearer API
- ✅ Added `normalizeLineEndings()` extension function (DRY)
- ✅ Improved Kotlin idiomaticity with `?.let`, method chaining, and expression-bodied functions
- ✅ Enhanced documentation with NOTE/TODO comments per AGENTS.md guidelines
- ✅ Used string templates instead of concatenation

**Tests:**
- ✅ Added 11 comprehensive tests covering all shebang scenarios
- ✅ Organized tests with `@Nested` classes (General formatting, OpenRewrite limitations, Shebang handling)
- ✅ Created `assertFormatsTo()` helper for concise, readable tests
- ✅ All tests use backtick naming style per AGENTS.md
- ✅ Named parameters for clarity

## Test Coverage

### Core Functionality (4 tests)
- Standard shebang with imports (`#!/usr/bin/env groovy`)
- Normalize missing blank line after shebang
- Direct path format (`#!/usr/bin/groovy`)
- Shortened format (`#!groovy`)

### Edge Cases (6 tests)
- Script with only shebang
- Shebang with whitespace only
- Comment vs shebang distinction (position 0 check)
- Script without shebang (regression)
- Windows CRLF normalization
- Malformed shebang preservation

### Whitespace Normalization (1 test)
- Multiple blank lines → single blank line

## Test Plan

- [x] All 11 new tests pass
- [x] All existing formatter tests pass (no regressions)
- [x] Code formatted with `./gradlew lintFix`
- [x] Follows AGENTS.md heuristics documentation guidelines
- [x] TDD approach: wrote tests first, then implementation

### Manual Verification
Test with the original example:
```groovy
#!/usr/bin/env groovy

import io.jenkins.infra.InfraConfig
import jenkins.scm.api.SCMSource

Boolean isRunningOnJenkinsInfra() {
  return new InfraConfig(env).isRunningOnJenkinsInfra()
}
```

Expected: Shebang preserved with one blank line, indentation fixed ✅