### PR TITLE
fix(ci): use correct input 'custom_config' for copybara action

### DIFF
--- a/.github/workflows/mirror-vscode-groovy.yml
+++ b/.github/workflows/mirror-vscode-groovy.yml
@@ -30,4 +30,4 @@ jobs:
           ssh_key: ${{ secrets.COPYBARA_SSH_KEY }}
           workflow: push-to-vscode-groovy
           copybara_options: "--force"
-          copybara_file: infra/copybara/vscode-groovy.bara.sky
+          custom_config: infra/copybara/vscode-groovy.bara.sky


### PR DESCRIPTION
Updates the copybara-action configuration to use the correct input name 'custom_config' instead of 'copybara_file', as required by the action version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects the Copybara action configuration in the GitHub workflow.
> 
> - Replaces `copybara_file` with the correct `custom_config` input in `.github/workflows/mirror-vscode-groovy.yml`, pointing to `infra/copybara/vscode-groovy.bara.sky`
> - Keeps all other workflow settings unchanged (`workflow`, `ssh_key`, `copybara_options`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aefd5083b2336f3e0f1af7a70ad742d64d7d6793. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->