### PR TITLE
fix(infra): upgrade Terraform to 1.11.4

### DIFF
--- a/.github/workflows/runner-destroy.yml
+++ b/.github/workflows/runner-destroy.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
         with:
-          terraform_version: 1.5.7
+          terraform_version: 1.11.4
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
       - name: Terraform Init
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
         with:
-          terraform_version: 1.5.7
+          terraform_version: 1.11.4
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
       - name: Download Destroy Plan

--- a/.github/workflows/runner-provision.yml
+++ b/.github/workflows/runner-provision.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
         with:
-          terraform_version: 1.5.7
+          terraform_version: 1.11.4
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
       # TODO: Consider migrating to dflook/terraform-github-actions for better TFC integration
@@ -100,7 +100,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
         with:
-          terraform_version: 1.5.7
+          terraform_version: 1.11.4
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
       - name: Download Plan Artifact

--- a/infra/runner/providers.tf
+++ b/infra/runner/providers.tf
@@ -16,7 +16,7 @@ terraform {
     }
   }
 
-  required_version = ">= 1.5.7"
+  required_version = ">= 1.11.0"
 }
 
 # Configure the Magalu Cloud provider


### PR DESCRIPTION
Fixes `WriteOnly Attribute Not Allowed` error from MGC provider.

The error occurs because `allocate_public_ipv4` is a WriteOnly attribute, which requires Terraform 1.11+.

Changes:
- Upgrade `terraform_version` in GitHub workflows: 1.5.7 → 1.11.4
- Upgrade `required_version` in `providers.tf`: >= 1.5.7 → >= 1.11.0