### PR TITLE
chore(runner): update magalu-github-runner to latest

### DIFF
--- a/infra/runner/main.tf
+++ b/infra/runner/main.tf
@@ -3,10 +3,10 @@
 
 # To update the module ref to the latest commit from main:
 # NEW_REF=$(gh api /repos/albertocavalcante/magalu-github-runner/commits/main --jq .sha) && \
-# sed -i '' "s/ref=5bb285c1fa3e32634f592fba9d00bc08069986a0[a-f0-9]*/ref=${NEW_REF}/" infra/runner/main.tf
+# sed -i '' "s/ref=47708af56676a76c24823a4644f91db3f91e9421[a-f0-9]*/ref=${NEW_REF}/" infra/runner/main.tf
 
 module "runner" {
-  source = "github.com/albertocavalcante/magalu-github-runner?ref=5bb285c1fa3e32634f592fba9d00bc08069986a0"
+  source = "github.com/albertocavalcante/magalu-github-runner?ref=47708af56676a76c24823a4644f91db3f91e9421"
 
   runner_count                 = var.runner_count
   runner_name_prefix           = var.runner_name_prefix


### PR DESCRIPTION
Updates the `magalu-github-runner` module reference to the latest commit on main.