### PR TITLE
refactor(completion): introduce CompletionContext data class

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/CompletionProvider.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/CompletionProvider.kt
@@ -8,6 +8,7 @@ import com.github.albertocavalcante.groovylsp.dsl.completion.GroovyCompletions
 import com.github.albertocavalcante.groovylsp.dsl.completion.completions
 import com.github.albertocavalcante.groovyparser.ast.ClassSymbol
 import com.github.albertocavalcante.groovyparser.ast.FieldSymbol
+import com.github.albertocavalcante.groovyparser.ast.GroovyAstModel
 import com.github.albertocavalcante.groovyparser.ast.ImportSymbol
 import com.github.albertocavalcante.groovyparser.ast.MethodSymbol
 import com.github.albertocavalcante.groovyparser.ast.SymbolCompletionContext
@@ -15,20 +16,22 @@ import com.github.albertocavalcante.groovyparser.ast.SymbolExtractor
 import com.github.albertocavalcante.groovyparser.ast.VariableSymbol
 import com.github.albertocavalcante.groovyparser.tokens.GroovyTokenIndex
 import com.github.albertocavalcante.groovyspock.SpockDetector
+import org.codehaus.groovy.ast.ASTNode
 import org.codehaus.groovy.control.CompilationFailedException
 import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionItemKind
 import org.slf4j.LoggerFactory
+import java.net.URI
 
 /**
  * Context for completion operations.
  */
 data class CompletionContext(
-    val uri: java.net.URI,
+    val uri: URI,
     val line: Int,
     val character: Int,
-    val ast: org.codehaus.groovy.ast.ASTNode,
-    val astModel: com.github.albertocavalcante.groovyparser.ast.GroovyAstModel,
+    val ast: ASTNode,
+    val astModel: GroovyAstModel,
     val isSpockSpec: Boolean,
     val tokenIndex: GroovyTokenIndex?,
     val compilationService: GroovyCompilationService,
@@ -258,7 +261,6 @@ object CompletionProvider {
         return metadata.globalVariables.values.find { it.type == type }
     }
 
-    // @Suppress("LongParameterList") // Refactored to use CompletionContext
     private fun CompletionsBuilder.addSpockBlockLabelsIfApplicable(
         ctx: CompletionContext,
         completionContext: ContextType?,


### PR DESCRIPTION
## Summary
Encapsulates completion request parameters into a structured `CompletionContext` data class.

## Changes
- **New Data Class**: `CompletionContext` holds `uri`, `line`, `character`, `ast`, `astModel`, `isSpockSpec`, `tokenIndex`, `compilationService`, and `content`.
- **Refactored Methods**: `buildCompletionsList` and `addSpockBlockLabelsIfApplicable` now accept `CompletionContext`.
- **Removed Suppressions**: `@Suppress(LongParameterList)` annotations are no longer needed.

## Why
This is a foundational refactor to prepare for future enhancements (e.g., classpath-aware completions) without breaking method signatures.

## Verification
- All existing tests pass (`JenkinsPropertyCompletionTest`, `CompletionProviderTest`, etc.).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors completion flow to use a single `CompletionContext` object, simplifying parameter passing and centralizing request state.
> 
> - Adds `CompletionContext` (fields: `uri`, `line`, `character`, `ast`, `astModel`, `isSpockSpec`, `tokenIndex`, `compilationService`, `content`).
> - Updates `CompletionProvider`: `buildCompletionsList` and `addSpockBlockLabelsIfApplicable` now take `ctx`; all internal references switched to `ctx.*` and call sites updated in `getContextualCompletions`.
> - Cleans up long parameter lists and removes related suppressions without altering completion logic (Jenkins/Spock handling now reads from `ctx`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e6f223da12758eb931b1c8e89aaa49753f81c0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->