### PR TITLE
feat(infra): prune offline runners in destroy workflow

### DIFF
--- a/.github/actions/runner-status/action.yml
+++ b/.github/actions/runner-status/action.yml
@@ -9,6 +9,7 @@ inputs:
         - check: Single check, returns has_runners boolean and runner_count
         - wait-online: Poll until a runner with label is online (fails on timeout)
         - verify-absent: Check that no runners with label exist (warns but succeeds)
+        - prune-offline: Delete offline runners with the specified label
     required: true
   label:
     description: 'Runner label to check/wait for'

--- a/.github/actions/runner-status/runner-status.sh
+++ b/.github/actions/runner-status/runner-status.sh
@@ -5,10 +5,13 @@
 #   check        - Single check, returns has_runners boolean and runner_count
 #   wait-online  - Poll until a runner with label is online (fails on timeout)
 #   verify-absent - Check that no runners with label exist (warns but succeeds)
+#   prune-offline - Delete offline runners with label
 #
 # Required environment variables:
 #   GITHUB_TOKEN      - GitHub PAT with repo scope
-#   MODE              - Operation mode (check, wait-online, verify-absent)
+#   GITHUB_TOKEN      - GitHub PAT with repo scope
+#   MODE              - Operation mode (check, wait-online, verify-absent, prune-offline)
+#   LABEL_NAME        - Runner label to check for
 #   LABEL_NAME        - Runner label to check for
 #   GITHUB_REPOSITORY - Owner/repo (automatically set by GitHub Actions)
 #
@@ -58,6 +61,25 @@ get_online_runners() {
     '[.runners[] | select(any(.labels[]?; .name == $label) and .status == "online")]'
 }
 
