### PR TITLE
chore(release): rename artifacts from groovy-lsp to gls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
       shell: bash
       run: |
         echo "Testing JAR with --help flag..."
-        java -jar groovy-lsp/build/libs/groovy-lsp-*-all.jar --help
+        java -jar groovy-lsp/build/libs/gls-*-all.jar --help
     - name: Prepare artifacts
       shell: bash
       run: |
@@ -131,18 +131,18 @@ jobs:
         if [ "${{ matrix.os }}" = "self-hosted" ]; then
            # On self-hosted, we assume the JAR is portable and generate all platform variants
            echo "Generating all platform artifacts from single build..."
-           cp groovy-lsp/build/libs/groovy-lsp-*-all.jar dist/groovy-lsp-${BUILD_VERSION#v}-linux-amd64.jar
-           cp groovy-lsp/build/libs/groovy-lsp-*-all.jar dist/groovy-lsp-${BUILD_VERSION#v}-darwin-amd64.jar
-           cp groovy-lsp/build/libs/groovy-lsp-*-all.jar dist/groovy-lsp-${BUILD_VERSION#v}-windows-amd64.jar
+           cp groovy-lsp/build/libs/gls-*-all.jar dist/gls-${BUILD_VERSION#v}-linux-amd64.jar
+           cp groovy-lsp/build/libs/gls-*-all.jar dist/gls-${BUILD_VERSION#v}-darwin-amd64.jar
+           cp groovy-lsp/build/libs/gls-*-all.jar dist/gls-${BUILD_VERSION#v}-windows-amd64.jar
         elif [[ "${{ matrix.os }}" == ubuntu* ]]; then
-          cp groovy-lsp/build/libs/groovy-lsp-*-all.jar dist/groovy-lsp-${BUILD_VERSION#v}-linux-amd64.jar
+          cp groovy-lsp/build/libs/gls-*-all.jar dist/gls-${BUILD_VERSION#v}-linux-amd64.jar
         elif [[ "${{ matrix.os }}" == macos* ]] || [[ "${{ matrix.os }}" == *macos* ]]; then
-          cp groovy-lsp/build/libs/groovy-lsp-*-all.jar dist/groovy-lsp-${BUILD_VERSION#v}-darwin-amd64.jar
+          cp groovy-lsp/build/libs/gls-*-all.jar dist/gls-${BUILD_VERSION#v}-darwin-amd64.jar
         elif [[ "${{ matrix.os }}" == windows* ]]; then
-          cp groovy-lsp/build/libs/groovy-lsp-*-all.jar dist/groovy-lsp-${BUILD_VERSION#v}-windows-amd64.jar
+          cp groovy-lsp/build/libs/gls-*-all.jar dist/gls-${BUILD_VERSION#v}-windows-amd64.jar
         else
           echo "Unknown OS: ${{ matrix.os }}, creating generic artifact"
-          cp groovy-lsp/build/libs/groovy-lsp-*-all.jar dist/groovy-lsp-${BUILD_VERSION#v}-generic.jar
+          cp groovy-lsp/build/libs/gls-*-all.jar dist/gls-${BUILD_VERSION#v}-generic.jar
         fi
     - name: Upload release artifacts
       uses: actions/upload-artifact@v6
@@ -214,21 +214,21 @@ jobs:
 
         \`\`\`bash
         # Download JAR (replace linux-amd64 with your platform)
-        curl -LO https://github.com/${{ github.repository }}/releases/download/${VERSION}/groovy-lsp-${VERSION#v}-linux-amd64.jar
+        curl -LO https://github.com/${{ github.repository }}/releases/download/${VERSION}/gls-${VERSION#v}-linux-amd64.jar
 
         # Verify checksum
         curl -LO https://github.com/${{ github.repository }}/releases/download/${VERSION}/checksums.txt
         sha256sum -c checksums.txt --ignore-missing
 
         # Run the Language Server
-        java -jar groovy-lsp-${VERSION#v}-linux-amd64.jar
+        java -jar gls-${VERSION#v}-linux-amd64.jar
         \`\`\`
 
         ### Supported Platforms
 
-        - **Linux AMD64** \`groovy-lsp-${VERSION#v}-linux-amd64.jar\`
-        - **macOS AMD64** \`groovy-lsp-${VERSION#v}-darwin-amd64.jar\`
-        - **Windows AMD64** \`groovy-lsp-${VERSION#v}-windows-amd64.jar\`
+        - **Linux AMD64** \`gls-${VERSION#v}-linux-amd64.jar\`
+        - **macOS AMD64** \`gls-${VERSION#v}-darwin-amd64.jar\`
+        - **Windows AMD64** \`gls-${VERSION#v}-windows-amd64.jar\`
 
         ### Usage
 
@@ -281,11 +281,11 @@ jobs:
         tag_name: "${{ steps.release_info.outputs.version }}"
         draft: "${{ steps.release_info.outputs.is_draft }}"
         prerelease: "${{ steps.release_info.outputs.is_prerelease }}"
-        name: "Groovy LSP ${{ steps.release_info.outputs.version }}"
+        name: "gls ${{ steps.release_info.outputs.version }}"
         body_path: release-notes.md
         generate_release_notes: true
         files: |
-          dist/groovy-lsp-*.jar
+          dist/gls-*.jar
           dist/checksums.txt
         fail_on_unmatched_files: false
         make_latest: "${{ steps.release_info.outputs.is_prerelease == 'false' }}"
@@ -302,7 +302,7 @@ jobs:
         echo ""
         echo "📋 Artifacts included:"
         cd dist
-        for file in groovy-lsp-*.jar checksums.txt; do
+        for file in gls-*.jar checksums.txt; do
           if [[ -f "$file" ]]; then
             size=$(ls -lh "$file" | awk '{print $5}')
             echo "  - $file ($size)"


### PR DESCRIPTION
## Summary

Updates the release workflow to produce `gls-*.jar` artifacts instead of `groovy-lsp-*.jar`.

This is Phase 2 of the gls rebrand, following PR #342 which updated the CLI and build output.

## Changes

- **Build artifacts**: `gls-VERSION-PLATFORM.jar` naming
- **Release notes**: Updated download examples with gls naming
- **File patterns**: Updated upload/iteration patterns to `gls-*.jar`
- **Release name**: Changed from "Groovy LSP VERSION" to "gls VERSION"

## Next Steps

After this PR is merged and a release is cut:
1. New release will produce `gls-0.X.0-linux-amd64.jar` etc.
2. Update `PINNED_JAR_ASSET` in `prepare-server.js` to point to new gls artifact
3. Consider repository rename from `groovy-lsp` → `gls`

## Testing

- [ ] CI passes
- [ ] Cut a test release to verify artifact naming

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Completes artifact rename in the release workflow from `groovy-lsp` to `gls`.
> 
> - Updates build/test paths and copy steps to use `groovy-lsp/build/libs/gls-*-all.jar` and produce `dist/gls-${VERSION}-<platform>.jar`
> - Adjusts release asset globs and listing to `dist/gls-*.jar` and checksum generation
> - Revises release notes download/run examples and supported platform entries to `gls-...` filenames
> - Changes GitHub release display name to `gls <version>`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e978609505a491c2d9687bce11f351a2e8e9f617. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->