### PR TITLE
fix(ci): use pattern matching for OS detection in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,18 +114,22 @@ jobs:
       run: |
         mkdir -p dist
         # Copy JAR with version in filename
+        # Use pattern matching to handle versioned runner labels (e.g., ubuntu-24.04, macos-14)
         if [ "${{ matrix.os }}" = "self-hosted" ]; then
            # On self-hosted, we assume the JAR is portable and generate all platform variants
            echo "Generating all platform artifacts from single build..."
            cp groovy-lsp/build/libs/groovy-lsp-*-all.jar dist/groovy-lsp-${BUILD_VERSION#v}-linux-amd64.jar
            cp groovy-lsp/build/libs/groovy-lsp-*-all.jar dist/groovy-lsp-${BUILD_VERSION#v}-darwin-amd64.jar
            cp groovy-lsp/build/libs/groovy-lsp-*-all.jar dist/groovy-lsp-${BUILD_VERSION#v}-windows-amd64.jar
-        elif [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+        elif [[ "${{ matrix.os }}" == ubuntu* ]]; then
           cp groovy-lsp/build/libs/groovy-lsp-*-all.jar dist/groovy-lsp-${BUILD_VERSION#v}-linux-amd64.jar
-        elif [ "${{ matrix.os }}" = "macos-latest" ]; then
+        elif [[ "${{ matrix.os }}" == macos* ]] || [[ "${{ matrix.os }}" == *macos* ]]; then
           cp groovy-lsp/build/libs/groovy-lsp-*-all.jar dist/groovy-lsp-${BUILD_VERSION#v}-darwin-amd64.jar
-        elif [ "${{ matrix.os }}" = "windows-latest" ]; then
+        elif [[ "${{ matrix.os }}" == windows* ]]; then
           cp groovy-lsp/build/libs/groovy-lsp-*-all.jar dist/groovy-lsp-${BUILD_VERSION#v}-windows-amd64.jar
+        else
+          echo "Unknown OS: ${{ matrix.os }}, creating generic artifact"
+          cp groovy-lsp/build/libs/groovy-lsp-*-all.jar dist/groovy-lsp-${BUILD_VERSION#v}-generic.jar
         fi
     - name: Upload release artifacts
       uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary
Fixes the release workflow artifact preparation which was failing because it checked for exact OS strings like `ubuntu-latest` but the workflow runs on `ubuntu-24.04`.

## Root Cause
The artifact preparation step used exact string matching:
```bash
elif [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
```

But the workflow is configured to run on `ubuntu-24.04`:
```yaml
os:
  - ${{ ... || 'ubuntu-24.04' }}
```

This mismatch caused **no artifacts to be generated**, which caused the release to fail.

## Changes
- Use bash glob patterns (`ubuntu*`, `macos*`, `windows*`) instead of exact version matches
- Handle local-macos runner label with `*macos*` pattern  
- Add fallback for unknown OS to create generic artifact with warning
- Add comment explaining the pattern matching approach

## Testing
This change can be verified by running the Release workflow with `workflow_dispaFixes the release wo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves artifact preparation in `release.yml` to work with versioned runner labels.
> 
> - Switches OS checks to bash pattern matching (`ubuntu*`, `macos*`, `*macos*`, `windows*`) when copying platform-specific JARs
> - Adds fallback branch to create `groovy-lsp-<version>-generic.jar` for unknown `matrix.os`
> - Adds a comment explaining the pattern-matching approach
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67612457f3d8b8066d3d641f58ec3024e1ca772e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->