### PR TITLE
fix(infra): add missing changes from PR #214

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
         type: choice
         options:
           - 'self-hosted'
+          - 'magalu'
           - 'cloud'
         default: 'self-hosted'
       disable_scan:
@@ -41,16 +42,22 @@ concurrency:
 #
 # Default: self-hosted runner (faster, no GitHub Actions minutes cost)
 #
-# To switch to cloud runners permanently:
+# Runner options:
+#   - self-hosted: Local runner (default, fastest, no cost)
+#   - magalu: Magalu Cloud ephemeral runner (use runner-provision.yml first!)
+#   - cloud: GitHub-hosted runners (macos-15 for PRs, matrix for main)
+#
+# To switch runners permanently:
 #   Settings → Secrets and variables → Actions → Variables → New repository variable
-#   Name: CI_RUNNER_LABEL  Value: cloud
+#   Name: CI_RUNNER_LABEL  Value: cloud (or magalu)
 #
-# To switch to cloud for a single run:
-#   Actions → CI → Run workflow → runner_label: cloud
+# To switch for a single run:
+#   Actions → CI → Run workflow → runner_label: <choice>
 #
-# Cloud runner options (when CI_RUNNER_LABEL=cloud):
-#   - PRs: macos-15 (stable Arm64)
-#   - Main: macos-15 + ubuntu-24.04 matrix
+# Magalu Cloud runners:
+#   1. Run "Infra: Provision Magalu Runner" workflow first
+#   2. Then run CI with runner_label: magalu
+#   3. Run "Infra: Destroy Magalu Runner" when done (or wait for nightly cleanup)
 #
 # NOTE: Avoiding ubuntu-latest due to stability issues causing builds to hang.
 # See: https://github.com/actions/runner-images/issues/13182
@@ -78,25 +85,32 @@ jobs:
               - '!infra/**'
               - '!*.md'
               - '!docs/**'
-              - '!.github/workflows/runner-infra.yml'
+              - '!.github/workflows/runner-*.yml'
 
   build:
     name: Build and Test
     needs: check-paths
     if: needs.check-paths.outputs.run_main_ci == 'true' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 45
-    runs-on: ${{ matrix.os }}
+    # For Magalu runners, we need all three labels; for others, use the matrix value directly
+    runs-on: ${{ matrix.os == 'magalu' && fromJSON('["self-hosted", "magalu", "groovy-lsp"]') || matrix.os }}
     permissions:
       checks: write
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        # Default: self-hosted (single runner, Java 17 only)
-        # Cloud (opt-in): macos-15 for PRs, multi-platform for main pushes
+        # Runner selection:
+        #   - self-hosted (default): Local runner, Java 17 only
+        #   - magalu: Magalu Cloud ephemeral runner (provision first via runner-provision.yml)
+        #   - cloud: GitHub-hosted (macos-15 for PRs, multi-platform for main)
         # NOTE: Using macos-15 instead of ubuntu-latest due to runner stability issues
         # See: https://github.com/actions/runner-images/issues/13182
-        os: ${{ fromJSON( (github.event.inputs.runner_label == 'cloud' || vars.CI_RUNNER_LABEL == 'cloud') && (github.event_name == 'pull_request' && '["macos-15"]' || '["macos-15", "ubuntu-24.04"]') || '["self-hosted"]' ) }}
+        os: ${{ fromJSON( 
+          (github.event.inputs.runner_label == 'magalu' || vars.CI_RUNNER_LABEL == 'magalu') && '["magalu"]' ||
+          (github.event.inputs.runner_label == 'cloud' || vars.CI_RUNNER_LABEL == 'cloud') && (github.event_name == 'pull_request' && '["macos-15"]' || '["macos-15", "ubuntu-24.04"]') || 
+          '["self-hosted"]' 
+        ) }}
         java: ${{ fromJSON( (github.event.inputs.runner_label == 'cloud' || vars.CI_RUNNER_LABEL == 'cloud') && (github.event_name == 'pull_request' && '[17]' || '[17, 21]') || '[17]' ) }}
         exclude:
           - os: ubuntu-24.04

--- a/infra/runner/main.tf
+++ b/infra/runner/main.tf
@@ -19,7 +19,8 @@ terraform {
 }
 
 provider "mgc" {
-  region = "br-ne1" // NorthEast 1
+  api_key = var.mgc_api_key
+  region  = "br-ne1" // NorthEast 1
 }
 
 module "runner" {
@@ -31,6 +32,7 @@ module "runner" {
   github_personal_access_token = var.github_token
   machine_type                 = var.machine_type
 
-  # Ephemeral labeling
-  runner_labels = ["self-hosted", "magalu", "groovy-lsp"]
+  # Labels for targeting from CI workflows
+  # NOTE: "self-hosted" is auto-added by GitHub and does not need to be specified here.
+  runner_labels = ["magalu", "groovy-lsp"]
 }

--- a/infra/runner/terraform.tfvars.example
+++ b/infra/runner/terraform.tfvars.example
@@ -1,4 +1,6 @@
 # Sensitive Variables (Do not commit actual values)
+# IMPORTANT: When using a real terraform.tfvars file, ensure it is listed in .gitignore
+# (e.g. add 'terraform.tfvars' or '*.tfvars' to prevent accidental credential commits)
 github_token = "ghp_YOUR_GITHUB_PAT"
 mgc_api_key  = "YOUR_MAGALU_CLOUD_API_KEY"
 


### PR DESCRIPTION
## Summary
This PR adds changes that were accidentally left uncommitted when PR #214 was merged.

## Changes

### `ci.yml`
- Add `magalu` option to `runner_label` workflow_dispatch input
- Update runner matrix to support magalu label with proper label array `[self-hosted, magalu, groovy-lsp]`
- Add documentation explaining Magalu Cloud runner workflow
- Fix path filter to exclude `runner-*.yml` (was `runner-infra.yml`)

### `infra/runner/main.tf`
- Add missing `api_key = var.mgc_api_key` to MGC provider block (was missing!)
- Update `runner_labels` to remove redundant `self-hosted` (auto-added by GitHub)

### `infra/runner/terraform.tfvars.example`
- Add gitignore warning comment for sensitive credentials

## Why This Happened
These changes were in the local working directory but the git stash/pop during PR merge didnt include them in the squashed commit.