### PR TITLE
fix(ci): add workflow_dispatch to concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,12 @@ concurrency:
   # PRs: group by head_ref (cancel outdated runs for same branch)
   # Main pushes: group by SHA (allows parallel runs per commit for fast regression detection)
   # workflow_run: group by triggering run ID (allows resume after provisioning)
+  # workflow_dispatch: group by run ID (never wait for other CI runs)
   group: >-
     ${{ github.workflow }}-${{
       github.event_name == 'pull_request' && github.head_ref ||
       github.event_name == 'workflow_run' && github.event.workflow_run.id ||
+      github.event_name == 'workflow_dispatch' && github.run_id ||
       github.sha
     }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/infra/runner/.gitignore
+++ b/infra/runner/.gitignore
@@ -1,0 +1,2 @@
+.terraform
+*.pem

--- a/infra/runner/.terraform.lock.hcl
+++ b/infra/runner/.terraform.lock.hcl
@@ -1,0 +1,59 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.7.2"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.1.0"
+  constraints = ">= 4.0.0"
+  hashes = [
+    "h1:zEv9tY1KR5vaLSyp2lkrucNJ+Vq3c+sTFK9GyQGLtFs=",
+    "zh:14c35d89307988c835a7f8e26f1b83ce771e5f9b41e407f86a644c0152089ac2",
+    "zh:2fb9fe7a8b5afdbd3e903acb6776ef1be3f2e587fb236a8c60f11a9fa165faa8",
+    "zh:35808142ef850c0c60dd93dc06b95c747720ed2c40c89031781165f0c2baa2fc",
+    "zh:35b5dc95bc75f0b3b9c5ce54d4d7600c1ebc96fbb8dfca174536e8bf103c8cdc",
+    "zh:38aa27c6a6c98f1712aa5cc30011884dc4b128b4073a4a27883374bfa3ec9fac",
+    "zh:51fb247e3a2e88f0047cb97bb9df7c228254a3b3021c5534e4563b4007e6f882",
+    "zh:62b981ce491e38d892ba6364d1d0cdaadcee37cc218590e07b310b1dfa34be2d",
+    "zh:bc8e47efc611924a79f947ce072a9ad698f311d4a60d0b4dfff6758c912b7298",
+    "zh:c149508bd131765d1bc085c75a870abb314ff5a6d7f5ac1035a8892d686b6297",
+    "zh:d38d40783503d278b63858978d40e07ac48123a2925e1a6b47e62179c046f87a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb07f708e3316615f6d218cec198504984c0ce7000b9f1eebff7516e384f4b54",
+  ]
+}
+
+provider "registry.terraform.io/magalucloud/mgc" {
+  version     = "0.41.1"
+  constraints = ">= 0.18.0, ~> 0.41.0"
+  hashes = [
+    "h1:rmdh/f9p5PCr+sxwnm3k5xrsMmiVaNa3wVjmKhS0/jg=",
+    "zh:072e80d7bd93473d64f9cdec152de1cbbf47bd85fa22b46bf274d1919a7429b4",
+    "zh:28d6c4c12ac40b25217c2bffc11c4941645686767d53a4361c8d220a08e85bd1",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:89cc085ca7260b7dab77c6684bb14ccc5c588bef93b32ddb8e1382202dde1638",
+    "zh:ba0217adf4f0dfa391fcff2511a584098a1271badc1f702436a7ef3994b2b579",
+    "zh:ce201847e7a43615eb51c0dc245012849156e672f7eb1c57a846beac2b5227ab",
+    "zh:da71da7424758a0776c50177f05078465a62cf4c3255d19bdc748e0bd46aa18b",
+    "zh:e432417ed0fbd82a1b450c81126996ae480843d17908f6e17c6d8999e555830e",
+    "zh:fb71c4857441c88ed7649ec313f5d282b080c6c184aeac9871615484cd1c2f8f",
+  ]
+}


### PR DESCRIPTION
## Problem

When triggering the CI workflow via `workflow_dispatch`, users encounter the message: "This workflow is waiting for CI to complete before running."

This occurs because the concurrency group configuration doesn't handle `workflow_dispatch` events explicitly, causing them to share the same concurrency group as push events with the same commit SHA.

## Solution

Add explicit handling for `workflow_dispatch` events in the concurrency group configuration to use `github.run_id` instead of `github.sha`. This ensures:

- ✅ Manual workflow_dispatch triggers run immediately without waiting
- ✅ Each workflow_dispatch gets its own concurrency group  
- ✅ Existing behavior for PRs, pushes, and workflow_run events remains unchanged
- ✅ No changes to cancel-in-progress logic (only PRs auto-cancel)

## Changes

### CI Workflow
- Updated `.github/workflows/ci.yml` concurrency configuration to add `workflow_dispatch` case using `github.run_id`
- Added comment to document the workflow_dispatch behavior

### Infrastructure
- Added `.gitignore` for Terraform runner directory with patterns for `.terraform` and `*.pem`
- Committed `.terraform.lock.hcl` for consistent provider versions

## Testing

**YAML Validation**: ✅ Passed (`yq eval` confirmed syntax is valid)

**Manual Testing Required**:
1. Trigger workflow_dispatch while CI is running on the same commit
2. Verify it starts immediately without "waiting for CI to complete" message