### PR TITLE
fix(infra): use single-string format for copybara add_header

### DIFF
--- a/infra/copybara/vscode-groovy.bara.sky
+++ b/infra/copybara/vscode-groovy.bara.sky
@@ -68,7 +68,7 @@ core.workflow(
         metadata.expose_label("Fixes"),
 
         # Add sync metadata to commit message
-        metadata.add_header("Synced-From", "https://github.com/albertocavalcante/groovy-devtools/tree/main/editors/code"),
-        metadata.add_header("Note", "This is a read-only mirror. Do not edit directly."),
+        metadata.add_header("Synced-From: https://github.com/albertocavalcante/groovy-devtools/tree/main/editors/code"),
+        metadata.add_header("Note: This is a read-only mirror. Do not edit directly."),
     ],
 )


### PR DESCRIPTION
Fixes type error in Copybara config where 2-argument add_header was interpreted as (string, bool).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts Copybara config to correct header syntax.
> 
> - In `infra/copybara/vscode-groovy.bara.sky`, replace two-argument `metadata.add_header(key, value)` with single-string entries: `"Synced-From: https://github.com/albertocavalcante/groovy-devtools/tree/main/editors/code"` and `"Note: This is a read-only mirror. Do not edit directly."`
> - Prevents type mismatch errors during Copybara runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c66f1d7bd87b0c90d816ba88cd437ce59b93181. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->