### PR TITLE
feat(infra): mark runner ips as sensitive output

### DIFF
--- a/infra/runner/outputs.tf
+++ b/infra/runner/outputs.tf
@@ -18,4 +18,5 @@ output "generated_ssh_private_key" {
 output "runner_ipv4s" {
   description = "Public IP addresses of the runners"
   value       = module.runner.runner_public_ips
+  sensitive   = true
 }


### PR DESCRIPTION
Marks `runner_ipv4s` output as sensitive to prevent public IP exposure in CI logs.