### PR TITLE
fix: make KernelExecutor a functional interface

### DIFF
--- a/jupyter/kernel-core/src/main/kotlin/com/github/albertocavalcante/groovyjupyter/kernel/core/KernelExecutor.kt
+++ b/jupyter/kernel-core/src/main/kotlin/com/github/albertocavalcante/groovyjupyter/kernel/core/KernelExecutor.kt
@@ -5,8 +5,10 @@ import com.github.albertocavalcante.groovyjupyter.handlers.ExecuteResult
 /**
  * Interface for the kernel's execution engine.
  * Decouples the ZMQ message handling from the actual code execution (Groovy, Mock Jenkins, etc).
+ *
+ * This is a SAM (Single Abstract Method) interface, allowing lambda conversion.
  */
-interface KernelExecutor {
+fun interface KernelExecutor {
     /**
      * Executes the provided code and returns a result.
      */


### PR DESCRIPTION
## Summary
Addresses SonarCloud code smell about non-functional single-method interfaces.

## Changes
- Added `fun` modifier to `KernelExecutor` interface
- Updated KDoc to document SAM (Single Abstract Method) capability
- Enables lambda conversion for callers

## SonarCloud Issue
- **Type**: CODE_SMELL  
- **Severity**: MAJOR
- **Message**: Make this interface functional or replace it with a function type
- **Location**: KernelExecutor.kt line 9

## Verification
- [x] Unit tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Converts `KernelExecutor` to a Kotlin `fun interface` to enable SAM/lambda usage and updates KDoc accordingly.
> 
> - Change `interface KernelExecutor` -> `fun interface KernelExecutor`
> - KDoc updated to note SAM (Single Abstract Method) and lambda conversion
> - No runtime logic changes; only type declaration/documentation adjustment
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3937d7b6f2946f7034bed15ace4385a491fd48e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->