### PR TITLE
fix(ci): remove invalid predicate-quantifier from paths-filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,28 +97,22 @@ jobs:
           # For workflow_run events, use the triggering workflow's head commit as base
           # This fixes the 'before field is missing' warning
           base: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
-          # Use 'every' predicate to properly handle exclusion patterns
-          # With 'some' (default), a file matches if it matches ANY pattern, breaking negations
-          predicate-quantifier: 'every'
+          # NOTE: Only positive patterns work reliably with paths-filter
+          # Exclusions like !**/*.md don't work as expected with default 'some' predicate
+          # Files in excluded dirs (docs/, .agent/) simply won't match positive patterns
           filters: |
             run_main_ci:
-              # Positive patterns: paths that require CI
+              # Code that requires CI to run
               - 'src/**'
               - 'gradle/**'
-              - 'groovy-*/**'
+              - 'groovy-*/src/**'
+              - 'groovy-*/*.gradle.kts'
               - 'tests/**'
               - '*.gradle'
               - '*.gradle.kts'
               - 'gradle.properties'
               - 'settings.gradle.kts'
               - '.github/workflows/ci.yml'
-              # Negative patterns: paths that should NOT trigger CI
-              - '!**/*.md'
-              - '!.agent/**'
-              - '!.gemini/**'
-              - '!docs/**'
-              - '!infra/**'
-              - '!.github/workflows/runner-*.yml'
 
   check-runner:
     name: Check Runner Availability


### PR DESCRIPTION
## Summary

Fixes CI being skipped for actual code changes.

## Problem

The `predicate-quantifier: 'every'` input is not valid for `dorny/paths-filter@v3.0.2`:
```
Warning: Unexpected input(s) 'predicate-quantifier', valid inputs are ['token', 'working-directory', 'ref', 'base', 'filters', 'list-files', 'initial-fetch-depth']
```

This caused `run_main_ci` to always be `false`, skipping the Build and Test job for all PRs.

## Solution

- Remove the unsupported `predicate-quantifier` input
- Restructure filters to use **only positive patterns** (exclusions don't work reliably)
- Use `groovy-*/src/**` to match source files (not `groovy-*/**` which would match README files)
- Add `groovy-*/*.gradle.kts` pattern for build file changes

## Testing

This PR itself will verify the fix - CI should run Build and Test since `.github/workflows/ci.yml` is a positive pattern match.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures CI triggers for real code changes by fixing the `paths-filter` configuration.
> 
> - Remove invalid `predicate-quantifier` input from `dorny/paths-filter@v3.0.2`
> - Use positive-only patterns; drop exclusions and refine Groovy matches to `groovy-*/src/**` and `groovy-*/*.gradle.kts`
> - Keep triggers for source, tests, Gradle files, and `.github/workflows/ci.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04ea158baad7fd3562186693ae10be0e27d5e188. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->