### PR TITLE
fix(ci): update copybara-action to v1.2.5

### DIFF
--- a/.github/workflows/mirror-vscode-groovy.yml
+++ b/.github/workflows/mirror-vscode-groovy.yml
@@ -24,7 +24,7 @@ jobs:
           java-version: 17
 
       - name: Run Copybara
-        uses: olivr/copybara-action@ecdb2ec11c4c5e8adad65387fd2e6acc52bc9f7a # v1.2.3
+        uses: olivr/copybara-action@042b4395839f3a374a6455b541e29e40c949d717 # v1.2.5
         with:
           ssh_key: ${{ secrets.COPYBARA_SSH_KEY }}
           workflow: push-to-vscode-groovy


### PR DESCRIPTION
Updates the copybara-action to v1.2.5 (pinned by SHA) to resolve the 'action not found' error in the mirror workflow. This fixes the CI failure where the previous version/SHA could not be resolved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates CI workflow for mirroring to vscode-groovy.
> 
> - Bumps `olivr/copybara-action` from `v1.2.3` to `v1.2.5` (pinned SHA) in `.github/workflows/mirror-vscode-groovy.yml` for the "Run Copybara" step
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e5bf65b5a240aac92275eed5f6eeaa165f07db1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->