### PR TITLE
fix: add CodeNarc Jenkins diagnostics support and fix ruleset resolution

### DIFF
--- a/docs/CODENARC.md
+++ b/docs/CODENARC.md
@@ -264,7 +264,7 @@ When disabled, CodeNarc analysis is skipped entirely (no ruleset loading, no dia
 
 **Fallback Mechanism**: If custom rulesets are missing from the classpath, the LSP automatically falls back to CodeNarc's bundled XML rulesets, preventing crashes.
 
-**Legacy Configuration** (for custom rulesets):
+**Customizing Jenkins Rules** (for custom rulesets):
 
 Jenkins projects require special handling due to DSL patterns and implicit variables:
 

--- a/groovy-diagnostics/codenarc/src/main/kotlin/com/github/albertocavalcante/diagnostics/codenarc/RulesetResolver.kt
+++ b/groovy-diagnostics/codenarc/src/main/kotlin/com/github/albertocavalcante/diagnostics/codenarc/RulesetResolver.kt
@@ -260,7 +260,7 @@ class HierarchicalRulesetResolver(
         // Try default ruleset as fallback
         val defaultResourcePath = "codenarc/rulesets/base/default.groovy"
         loadRulesetFromResource(defaultResourcePath)?.let {
-            logger.info("Falling back to default ruleset: $defaultResourcePath")
+            logger.info("Falling back to default ruleset: {}", defaultResourcePath)
             return ResolvedRuleset(it, "resource:$defaultResourcePath")
         }
 

--- a/groovy-diagnostics/codenarc/src/main/resources/codenarc/rulesets/base/default.groovy
+++ b/groovy-diagnostics/codenarc/src/main/resources/codenarc/rulesets/base/default.groovy
@@ -10,9 +10,13 @@ ruleset {
 
     // Import rules for clean imports
     ruleset('rulesets/imports.xml') {
-        // Exclude noisy import rules (we'll configure them separately below)
-        exclude 'DuplicateImport'
-        exclude 'UnnecessaryGroovyImport'
+        // Configure priorities for import rules
+        DuplicateImport {
+            priority = 3
+        }
+        UnnecessaryGroovyImport {
+            priority = 3
+        }
     }
 
     // Unnecessary code
@@ -20,77 +24,63 @@ ruleset {
         // Exclude rules we want to disable
         exclude 'UnnecessaryGetter'
         exclude 'UnnecessarySetter'
+
+        // Configure priorities
+        UnnecessaryPublicModifier {
+            priority = 3
+        }
+        UnnecessarySemicolon {
+            priority = 3
+        }
     }
 
     // Unused code
-    ruleset('rulesets/unused.xml')
+    ruleset('rulesets/unused.xml') {
+        UnusedVariable {
+            priority = 2
+        }
+        UnusedPrivateField {
+            priority = 2
+        }
+        UnusedPrivateMethod {
+            priority = 2
+        }
+    }
 
     // Formatting rules
     ruleset('rulesets/formatting.xml') {
         // Exclude line length (too noisy)
         exclude 'LineLength'
+
+        // Configure priorities
+        SpaceAroundClosureArrow {
+            enabled = true
+        }
+        TrailingWhitespace {
+            priority = 3
+        }
     }
 
     // Groovyism - idiomatic Groovy
-    ruleset('rulesets/groovyism.xml')
+    ruleset('rulesets/groovyism.xml') {
+        GStringExpressionWithinString {
+            priority = 3
+        }
+        ExplicitCallToEqualsMethod {
+            priority = 3
+        }
+    }
 
     // Exception handling
-    ruleset('rulesets/exceptions.xml')
-}
-
-// Configure individual rules outside ruleset blocks
-DuplicateImport {
-    priority = 3
-}
-
-UnnecessaryGroovyImport {
-    priority = 3
-}
-
-UnnecessaryPublicModifier {
-    priority = 3
-}
-
-UnnecessarySemicolon {
-    priority = 3
-}
-
-UnusedVariable {
-    priority = 2
-}
-
-UnusedPrivateField {
-    priority = 2
-}
-
-UnusedPrivateMethod {
-    priority = 2
-}
-
-SpaceAroundClosureArrow {
-    enabled = true
-}
-
-TrailingWhitespace {
-    priority = 3
-}
-
-GStringExpressionWithinString {
-    priority = 3
-}
-
-ExplicitCallToEqualsMethod {
-    priority = 3
-}
-
-CatchException {
-    priority = 2
-}
-
-CatchThrowable {
-    priority = 1
-}
-
-ThrowException {
-    priority = 2
+    ruleset('rulesets/exceptions.xml') {
+        CatchException {
+            priority = 2
+        }
+        CatchThrowable {
+            priority = 1
+        }
+        ThrowException {
+            priority = 2
+        }
+    }
 }

--- a/groovy-diagnostics/codenarc/src/main/resources/codenarc/rulesets/frameworks/jenkins.groovy
+++ b/groovy-diagnostics/codenarc/src/main/resources/codenarc/rulesets/frameworks/jenkins.groovy
@@ -18,7 +18,13 @@ ruleset {
     // - ForbiddenCallInCpsMethod: Non-CPS methods called with CPS closures
     // - ObjectOverrideOnlyNonCpsMethods: Overridden Object methods must be @NonCPS
     // - ParameterOrReturnTypeNotSerializable: Parameters/returns must be Serializable
-    ruleset('rulesets/jenkins.xml')
+    ruleset('rulesets/jenkins.xml') {
+        // Configure CpsCallFromNonCpsMethod for common Jenkins patterns
+        CpsCallFromNonCpsMethod {
+            cpsScriptVariableName = 'script'
+            cpsPackages = []
+        }
+    }
 
     // Basic rules (excluding patterns common in Jenkinsfiles)
     ruleset('rulesets/basic.xml') {
@@ -32,10 +38,4 @@ ruleset {
     ruleset('rulesets/formatting.xml') {
         exclude 'LineLength'  // Jenkinsfiles often have long lines
     }
-}
-
-// Configure CpsCallFromNonCpsMethodRule for common Jenkins patterns
-CpsCallFromNonCpsMethodRule {
-    cpsScriptVariableName = 'script'
-    cpsPackages = []
 }

--- a/groovy-diagnostics/codenarc/src/test/kotlin/com/github/albertocavalcante/diagnostics/codenarc/RulesetResolverTest.kt
+++ b/groovy-diagnostics/codenarc/src/test/kotlin/com/github/albertocavalcante/diagnostics/codenarc/RulesetResolverTest.kt
@@ -51,13 +51,16 @@ class RulesetResolverTest {
         val context = createWorkspaceContext(tempDir, enabled = true)
         val config = resolver.resolve(context)
 
-        // Then: Should load Jenkins ruleset
+        // Then: Should load Jenkins ruleset from classpath resource
         assertNotNull(config.rulesetContent)
-        assertTrue(config.source.contains("jenkins"), "Expected Jenkins ruleset, got: ${config.source}")
+        assertEquals(
+            "resource:codenarc/rulesets/frameworks/jenkins.groovy",
+            config.source,
+            "Expected Jenkins ruleset resource",
+        )
         assertTrue(
-            config.rulesetContent.contains("rulesets/jenkins.xml") ||
-                config.rulesetContent.contains("jenkins"),
-            "Ruleset should reference Jenkins rules",
+            config.rulesetContent.contains("ruleset('rulesets/jenkins.xml')"),
+            "Ruleset should reference Jenkins CPS rules",
         )
     }
 
@@ -67,11 +70,12 @@ class RulesetResolverTest {
         val context = createWorkspaceContext(tempDir, enabled = true)
         val config = resolver.resolve(context)
 
-        // Then: Should load default ruleset
+        // Then: Should load default ruleset from classpath resource
         assertNotNull(config.rulesetContent)
-        assertTrue(
-            config.source.contains("default") || config.source.contains("basic"),
-            "Expected default ruleset, got: ${config.source}",
+        assertEquals(
+            "resource:codenarc/rulesets/base/default.groovy",
+            config.source,
+            "Expected default ruleset resource",
         )
     }
 


### PR DESCRIPTION
## Summary

Fixes #124 and #125 by adding proper CodeNarc ruleset resolution with fallback to bundled rulesets and Jenkins-specific diagnostic support.

## Changes

- **Fix #124**: Add fallback chain to CodeNarc's bundled XML rulesets (`rulesets/jenkins.xml`, `rulesets/basic.xml`) when custom DSL rulesets are missing, preventing `IllegalStateException` crashes
- **Fix #125**: Verify early guard for disabled CodeNarc (already implemented in both `TextDocumentService` and `CodeNarcDiagnosticProvider`)
- **Add Jenkins ruleset**: Create `frameworks/jenkins.groovy` that references CodeNarc's bundled `rulesets/jenkins.xml` with 7 Jenkins CPS rules
- **Fix DSL syntax**: Correct CodeNarc DSL syntax errors in `default.groovy` (proper use of include/exclude inside ruleset blocks, rule configuration outside)
- **Add tests**: Comprehensive `RulesetResolverTest` with 8 test cases covering fallback chain, Jenkins ruleset loading, and edge cases

## Technical Details

The resolver now uses a three-tier fallback:
1. Try custom DSL ruleset for project type
2. Try default DSL ruleset  
3. Fall back to CodeNarc's bundled XML rulesets (wrapped in minimal DSL)

This ensures CodeNarc diagnostics work even when resources aren't packaged, and Jenkins projects get proper CPS safety rule diagnostics.

## Testing

- All existing tests pass
- 8 new RulesetResolverTest cases pass
- No linting errors (auto-fixed unused import)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Jenkins-aware ruleset resolution with fallback to bundled CodeNarc XML and ship default/jenkins rulesets with tests and docs.
> 
> - **Diagnostics · CodeNarc**
>   - Enhance `HierarchicalRulesetResolver` with injectable `ResourceLoader` and `ClasspathResourceLoader`.
>   - Implement fallback chain: custom DSL → default DSL (`codenarc/rulesets/base/default.groovy`) → generated wrapper for bundled XML (`rulesets/jenkins.xml` or `rulesets/basic.xml`).
>   - Improve logging and resilient loading via `loadRulesetFromResource()`.
> - **Rulesets**
>   - Add `codenarc/rulesets/base/default.groovy` baseline ruleset.
>   - Add Jenkins CPS ruleset `codenarc/rulesets/frameworks/jenkins.groovy` (includes `rulesets/jenkins.xml` and basic/formatting tweaks).
> - **Tests**
>   - Introduce `RulesetResolverTest` covering classpath loading, workspace override, properties auto-detect, Jenkins detection, and fallback behaviors.
> - **Docs**
>   - Update `docs/CODENARC.md` with ruleset resolution/fallback strategy, configuration options (including disabling), and Jenkins project guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53792d4264535e2ee23b3b44c7b75289ccde507e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->