### PR TITLE
fix(copybara): preserve Closes/Fixes and add read-only warning

### DIFF
--- a/infra/copybara/vscode-groovy.bara.sky
+++ b/infra/copybara/vscode-groovy.bara.sky
@@ -61,11 +61,16 @@ core.workflow(
             paths = glob(["package.json"]),
         ),
         
-        # Add descriptive footer instead of header for cleaner log
         # Expose standard Git trailers and GitHub keywords to preserve them in the destination
         metadata.expose_label("Co-authored-by"),
         metadata.expose_label("Signed-off-by"),
         metadata.expose_label("Closes"),
         metadata.expose_label("Fixes"),
+
+        # Add sync metadata to commit message footer
+        metadata.add_footer(
+            "Synced from: https://github.com/albertocavalcante/groovy-lsp/tree/main/editors/code\n" +
+            "This is a read-only mirror. Do not edit directly."
+        ),
     ],
 )


### PR DESCRIPTION
This PR refines the Copybara configuration to:

1.  **Expose 'Closes' and 'Fixes' labels**: Ensures issue references are preserved.
2.  **Add Read-Only Footer**: Restores a concise warning at the bottom of commit messages to prevent accidental direct edits.

**Verification**:
- Complements `ITERATIVE` mode and `authoring.pass_thru` for full history fidelity.
- NOT merged automatically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves commit metadata handling in `vscode-groovy.bara.sky` for the mirror sync.
> 
> - Exposes Git trailers/keywords `Co-authored-by`, `Signed-off-by`, `Closes`, and `Fixes` so they are preserved in destination commits
> - Appends a commit footer with the source path and a read-only warning via `metadata.add_footer`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06706122f0d892e1c7bbe17665ebefd72ae84bfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->