### PR TITLE
docs: annotate cron schedules

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    - cron: "0 6 * * 1"
+    - cron: "0 6 * * 1" # Weekly on Monday at 06:00 UTC
 
 jobs:
   analyze:

--- a/.github/workflows/extension-nightly.yml
+++ b/.github/workflows/extension-nightly.yml
@@ -2,7 +2,7 @@ name: Extension Nightly
 
 on:
   schedule:
-    - cron: "0 3 * * *"
+    - cron: "0 3 * * *" # Daily at 03:00 UTC
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/extract-jenkins-metadata.yml
+++ b/.github/workflows/extract-jenkins-metadata.yml
@@ -10,7 +10,7 @@ name: Extract Jenkins Metadata
 on:
   # Quarterly schedule - runs on the 1st of Jan, Apr, Jul, Oct
   schedule:
-    - cron: '0 0 1 1,4,7,10 *'
+    - cron: '0 0 1 1,4,7,10 *' # Quarterly on Jan/Apr/Jul/Oct 1st at 00:00 UTC
 
   # Manual trigger with version input
   workflow_dispatch:
@@ -125,4 +125,3 @@ jobs:
               body: body,
               labels: ['bug', 'ci']
             });
-

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly Build
 
 on:
   schedule:
-    - cron: "0 3 * * *"
+    - cron: "0 3 * * *" # Daily at 03:00 UTC
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/runner-cleanup.yml
+++ b/.github/workflows/runner-cleanup.yml
@@ -11,8 +11,8 @@ name: 'Infra: Auto-Cleanup Magalu Runner'
 
 on:
   schedule:
-    # Run every 2 hours
-    - cron: '0 */2 * * *'
+    # Every 2 hours at minute 0 UTC
+    - cron: '0 */2 * * *' # Every 2 hours at minute 0 UTC
   workflow_dispatch:
     inputs:
       force_cleanup:

--- a/.github/workflows/runner-destroy.yml
+++ b/.github/workflows/runner-destroy.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
   schedule:
     # Run nightly at 3 AM UTC to clean up any leftover runners
-    - cron: "0 3 * * *"
+    - cron: "0 3 * * *" # Daily at 03:00 UTC
 
 env:
   TF_CLOUD_ORGANIZATION: "alberto"


### PR DESCRIPTION
## Summary
- add human-readable cron schedule comments to workflow triggers

## Testing
- not run (comments only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds human-readable comments to cron schedules in GitHub Actions workflows; no logic or behavior changes.
> 
> - Annotates `schedule` cron lines in `codeql.yml` (weekly Mon 06:00 UTC)
> - Adds schedule comments to `extension-nightly.yml` and `nightly.yml` (daily 03:00 UTC)
> - Clarifies cadence in `runner-cleanup.yml` (every 2 hours at minute 0 UTC)
> - Documents nightly cleanup timing in `runner-destroy.yml` (daily 03:00 UTC)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa7eecfe73c731f3a23b95ebb914754c48e82858. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->