+# Get offline runners with specified label
+get_offline_runners() {
+  local response="$1"
+  echo "$response" | jq --arg label "$LABEL_NAME" \
+    '[.runners[] | select(any(.labels[]?; .name == $label) and .status == "offline")]'
+}
+
+# Delete a runner by ID
+delete_runner() {
+  local runner_id="$1"
+  local url="https://api.github.com/repos/${OWNER}/${REPO}/actions/runners/${runner_id}"
+
+  curl -sS -X DELETE \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "$url"
+}
+
 # Write outputs to GITHUB_OUTPUT
 set_output() {
   echo "$1=$2" >> "$GITHUB_OUTPUT"
@@ -73,29 +95,29 @@ write_summary() {
 # ============================================================================
 mode_check() {
   echo "::group::🔍 Checking for runners with label '${LABEL_NAME}'"
-  
+
   local response
   response=$(fetch_runners) || {
     echo "::error::Failed to fetch runners: ${response}"
     exit 1
   }
-  
+
   local runners count
   runners=$(get_labeled_runners "$response")
   count=$(echo "$runners" | jq 'length')
-  
+
   echo "Found ${count} runner(s) with label '${LABEL_NAME}'"
-  
+
   if [ "$count" -gt 0 ]; then
     echo "$runners" | jq '.[] | {name: .name, status: .status}'
     set_output "has_runners" "true"
   else
     set_output "has_runners" "false"
   fi
-  
+
   set_output "runner_count" "$count"
   echo "::endgroup::"
-  
+
   # Job summary
   write_summary "## 🔍 Runner Check"
   write_summary ""
@@ -110,18 +132,18 @@ mode_check() {
 mode_wait_online() {
   local max_attempts
   max_attempts=$((MAX_WAIT_MINUTES * 60 / POLL_INTERVAL))
-  
+
   echo "::group::⚙️ Configuration"
   echo "  Repository:    ${OWNER}/${REPO}"
   echo "  Label:         ${LABEL_NAME}"
   echo "  Max wait:      ${MAX_WAIT_MINUTES} minutes (${max_attempts} attempts)"
   echo "  Poll interval: ${POLL_INTERVAL} seconds"
   echo "::endgroup::"
-  
+
   local attempt=1
   while [ "$attempt" -le "$max_attempts" ]; do
     echo "⏳ Attempt ${attempt}/${max_attempts}..."
-    
+
     local response
     response=$(fetch_runners) || {
       echo "::warning::GitHub API request failed: ${response}"
@@ -129,7 +151,7 @@ mode_wait_online() {
       attempt=$((attempt + 1))
       continue
     }
-    
+
     # Check for API error messages
     if echo "$response" | jq -e '.message' > /dev/null 2>&1; then
       local error_msg
@@ -139,28 +161,28 @@ mode_wait_online() {
       attempt=$((attempt + 1))
       continue
     fi
-    
+
     local online_runners runner_info
     online_runners=$(get_online_runners "$response")
-    
+
     if [ "$(echo "$online_runners" | jq 'length')" -gt 0 ]; then
       runner_info=$(echo "$online_runners" | jq '.[0]')
       local runner_name runner_status
       runner_name=$(echo "$runner_info" | jq -r '.name')
       runner_status=$(echo "$runner_info" | jq -r '.status')
-      
+
       echo ""
       echo "✅ Found online runner with label '${LABEL_NAME}'!"
       echo ""
       echo "::group::📋 Runner Details"
       echo "$runner_info" | jq '{name: .name, status: .status, labels: [.labels[].name], busy: .busy}'
       echo "::endgroup::"
-      
+
       set_output "runner_name" "$runner_name"
       set_output "runner_status" "$runner_status"
       set_output "runner_count" "$(echo "$online_runners" | jq 'length')"
       set_output "has_runners" "true"
-      
+
       # Job summary
       write_summary "## 🏃 Runner Ready"
       write_summary ""
@@ -170,23 +192,23 @@ mode_wait_online() {
       write_summary "| **Status** | ${runner_status} |"
       write_summary "| **Label** | \`${LABEL_NAME}\` |"
       write_summary "| **Wait Time** | ~$((attempt * POLL_INTERVAL)) seconds |"
-      
+
       exit 0
     fi
-    
+
     echo "  Runner not ready yet. Sleeping for ${POLL_INTERVAL}s..."
     sleep "$POLL_INTERVAL"
     attempt=$((attempt + 1))
   done
-  
+
   # Timeout
   echo ""
   echo "❌ Timeout: No online runner found with label '${LABEL_NAME}' after ${MAX_WAIT_MINUTES} minutes"
   echo ""
-  
+
   set_output "runner_count" "0"
   set_output "has_runners" "false"
-  
+
   write_summary "## ❌ Runner Wait Timeout"
   write_summary ""
   write_summary "No runner with label \`${LABEL_NAME}\` came online within ${MAX_WAIT_MINUTES} minutes."
@@ -195,7 +217,7 @@ mode_wait_online() {
   write_summary "- Check if the Terraform apply completed successfully"
   write_summary "- Verify the runner VM has network connectivity"
   write_summary "- Check runner registration logs in Magalu Cloud console"
-  
+
   exit 1
 }
 
@@ -204,11 +226,11 @@ mode_wait_online() {
 # ============================================================================
 mode_verify_absent() {
   echo "::group::🔍 Verifying runners with label '${LABEL_NAME}' are removed"
-  
+
   # Give GitHub API time to reflect the change
   echo "Waiting 10s for API to sync..."
   sleep 10
-  
+
   local response
   response=$(fetch_runners) || {
     echo "::warning::Failed to fetch runners: ${response}"
@@ -217,17 +239,17 @@ mode_verify_absent() {
     echo "::endgroup::"
     exit 0  # Don't fail, just warn
   }
-  
+
   local runners count
   runners=$(get_labeled_runners "$response")
   count=$(echo "$runners" | jq 'length')
-  
+
   set_output "runner_count" "$count"
-  
+
   if [ "$count" -eq 0 ]; then
     echo "✅ All runners with label '${LABEL_NAME}' successfully removed"
     set_output "has_runners" "false"
-    
+
     write_summary "## ✅ Runners Removed"
     write_summary ""
     write_summary "All runners with label \`${LABEL_NAME}\` have been successfully deregistered."
@@ -236,17 +258,58 @@ mode_verify_absent() {
     echo "   (They may take additional time to fully deregister)"
     echo "$runners" | jq '.[] | {name: .name, status: .status}'
     set_output "has_runners" "true"
-    
+
     write_summary "## ⚠️ Runners Still Registered"
     write_summary ""
     write_summary "${count} runner(s) with label \`${LABEL_NAME}\` are still registered."
     write_summary "They may take additional time to fully deregister."
   fi
-  
+
   echo "::endgroup::"
-  
+
   # Always exit 0 - this is a verification step, not a gate
   exit 0
+}
+
+# ============================================================================
+# Mode: prune-offline
+# ============================================================================
+mode_prune_offline() {
+  echo "::group::🗑️ Pruning offline runners with label '${LABEL_NAME}'"
+
+  local response
+  response=$(fetch_runners) || {
+    echo "::error::Failed to fetch runners: ${response}"
+    exit 1
+  }
+
+  local offline_runners
+  offline_runners=$(get_offline_runners "$response")
+  local count
+  count=$(echo "$offline_runners" | jq 'length')
+
+  echo "Found ${count} offline runner(s) with label '${LABEL_NAME}'"
+
+  if [ "$count" -gt 0 ]; then
+    echo "$offline_runners" | jq -c '.[]' | while read -r runner; do
+      local id name
+      id=$(echo "$runner" | jq -r '.id')
+      name=$(echo "$runner" | jq -r '.name')
+
+      echo "Deleting runner: ${name} (ID: ${id})..."
+      delete_runner "$id"
+    done
+
+    set_output "pruned_count" "$count"
+    write_summary "## 🗑️ Pruned Offline Runners"
+    write_summary ""
+    write_summary "Deleted ${count} offline runner(s) with label \`${LABEL_NAME}\`."
+  else
+    echo "No offline runners found."
+    set_output "pruned_count" "0"
+  fi
+
+  echo "::endgroup::"
 }
 
 # ============================================================================
@@ -262,8 +325,11 @@ case "$MODE" in
   verify-absent)
     mode_verify_absent
     ;;
+  prune-offline)
+    mode_prune_offline
+    ;;
   *)
-    echo "::error::Unknown mode: ${MODE}. Valid modes: check, wait-online, verify-absent"
+    echo "::error::Unknown mode: ${MODE}. Valid modes: check, wait-online, verify-absent, prune-offline"
     exit 1
     ;;
 esac

--- a/.github/workflows/runner-destroy.yml
+++ b/.github/workflows/runner-destroy.yml
@@ -40,6 +40,13 @@ jobs:
           label: magalu
           github-token: ${{ secrets.GH_PAT_RUNNER }}
 
+      - name: Prune Offline Runners
+        uses: ./.github/actions/runner-status
+        with:
+          mode: prune-offline
+          label: magalu
+          github-token: ${{ secrets.GH_PAT_RUNNER }}
+
   plan-destroy:
     name: Terraform Plan Destroy
     needs: check-runners


### PR DESCRIPTION
## Summary
This PR modifies the `runner-destroy` workflow to automatically detect and remove offline runners before destroying the infrastructure.

## Changes
- **.github/actions/runner-status**:
  - Added `prune-offline` mode to delete offline runners via GitHub API.
  - Implemented `get_offline_runners` and `delete_runner` helper functions.
- **.github/workflows/runner-destroy.yml**:
  - Added 'Prune Offline Runners' step to the `check-runners` job.

## Motivation
Currently, when runners are destroyed (or crash), they can leave behind 'offline' registrations in GitHub. This change ensures a clean state by removing these invalid registrations during the destruction process.

## Verification
- Verified bash script syntax with `bash -n`.
- Manual review of logic flow.