### PR TITLE
chore: add gradle wrapper validation

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -16,4 +16,4 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 # v3.5.0
+        uses: gradle/actions/wrapper-validation@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0


### PR DESCRIPTION
## Summary
- add Gradle wrapper validation workflow to block tampered wrapper changes in PRs
- switch to the supported gradle/actions wrapper validation action

## Testing
- not run (workflow only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a CI workflow to verify Gradle wrapper integrity on PRs.
> 
> - New `/.github/workflows/gradle-wrapper-validation.yml` triggered on `pull_request` to `main` with read-only `contents` permissions
> - Uses pinned `actions/checkout@v6` and `gradle/actions/wrapper-validation@v3.5.0` on `ubuntu-24.04`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb43f011c34d6bcc3861491c45a80489efefa47e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->