### PR TITLE
fix(lsp): compile on-demand for definition

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/services/GroovyTextDocumentService.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/services/GroovyTextDocumentService.kt
@@ -432,7 +432,8 @@ class GroovyTextDocumentService(
 
         try {
             val uri = java.net.URI.create(params.textDocument.uri)
-            if (ensureCompiledOrCompileNow(uri) == null) {
+            val compilationResult = ensureCompiledOrCompileNow(uri)
+            if (compilationResult == null) {
                 logger.warn("Document $uri not compiled, cannot provide references")
                 return@future emptyList()
             }


### PR DESCRIPTION
Fixes a flaky race where `textDocument/definition` (and references) can be requested immediately after `didOpen`/`didChange` before the async diagnostics compilation pipeline has registered a compilation job.

Symptoms
- E2E scenario `definition-local-variable` intermittently receives an empty definition result (`items: []`).

Fix
- In `GroovyTextDocumentService`, if `ensureCompiled(uri)` returns null, fall back to compiling on-demand using the in-memory document text from `DocumentProvider`.

Notes
- `NOTE:`/`TODO:` added to document the tradeoff and the preferred long-term approach (pre-register compilation jobs synchronously).

Tests
- `./gradlew :tests:e2eTest -Dgroovy.lsp.e2e.filter=definition-local-variable`
