### PR TITLE
perf(ci): eliminate polling waste with event-driven runner provisioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,13 +317,37 @@ jobs:
   validate:
     name: Validation Check
     runs-on: ${{ github.event.inputs.runner_label == 'self-hosted' && 'self-hosted' || vars.CI_RUNNER_LABEL == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
-    needs: build
+    needs: [build, check-runner]
     if: always()
     steps:
       - name: Check build status
-        run: |-
-          if [[ "${{ needs.build.result }}" != "success" ]]; then
-            echo "Build failed or was cancelled"
+        run: |
+          BUILD_RESULT="${{ needs.build.result }}"
+          PROVISIONING="${{ needs.check-runner.outputs.provisioning_triggered }}"
+
+          echo "Build result: $BUILD_RESULT"
+          echo "Provisioning triggered: $PROVISIONING"
+
+          # If provisioning was triggered, build is expected to be skipped
+          if [[ "$PROVISIONING" == "true" && "$BUILD_RESULT" == "skipped" ]]; then
+            echo "ℹ️ Build skipped - runner provisioning in progress"
+            echo "   CI will resume automatically after provisioning completes"
+            exit 0
+          fi
+
+          # For workflow_run events, check-runner is skipped so we can't check provisioning_triggered
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            if [[ "$BUILD_RESULT" != "success" ]]; then
+              echo "❌ Build failed after provisioning"
+              exit 1
+            fi
+            echo "✅ All checks passed!"
+            exit 0
+          fi
+
+          # Normal case: build must succeed
+          if [[ "$BUILD_RESULT" != "success" ]]; then
+            echo "❌ Build failed or was cancelled"
             exit 1
           fi
           echo "✅ All checks passed!"


### PR DESCRIPTION
## Summary

Eliminates wasted compute cycles when CI waits for runner provisioning that requires manual approval.

### Problem

When CI triggers `runner-provision.yml` and the provisioning workflow is blocked waiting for approval, the CI workflow was actively polling every 30 seconds for up to 15 minutes, burning compute cycles.

### Solution

Replace polling with an **event-driven architecture** using `workflow_run`:

```mermaid
sequenceDiagram
    participant CI as CI Workflow
    participant Prov as runner-provision.yml
    participant Human as Approver
    participant CI2 as CI (resumed)
    
    CI->>CI: No runner found
    CI->>Prov: Trigger provisioning
    CI->>CI: ✅ Exit immediately
    Note over CI,Prov: 💤 Zero compute used
    Human->>Prov: Approve
    Prov->>Prov: Apply + wait for runner
    Prov-->>CI2: workflow_run triggers CI
    CI2->>CI2: Build runs
```

### Key Changes

- Add `workflow_run` trigger for `Infra: Provision Magalu Runner` completion
- Modify `check-runner` to exit early after triggering provisioning
- Add `provisioning_triggered` output to skip build job in trigger run
- Update `build` job condition to handle both normal and `workflow_run` events

### Trade-off

Results in **two workflow runs** instead of one:
1. First run: triggers provisioning → exits cleanly
2. Second run: triggered by `workflow_run` → actually builds

This is acceptable because it eliminates all wasted compute during approval wait.