### PR TITLE
refactor(jenkins): decompose detectFromDocument to reduce complexity

### DIFF
--- a/groovy-jenkins/src/main/kotlin/com/github/albertocavalcante/groovyjenkins/completion/JenkinsContextDetector.kt
+++ b/groovy-jenkins/src/main/kotlin/com/github/albertocavalcante/groovyjenkins/completion/JenkinsContextDetector.kt
@@ -40,6 +40,9 @@ object JenkinsContextDetector {
         "changed", "fixed", "regression", "aborted", "cleanup",
     )
 
+    // Pre-compiled pattern for post conditions (avoids per-iteration regex compilation)
+    private val POST_CONDITION_PATTERN = Regex("""^(${POST_CONDITIONS.joinToString("|")})\s*\{.*""")
+
     // Step name pattern - matches step name followed by space or end of string
     private val STEP_PATTERN = Regex("""^\s*(\w+)(?:\s|$)""")
 
@@ -150,10 +153,8 @@ object JenkinsContextDetector {
      */
     private fun addPostConditionBlocks(line: String, blockStack: MutableList<String>) {
         val trimmedLine = line.trim()
-        for (condition in POST_CONDITIONS) {
-            if (trimmedLine.matches(Regex("""$condition\s*\{.*"""))) {
-                blockStack.add(condition)
-            }
+        POST_CONDITION_PATTERN.find(trimmedLine)?.groups?.get(1)?.value?.let { condition ->
+            blockStack.add(condition)
         }
     }
 


### PR DESCRIPTION
## Summary

Decompose `JenkinsContextDetector.detectFromDocument()` to reduce cognitive complexity from 18 to under 15 per method.

## Extracted Methods

| Method | Responsibility |
|--------|---------------|
| `analyzeBlockStructure` | Iterates through lines tracking block stack |
| `addBlockOpenings` | Finds block name patterns in a line |
| `addPostConditionBlocks` | Finds post conditions in a line |
| `trimBlockStackToDepth` | Removes blocks when braces close |
| `detectCurrentLineContext` | Gets inline context at cursor |
| `buildContext` | Constructs final JenkinsCompletionContext |

## Idiomatic Kotlin Improvements

- Use `in` operator instead of `.contains()` for readability
- Use `getOrElse()` instead of manual bounds checking

## Testing

- [x] `./gradlew :groovy-jenkins:test` passes (all 12 tests)
- [x] No behavioral changes - purely structural refactoring

Resolves SonarCloud CRITICAL cognitive complexity issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on structural refactor for clarity and lower cognitive complexity.
> 
> - Extracts helpers: `analyzeBlockStructure`, `addBlockOpenings`, `addPostConditionBlocks`, `trimBlockStackToDepth`, `detectCurrentLineContext`, `buildContext`
> - Precompiles post-condition pattern (`POST_CONDITION_PATTERN`) and centralizes post-condition detection
> - Simplifies checks using Kotlin idioms (`in`, `getOrElse`) and streamlines brace-depth trimming
> - No functional changes; `JenkinsContextDetector.kt` behavior preserved
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 185f1decdf3ffced31dd3772728ce0fe2af1eba0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->