### PR TITLE
feat: implement groovy/status notification for server readiness

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/services/GroovyLanguageClient.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/services/GroovyLanguageClient.kt
@@ -1,0 +1,28 @@
+package com.github.albertocavalcante.groovylsp.services
+
+import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
+import org.eclipse.lsp4j.services.LanguageClient
+
+/**
+ * Extended language client interface with Groovy-specific notifications.
+ *
+ * This interface extends the standard LSP [LanguageClient] with custom
+ * notifications like `groovy/status` for server readiness signaling.
+ *
+ * @see <a href="https://github.com/eclipse-lsp4j/lsp4j#extending-the-protocol">LSP4J Extending Protocol</a>
+ */
+interface GroovyLanguageClient : LanguageClient {
+    /**
+     * Receives server status notifications.
+     *
+     * This notification is sent during server lifecycle transitions:
+     * - `Starting`: Server is initializing
+     * - `Ready`: Server is ready to handle requests
+     * - `Indexing`: Background indexing in progress
+     * - `Error`: An error occurred
+     *
+     * @param status The status notification payload
+     */
+    @JsonNotification("groovy/status")
+    fun groovyStatus(status: StatusNotification)
+}

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/services/ServerStatus.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/services/ServerStatus.kt
@@ -1,0 +1,28 @@
+package com.github.albertocavalcante.groovylsp.services
+
+/**
+ * Server status enum for the `groovy/status` notification.
+ *
+ * Provides status notifications during server lifecycle phases.
+ */
+enum class ServerStatus {
+    /** Server is initializing (after `initialize` but before ready). */
+    Starting,
+
+    /** Server is fully ready to handle requests. */
+    Ready,
+
+    /** Server is performing background indexing. */
+    Indexing,
+
+    /** An error occurred during initialization. */
+    Error,
+}
+
+/**
+ * Payload for the `groovy/status` notification.
+ *
+ * @property status The current server status.
+ * @property message Optional human-readable message with additional context.
+ */
+data class StatusNotification(val status: ServerStatus, val message: String? = null)


### PR DESCRIPTION
## Summary

Implements `groovy/status` notification system to enable robust E2E test synchronization, replacing brittle `Thread.sleep()` calls.

## Changes

### New Files
- **`ServerStatus.kt`**: `ServerStatus` enum (Starting, Ready, Indexing, Error) and `StatusNotification` data class
- **`GroovyLanguageClient.kt`**: Extended `LanguageClient` interface with `@JsonNotification("groovy/status")`

### Modified Files
- **`GroovyLanguageServer.kt`**: Added `sendStatus()` helper, uses `GroovyLanguageClient`
- **`ProjectStartupManager.kt`**: Added `onReady` and `onError` callbacks
- **`HarnessLanguageClient.kt`**: Added `readyFuture` and `groovyStatus()` handler
- **`LanguageServerSessionFactory.kt`**: Updated docs, reduced sleep to 50ms

## Testing
- Build compiles successfully
- E2E tests pass

Closes #314

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces explicit server lifecycle notifications and test synchronization.
> 
> - New `GroovyLanguageClient` with `@JsonNotification("groovy/status")` and payload types `ServerStatus` and `StatusNotification`
> - `GroovyLanguageServer`: separates base vs. extended client, adds `sendStatus()`, emits `Starting`, `Ready`, `Error` during init and dependency resolution
> - `ProjectStartupManager`: adds `onReady`/`onError` hooks; wires them to dependency resolution completion/failure
> - Test harness: `HarnessLanguageClient` implements `groovyStatus()` and exposes `readyFuture`; `LanguageServerSessionFactory` trims launcher wait to 50ms and documents readiness flow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d7ee6e76efb016a6219398cb78eb9f6f762ec8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->