### PR TITLE
fix(infra): use SSH URL for copybara destination

### DIFF
--- a/infra/copybara/vscode-groovy.bara.sky
+++ b/infra/copybara/vscode-groovy.bara.sky
@@ -15,7 +15,7 @@ core.workflow(
     ),
     
     destination = git.github_destination(
-        url = "https://github.com/albertocavalcante/vscode-groovy.git",
+        url = "git@github.com:albertocavalcante/vscode-groovy.git",
         push = "main",
     ),
     


### PR DESCRIPTION
Updates the Copybara configuration to use the SSH URL for the destination repository. This is required for the SSH key authentication to work correctly in the CI environment, resolving the 'Invalid username or token' error during push.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Copybara to push via SSH instead of HTTPS for the `vscode-groovy` mirror.
> 
> - Update `infra/copybara/vscode-groovy.bara.sky` `git.github_destination.url` to `git@github.com:albertocavalcante/vscode-groovy.git` to use SSH auth in CI
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd2659f814d52081cb46bb2234d39c434a701f7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->