### PR TITLE
fix(security): add tag validation to prevent script injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,14 +51,15 @@ jobs:
     - name: Validate tag input
       if: github.event.inputs.tag != ''
       shell: bash
+      env:
+        TAG_INPUT: ${{ github.event.inputs.tag }}
       run: |
-        TAG="${{ github.event.inputs.tag }}"
         # Validate tag matches expected version format (v1.2.3 or v1.2.3-rc.1 or vscode-groovy-v1.2.3)
-        if [[ ! "$TAG" =~ ^(v|vscode-groovy-v)?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
-          echo "::error::Invalid tag format: $TAG. Expected formats: v1.2.3, v1.2.3-rc.1, or vscode-groovy-v1.2.3"
+        if [[ ! "$TAG_INPUT" =~ ^(v|vscode-groovy-v)?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
+          echo "::error::Invalid tag format: $TAG_INPUT. Expected formats: v1.2.3, v1.2.3-rc.1, or vscode-groovy-v1.2.3"
           exit 1
         fi
-        echo "Tag validation passed: $TAG"
+        echo "Tag validation passed: $TAG_INPUT"
     - name: Checkout code
       uses: actions/checkout@v6
       with:
@@ -160,14 +161,15 @@ jobs:
     - name: Validate tag input
       if: github.event.inputs.tag != ''
       shell: bash
+      env:
+        TAG_INPUT: ${{ github.event.inputs.tag }}
       run: |
-        TAG="${{ github.event.inputs.tag }}"
         # Validate tag matches expected version format (v1.2.3 or v1.2.3-rc.1 or vscode-groovy-v1.2.3)
-        if [[ ! "$TAG" =~ ^(v|vscode-groovy-v)?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
-          echo "::error::Invalid tag format: $TAG. Expected formats: v1.2.3, v1.2.3-rc.1, or vscode-groovy-v1.2.3"
+        if [[ ! "$TAG_INPUT" =~ ^(v|vscode-groovy-v)?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
+          echo "::error::Invalid tag format: $TAG_INPUT. Expected formats: v1.2.3, v1.2.3-rc.1, or vscode-groovy-v1.2.3"
           exit 1
         fi
-        echo "Tag validation passed: $TAG"
+        echo "Tag validation passed: $TAG_INPUT"
     - name: Checkout code
       uses: actions/checkout@v6
       with:


### PR DESCRIPTION
## Summary

Fixes 2 **BLOCKER** security vulnerabilities detected by SonarCloud (`githubactions:S8263`).

## Problem

The `release.yml` workflow used user-controlled `github.event.inputs.tag` directly as the `ref` parameter in `actions/checkout`. This could allow script injection if an attacker with write access provided a malicious tag value.

**Affected lines:**
- Line 55 (build-release job)
- Line 153 (create-release job)

## Solution

Add a validation step before checkout in both jobs that:
1. Checks if a tag input was provided
2. Validates the tag matches expected version formats:
   - `v1.2.3` - standard version tags
   - `v1.2.3-rc.1` - prerelease tags  
   - `vscode-groovy-v1.2.3` - VS Code extension tags
3. Fails with an error message if the format is invalid

## Verification

- Tag validation runs only when `github.event.inputs.tag` is provided
- Valid tags pass through unchanged
- Invalid tags fail fast with a clear error message

## References

- SonarCloud Rule: https://rules.sonarsource.com/github-actions/type/Vulnerability/RSPEC-8263

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens release workflow security by validating user-provided tag input before any checkout.
> 
> - Adds a `Validate tag input` step in `build-release` and `create-release` of `.github/workflows/release.yml`
> - Accepts only `vX.Y.Z`, `vX.Y.Z-rc.N` (and similar prereleases), or `vscode-groovy-vX.Y.Z`; otherwise fails early
> - Ensures `actions/checkout` `ref` uses only trusted, well-formed tags when `github.event.inputs.tag` is provided
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd7e3b3dd78a9d030121228777add13f72a354c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->