### PR TITLE
chore: add actions lint workflow

### DIFF
--- a/.github/workflows/actions-lint.yml
+++ b/.github/workflows/actions-lint.yml
@@ -28,7 +28,13 @@ jobs:
           go install github.com/suzuki-shunsuke/ghalint/cmd/ghalint@v1.5.4
 
       - name: Run actionlint
+        id: actionlint
         run: actionlint -color
+        continue-on-error: true
 
       - name: Run ghalint
         run: ghalint -c .github/ghalint.yaml run
+
+      - name: Fail if actionlint failed
+        if: ${{ steps.actionlint.outcome == 'failure' }}
+        run: exit 1


### PR DESCRIPTION
## Summary
- add Actions lint workflow running actionlint and ghalint
- run ghalint even if actionlint fails to surface both results

## Testing
- not run (workflow only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces CI to lint GitHub Actions workflows for correctness and policy.
> 
> - Adds `actions-lint.yml` to run `actionlint` and `ghalint` on PRs/pushes to `main` using pinned actions
> - Configures `contents: read` permission and sets up Go 1.25.x to install linters
> - Runs `actionlint` with `continue-on-error` and explicitly fails the job if it reports failure
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89ad039d9e75b6f1b0c3ee9af3739de6ff910b48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->