### PR TITLE
chore(infra): enhance copybara author preservation

### DIFF
--- a/infra/copybara/vscode-groovy.bara.sky
+++ b/infra/copybara/vscode-groovy.bara.sky
@@ -29,6 +29,12 @@ core.workflow(
         ]
     ),
     
+    mode = "ITERATIVE",
+    
+    # Preserve original author information
+    authoring = authoring.pass_thru("gls-bot <gls-bot@cavalcante.uk>"),
+    
+    # Improve commit message handling
     transformations = [
         # Move files from editors/code/ to root
         core.move("editors/code", ""),
@@ -55,14 +61,8 @@ core.workflow(
             paths = glob(["package.json"]),
         ),
         
-        # Add sync metadata to commit message
-        metadata.add_header(
-            "This commit was automatically synced from groovy-lsp monorepo.\n" +
-            "Source: https://github.com/albertocavalcante/groovy-lsp/tree/main/editors/code\n" +
-            "Do not edit this repository directly - changes will be overwritten.\n\n"
-        ),
+        # Add descriptive footer instead of header for cleaner log
+        metadata.expose_label("Co-authored-by"),
+        metadata.expose_label("Signed-off-by"),
     ],
-    
-    # All commits appear as from gls-bot (consistent with jenkins-extractor)
-    authoring = authoring.overwrite("gls-bot <gls-bot@cavalcante.uk>"),
 )


### PR DESCRIPTION
This PR updates the Copybara configuration to preserve original commit authorship and expose standard git trailers like 'Co-authored-by'.

### Changes
- Changed authoring mode to `pass_thru` (defaults to `gls-bot` only if mapping fails).
- Enabled `ITERATIVE` mode.
- Replaced custom header with standard exposed labels for cleaner history.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Copybara sync workflow in `infra/copybara/vscode-groovy.bara.sky`.
> 
> - Enable `ITERATIVE` mode for per-commit syncing
> - Preserve original authors with `authoring.pass_thru("gls-bot <gls-bot@cavalcante.uk>")` as fallback
> - Replace custom commit header with exposed trailers: `Co-authored-by` and `Signed-off-by`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1ed47188c657940472458415ed3adfd021cabd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->