### PR TITLE
perf(gradle): optimize JVM args for 16GB runner

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,11 @@
 # Gradle properties
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# JVM args optimized for BV4-16-10 runner (4 vCPU, 16GB RAM)
+org.gradle.jvmargs=-Xms2g -Xmx6g -XX:+UseG1GC -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=warn
+org.gradle.workers.max=4
 # Due to a deprecation warning in io.gitlab.arturbosch.detekt.DetektPlugin.apply(DetektPlugin.kt:28)
 # which we have no control over, we are setting the warning mode to none.
 org.gradle.warning.mode=none
@@ -12,3 +14,4 @@ org.gradle.scan=true
 # Kotlin
 kotlin.code.style=official
 kotlin.incremental=true
+kotlin.compiler.execution.strategy=in-process


### PR DESCRIPTION
## Summary

Optimizes Gradle JVM settings for the upgraded BV4-16-10 runner (4 vCPU, 16GB RAM).

## Changes

| Setting | Before | After | Impact |
|---------|--------|-------|--------|
| Heap size | 2GB | 6GB (-Xms2g -Xmx6g) | 3x more memory for compilation |
| GC | Default | G1GC | Better for large heaps, lower pause times |
| Metaspace | Default | 512m | Prevents Kotlin compiler OOM |
| Workers | Default (CPU cores) | 4 | Explicit match to vCPU count |
| Kotlin compiler | Default | in-process | Faster, avoids daemon overhead |

## Expected Results

- Faster compilation due to reduced GC pressure
- More parallel work capacity
- Fewer OOM failures on large builds