### PR TITLE
chore: add OSV scanner workflow

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,32 @@
+# OSV-Scanner checks dependencies for known vulnerabilities on PRs and on a schedule.
+name: OSV-Scanner
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 5 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  scan-scheduled:
+    if: ${{ github.event_name == 'schedule' }}
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@375a0e8ebdc98e99b02ac4338a724f5750f21213 # v2.3.1
+    with:
+      scan-args: |-
+        --include-git-root
+        -r
+        ./
+
+  scan-pr:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@375a0e8ebdc98e99b02ac4338a724f5750f21213 # v2.3.1
+    with:
+      scan-args: |-
+        --include-git-root
+        -r
+        ./


### PR DESCRIPTION
## Summary
- add OSV scanner workflow for PRs and weekly scheduled scans

## Testing
- not run (workflow only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces automated dependency vulnerability scanning via OSV-Scanner in GitHub Actions.
> 
> - New workflow `/.github/workflows/osv-scanner.yml` with two jobs: `scan-pr` (on PRs) and `scan-scheduled` (weekly cron)
> - Uses reusable workflows from `google/osv-scanner-action` (v2.3.1) with `--include-git-root` and recursive scanning
> - Sets minimal permissions (`actions: read`, `contents: read`, `security-events: write`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe44fdbd23454babc6a16eeb8d24cab8acb06fd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->