### PR TITLE
test: add document symbol e2e scenario

### DIFF
--- a/tests/e2e/resources/scenarios/README.md
+++ b/tests/e2e/resources/scenarios/README.md
@@ -21,6 +21,7 @@ This directory contains YAML scenario files that define end-to-end LSP test case
 | **Completion** | `completion-basic`, `completion-gdk` | Code completion |
 | **Definition** | `definition-*` | Go-to-definition |
 | **Diagnostics** | `diagnostics-*` | Error reporting |
+| **Document Symbols** | `document-symbol-basic` | Document symbols |
 | **Signature** | `signature-help` | Method signature help |
 | **Build Tools** | `gradle-hover-deps` | Gradle integration |
 | **CodeLens** | `codelens-spock` | Test CodeLens commands |

--- a/tests/e2e/resources/scenarios/document-symbol-basic.yaml
+++ b/tests/e2e/resources/scenarios/document-symbol-basic.yaml
@@ -1,0 +1,55 @@
+name: document-symbol-basic
+description: Document symbols should include class and method entries.
+workspace:
+  fixture: empty-workspace
+steps:
+  - initialize: {}
+  - initialized: {}
+  - waitNotification:
+      method: groovy/status
+      checks:
+        - jsonPath: $.status
+          expect:
+            type: EQUALS
+            value: Ready
+      timeoutMs: 180000
+  - openDocument:
+      path: src/Symbols.groovy
+      languageId: groovy
+      version: 1
+      text: |
+        package com.example
+
+        class Widget {
+            String name
+
+            Widget(String name) {
+                this.name = name
+            }
+
+            int compute(int value) {
+                return value + name.length()
+            }
+        }
+  - request:
+      method: textDocument/documentSymbol
+      params:
+        textDocument:
+          uri: "{{workspace.uri}}src/Symbols.groovy"
+      saveAs: documentSymbols
+  - assert:
+      source: documentSymbols
+      checks:
+        - jsonPath: $
+          expect:
+            type: NOT_EMPTY
+        - jsonPath: $[*].right.name
+          expect:
+            type: CONTAINS
+            value: Widget
+        - jsonPath: $[*].right.name
+          expect:
+            type: CONTAINS
+            value: compute
+  - shutdown: {}
+  - exit: {}


### PR DESCRIPTION
## Summary
- add a document symbol e2e scenario that asserts class/method symbols
- document the new scenario category in the e2e README

## Testing
- ./gradlew lintFix
- ./gradlew :tests:e2eTest -Dgroovy.lsp.e2e.filter=document-symbol-basic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces coverage for document symbols in E2E tests and documents the new category.
> 
> - Adds `tests/e2e/resources/scenarios/document-symbol-basic.yaml` that opens a Groovy file and asserts `Widget` class and `compute` method are returned by `textDocument/documentSymbol`
> - Updates `tests/e2e/resources/scenarios/README.md` to include the **Document Symbols** category
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 549329d7d077d87fdd56169591f083d9c59a5788. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->