### PR TITLE
feat(ci): allow manual trigger for mirror workflow

### DIFF
--- a/.github/workflows/mirror-vscode-groovy.yml
+++ b/.github/workflows/mirror-vscode-groovy.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'editors/code/**'
+  workflow_dispatch:
 
 jobs:
   mirror:


### PR DESCRIPTION
Enables 'workflow_dispatch' for the 'Mirror to vscode-groovy' workflow, allowing manual retries when the mirror fails or needs to be run ad-hoc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds manual trigger support to the CI mirror workflow.
> 
> - Enables `workflow_dispatch` in `.github/workflows/mirror-vscode-groovy.yml` so the "Mirror to vscode-groovy" job can be run on-demand in addition to `push` events
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 351b172269c9ff5e39d24027d1f77a4b1536bbe1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->