### PR TITLE
chore: add dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,19 @@
+# Dependency Review blocks PRs that introduce known vulnerable dependencies.
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4


### PR DESCRIPTION
## Summary
- add dependency review workflow to block new vulnerable dependencies in PRs

## Testing
- not run (workflow only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces automated dependency vulnerability checks in PRs.
> 
> - Adds `.github/workflows/dependency-review.yml` to run GitHub `dependency-review-action` on `pull_request`
> - Pins `actions/checkout@v6` and `dependency-review-action@v4` by commit SHA; job runs on `ubuntu-24.04` with read-only permissions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a1b46b5a007d7859d064c794e8ca2e3ffb3907f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->