### PR TITLE
docs: add git worktree guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,10 +53,12 @@ These rules apply to ALL tasks. Violation is unacceptable.
 - **Verify branch** — Run `git branch --show-current` before any commit
 
 ### Git Worktrees (preferred for clean PRs)
-- **Create from main** — `git fetch origin main` then `git worktree add -b <branch> <path> origin/main`
+- **Create from main** — `git fetch origin main` then `git worktree add -b <branch> ../<repo>-<branch> origin/main`
+- **Pick a sibling path** — Use a path at the same level as the repo, e.g. `../groovy-lsp-codeql`
 - **Keep changes isolated** — Do work only inside the worktree path for that PR
 - **Push from the worktree** — `git push -u origin <branch>`
-- **Clean up after merge** — `git worktree remove <path>` and `git worktree prune`
+- **Clean up after merge** — `git worktree remove <path>` then `git worktree prune`
+- **Optional housekeeping** — `git worktree list` to verify what’s active and remove stale entries
 
 ### Code Quality
 - **TDD required** — Red → Green → Refactor


### PR DESCRIPTION
## Summary
- document git worktree usage under Git Safety
- clarify sibling worktree path convention and cleanup steps

## Testing
- not run (docs only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds concise guidance on using `git worktree` for cleaner PRs.
> 
> - New "Git Worktrees (preferred for clean PRs)" section in `AGENTS.md` under Critical Rules
> - Outlines workflow: create from `origin/main`, use a sibling worktree path, keep changes isolated, push from the worktree, and clean up with `git worktree remove`/`prune`; includes `git worktree list` for housekeeping
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 252a18c50d870755ac7e7a901061329781cb4eff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->