### PR TITLE
refactor(jenkins): extract duplicated string literals into constants

### DIFF
--- a/groovy-jenkins/src/main/kotlin/com/github/albertocavalcante/groovyjenkins/metadata/StableStepDefinitions.kt
+++ b/groovy-jenkins/src/main/kotlin/com/github/albertocavalcante/groovyjenkins/metadata/StableStepDefinitions.kt
@@ -18,7 +18,7 @@ package com.github.albertocavalcante.groovyjenkins.metadata
  */
 object StableStepDefinitions {
 
-    // ========== Plugin name constants (SonarCloud: duplicated 19+ times) ==========
+    // Plugin name constants
     private object Plugins {
         const val DURABLE_TASK = "workflow-durable-task-step"
         const val BASIC_STEPS = "workflow-basic-steps"
@@ -34,7 +34,7 @@ object StableStepDefinitions {
         const val CORE = "core"
     }
 
-    // ========== Common parameter descriptions (SonarCloud: duplicated 3-4 times) ==========
+    // Common parameter descriptions
     private object Descriptions {
         const val RETURN_STDOUT = "If true, return the stdout as the step value."
         const val RETURN_STATUS = "If true, return the exit code as the step value."


### PR DESCRIPTION
## Summary

Extract plugin names and common parameter descriptions into private constant objects within `StableStepDefinitions.kt` to reduce code smells.

## Changes

- Add `Plugins` object with 12 plugin name constants
- Add `Descriptions` object with 5 common parameter descriptions  
- Replace ~50 duplicated string literals with constant references

## SonarCloud Issues Resolved

Resolves 8 CRITICAL code smell issues:
- `workflow-durable-task-step` duplicated 4 times
- `workflow-basic-steps` duplicated 19 times
- `pipeline-utility-steps` duplicated 4 times
- Common descriptions duplicated 3-4 times each

## Testing

- [x] `./gradlew :groovy-jenkins:compileKotlin` passes
- [x] No behavioral changes - purely structural refactoring

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces duplication in `StableStepDefinitions.kt` by centralizing repeated strings.
> 
> - Adds private `Plugins` and `Descriptions` constant objects for plugin IDs and common parameter descriptions
> - Replaces repeated literals (e.g., plugin IDs, `returnStdout`/`returnStatus`/`encoding`/`label`/file path descriptions) with constant references across all step metadata
> - No functional changes; improves maintainability and readability
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ebd4bc0ef90df15e177ac243881d6bfe9636235. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->