### PR TITLE
fix(infra): use cloud block instead of remote backend

### DIFF
--- a/infra/runner/main.tf
+++ b/infra/runner/main.tf
@@ -4,13 +4,13 @@
 module "runner" {
   source = "github.com/albertocavalcante/magalu-github-runner?ref=1ddc2d9d81f49c70a0f9aa4ee60acd09d09f9d60"
 
-  runner_count                 = 1
-  runner_name_prefix           = "groovy-lsp-ci"
+  runner_count                 = var.runner_count
+  runner_name_prefix           = var.runner_name_prefix
   github_repository_url        = var.github_repo_url
   github_personal_access_token = var.github_token
   machine_type                 = var.machine_type
 
   # Labels for targeting from CI workflows
   # NOTE: "self-hosted" is auto-added by GitHub and does not need to be specified here.
-  runner_labels = ["magalu", "groovy-lsp"]
+  runner_labels = var.runner_labels
 }

--- a/infra/runner/outputs.tf
+++ b/infra/runner/outputs.tf
@@ -1,13 +1,14 @@
 # Output Values
 # Useful information about the provisioned runner infrastructure
 
-output "runner_info" {
-  description = "Summary of provisioned runner configuration"
+output "runner_config" {
+  description = "Runner configuration summary"
   value = {
-    runner_count  = 1
-    runner_prefix = "groovy-lsp-ci"
-    labels        = ["self-hosted", "magalu", "groovy-lsp"]
-    machine_type  = var.machine_type
-    region        = "br-ne1"
+    count        = var.runner_count
+    name_prefix  = var.runner_name_prefix
+    labels       = concat(["self-hosted"], var.runner_labels)
+    machine_type = var.machine_type
+    region       = var.mgc_region
+    repo_url     = var.github_repo_url
   }
 }

--- a/infra/runner/providers.tf
+++ b/infra/runner/providers.tf
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     mgc = {
       source  = "magalucloud/mgc"
-      version = "0.41.0"
+      version = "~> 0.41.0"
     }
   }
 
@@ -22,5 +22,5 @@ terraform {
 # Configure the Magalu Cloud provider
 provider "mgc" {
   api_key = var.mgc_api_key
-  region  = "br-ne1" # NorthEast 1
+  region  = var.mgc_region
 }

--- a/infra/runner/variables.tf
+++ b/infra/runner/variables.tf
@@ -1,23 +1,66 @@
+# =============================================================================
+# Required Variables (no defaults - must be provided)
+# =============================================================================
+
 variable "github_token" {
-  description = "PAT for registering the runner"
+  description = "GitHub PAT for runner registration (requires 'repo' scope)"
   type        = string
   sensitive   = true
 }
 
 variable "mgc_api_key" {
-  description = "Magalu Cloud API Key"
+  description = "Magalu Cloud API Key (requires virtual-machine.read/write, network.read/write scopes)"
   type        = string
   sensitive   = true
 }
 
+# =============================================================================
+# Optional Variables (have sensible defaults)
+# =============================================================================
+
+variable "mgc_region" {
+  description = "Magalu Cloud region (br-ne1, br-se1, br-mgl1, br-mc1)"
+  type        = string
+  default     = "br-ne1"
+
+  validation {
+    condition     = contains(["br-ne1", "br-se1", "br-mgl1", "br-mc1"], var.mgc_region)
+    error_message = "Region must be one of: br-ne1, br-se1, br-mgl1, br-mc1"
+  }
+}
+
 variable "github_repo_url" {
-  description = "URL of the GitHub repository to register the runner with"
+  description = "GitHub repository URL to register the runner with"
   type        = string
   default     = "https://github.com/albertocavalcante/groovy-lsp"
 }
 
 variable "machine_type" {
-  description = "Magalu Cloud machine type"
+  description = "Magalu Cloud VM machine type (e.g., BV1-1-40 = 1vCPU, 4GB RAM)"
   type        = string
   default     = "BV1-1-40"
 }
+
+variable "runner_count" {
+  description = "Number of runner instances to provision"
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.runner_count >= 1 && var.runner_count <= 5
+    error_message = "Runner count must be between 1 and 5"
+  }
+}
+
+variable "runner_name_prefix" {
+  description = "Prefix for runner instance names"
+  type        = string
+  default     = "groovy-lsp-ci"
+}
+
+variable "runner_labels" {
+  description = "Labels for targeting runners from CI workflows"
+  type        = list(string)
+  default     = ["magalu", "groovy-lsp"]
+}
+


### PR DESCRIPTION
## Summary
Fixes the "workspaces not supported" error during `terraform init`.

## Root Cause
The `backend "remote"` block with explicit workspace name was incompatible with the Terraform Cloud configuration.

## Fix
- Use `cloud {}` block with empty body (org/workspace via env vars)
- This matches the working pattern from [hackathons repo](https://github.com/albertocavalcante/hackathons/blob/main/2025-06-29-modular-hack-weekend/infrastructure/providers.tf)

## File Structure Improvements
Split `main.tf` into:
- `providers.tf` - Terraform and provider configuration
- `main.tf` - Module definition only
- `outputs.tf` - Output values

## Environment Variables Used
Already set in workflows:
- `TF_CLOUD_ORGANIZATION=alberto`
- `TF_WORKSPACE=groovy-lsp-runner`