### PR TITLE
fix(infra): update runner module ref and add update helper

### DIFF
--- a/infra/runner/main.tf
+++ b/infra/runner/main.tf
@@ -1,8 +1,12 @@
 # Main Infrastructure Configuration
 # Magalu Cloud Self-Hosted GitHub Actions Runner
 
+# To update the module ref to the latest commit from main:
+# NEW_REF=$(gh api /repos/albertocavalcante/magalu-github-runner/commits/main --jq .sha) && \
+# sed -i '' "s/ref=[a-f0-9]*/ref=${NEW_REF}/" infra/runner/main.tf
+
 module "runner" {
-  source = "github.com/albertocavalcante/magalu-github-runner?ref=1ddc2d9d81f49c70a0f9aa4ee60acd09d09f9d60"
+  source = "github.com/albertocavalcante/magalu-github-runner?ref=76b92b2f7a6b23fb96023e6bbb79c8cb6718a62d"
 
   runner_count                 = var.runner_count
   runner_name_prefix           = var.runner_name_prefix


### PR DESCRIPTION
Updates the `magalu-github-runner` module reference to the latest commit `76b92b2` to pick up recent bug fixes.

Also adds a helpful comment in `infra/runner/main.tf` with a one-liner command to easily update the module reference to the latest main commit in the future.