### PR TITLE
chore: fix shellcheck findings in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
         run: |
           # Priority: Input > Variable > Default(github-hosted)
           LABEL="${{ github.event.inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-hosted' }}"
-          echo "label=$LABEL" >> $GITHUB_OUTPUT
+          echo "label=$LABEL" >> "$GITHUB_OUTPUT"
           echo "Checking availability for: $LABEL"
 
       # --- Magalu Check ---
@@ -155,7 +155,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT_RUNNER }}
         run: |
           echo "Triggering runner-provision.yml..."
-          gh workflow run runner-provision.yml --repo ${{ github.repository }}
+          gh workflow run runner-provision.yml --repo "${{ github.repository }}"
           echo ""
           echo "⏳ Provisioning triggered. Manual approval may be required."
           echo "👉 Go to: https://github.com/${{ github.repository }}/actions/workflows/runner-provision.yml"
@@ -163,7 +163,7 @@ jobs:
           echo "ℹ️ This CI run will exit now to avoid wasting compute cycles."
           echo "::notice::CI exiting early. Will auto-resume via workflow_run after runner-provision.yml completes."
           # Set output to signal downstream jobs to skip
-          echo "provisioning_triggered=true" >> $GITHUB_OUTPUT
+          echo "provisioning_triggered=true" >> "$GITHUB_OUTPUT"
 
       # --- Local macOS Check ---
       - name: Check Local macOS runner
@@ -299,7 +299,7 @@ jobs:
             echo "| **RAM** | $RAM |"
             echo "| **Disk** | $DISK |"
             echo "| **Hostname** | $HOSTNAME |"
-          } >> $GITHUB_STEP_SUMMARY
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
         with:
@@ -318,21 +318,21 @@ jobs:
         run: |-
           # Set scan flag
           if [[ "${{ github.event.inputs.disable_scan }}" == "true" ]]; then
-            echo "GRADLE_SCAN_FLAG=-Dorg.gradle.scan=false" >> $GITHUB_ENV
+            echo "GRADLE_SCAN_FLAG=-Dorg.gradle.scan=false" >> "$GITHUB_ENV"
           else
-            echo "GRADLE_SCAN_FLAG=" >> $GITHUB_ENV
+            echo "GRADLE_SCAN_FLAG=" >> "$GITHUB_ENV"
           fi
 
           # Set test log level flag
           case "${{ github.event.inputs.test_log_level }}" in
             "info")
-              echo "TEST_LOG_FLAG=--info" >> $GITHUB_ENV
+              echo "TEST_LOG_FLAG=--info" >> "$GITHUB_ENV"
               ;;
             "debug")
-              echo "TEST_LOG_FLAG=--debug" >> $GITHUB_ENV
+              echo "TEST_LOG_FLAG=--debug" >> "$GITHUB_ENV"
               ;;
             *)
-              echo "TEST_LOG_FLAG=" >> $GITHUB_ENV
+              echo "TEST_LOG_FLAG=" >> "$GITHUB_ENV"
               ;;
           esac
 
@@ -343,25 +343,51 @@ jobs:
 
       # Phase 1: Compile + Lint in single invocation with parallel execution
       - name: Compile and Lint
-        run: ./gradlew classes testClasses lint --parallel --build-cache --stacktrace $GRADLE_SCAN_FLAG
+        run: |
+          args=(classes testClasses lint --parallel --build-cache --stacktrace)
+          if [[ -n "${GRADLE_SCAN_FLAG}" ]]; then
+            args+=("${GRADLE_SCAN_FLAG}")
+          fi
+          ./gradlew "${args[@]}"
 
       # Phase 2: Unit Tests (generates coverage data in .ic files)
       - name: Run Unit Tests
         timeout-minutes: 20
-        run: ./gradlew test --parallel --build-cache --stacktrace $TEST_LOG_FLAG $GRADLE_SCAN_FLAG
+        run: |
+          args=(test --parallel --build-cache --stacktrace)
+          if [[ -n "${TEST_LOG_FLAG}" ]]; then
+            args+=("${TEST_LOG_FLAG}")
+          fi
+          if [[ -n "${GRADLE_SCAN_FLAG}" ]]; then
+            args+=("${GRADLE_SCAN_FLAG}")
+          fi
+          ./gradlew "${args[@]}"
 
       # Phase 3: Coverage Reports (reads .ic files from Phase 2)
       # NOTE: Split from test task to avoid Kover hang bug when running in same invocation
       # with --parallel. See: https://github.com/Kotlin/kotlinx-kover/issues/509
       - name: Generate Coverage Reports
-        run: ./gradlew koverXmlReport koverHtmlReport --parallel --build-cache --stacktrace $GRADLE_SCAN_FLAG
+        run: |
+          args=(koverXmlReport koverHtmlReport --parallel --build-cache --stacktrace)
+          if [[ -n "${GRADLE_SCAN_FLAG}" ]]; then
+            args+=("${GRADLE_SCAN_FLAG}")
+          fi
+          ./gradlew "${args[@]}"
 
       # Phase 4: E2E Tests (automatically builds shadowJar via task dependency)
       # Skip on macOS - E2E tests are platform-independent LSP protocol tests
       - name: Run E2E Tests
         if: github.event_name == 'pull_request' || matrix.os != 'macos-15'
         timeout-minutes: 30
-        run: ./gradlew :tests:e2eTest --parallel --build-cache --stacktrace $TEST_LOG_FLAG $GRADLE_SCAN_FLAG
+        run: |
+          args=(:tests:e2eTest --parallel --build-cache --stacktrace)
+          if [[ -n "${TEST_LOG_FLAG}" ]]; then
+            args+=("${TEST_LOG_FLAG}")
+          fi
+          if [[ -n "${GRADLE_SCAN_FLAG}" ]]; then
+            args+=("${GRADLE_SCAN_FLAG}")
+          fi
+          ./gradlew "${args[@]}"
 
       # Phase 5: SonarCloud (needs coverage reports from Phase 3)
       - name: SonarCloud Analysis
@@ -369,7 +395,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonar --info $GRADLE_SCAN_FLAG
+        run: |
+          args=(sonar --info)
+          if [[ -n "${GRADLE_SCAN_FLAG}" ]]; then
+            args+=("${GRADLE_SCAN_FLAG}")
+          fi
+          ./gradlew "${args[@]}"
 
       - name: Generate Test Report
         uses: dorny/test-reporter@fe45e9537387dac839af0d33ba56eed8e24189e8 # v2.3.0

--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -63,7 +63,7 @@ jobs:
           if [ -f "client/out/extension.js" ]; then
             size=$(stat -c%s client/out/extension.js 2>/dev/null || stat -f%z client/out/extension.js)
             echo "Bundle size: $size bytes"
-            if [ $size -gt 2000000 ]; then
+            if [ "$size" -gt 2000000 ]; then
               echo "❌ Bundle too large (>2MB)"
               exit 1
             fi
@@ -161,6 +161,6 @@ jobs:
       - name: Verify VSIX
         run: |
           echo "Generated VSIX files:"
-          ls -la *.vsix
-          npx @vscode/vsce ls *.vsix
+          ls -la -- ./*.vsix
+          npx @vscode/vsce ls -- ./*.vsix
         working-directory: editors/code

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -110,25 +110,42 @@ jobs:
           PY
           )
           NIGHTLY_VERSION="${BASE_VERSION}-nightly.$(date -u +%Y%m%d%H%M)"
-          echo "base_version=$BASE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "nightly_version=$NIGHTLY_VERSION" >> "$GITHUB_OUTPUT"
-          echo "nightly_tag=nightly-${NIGHTLY_VERSION}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
+          {
+            echo "base_version=$BASE_VERSION"
+            echo "nightly_version=$NIGHTLY_VERSION"
+            echo "nightly_tag=nightly-${NIGHTLY_VERSION}-${GITHUB_RUN_ID}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Run lint checks
-        run: ./gradlew --no-daemon lint --stacktrace $GRADLE_SCAN_FLAG
+        run: |
+          args=(--no-daemon lint --stacktrace)
+          if [[ -n "${GRADLE_SCAN_FLAG}" ]]; then
+            args+=("${GRADLE_SCAN_FLAG}")
+          fi
+          ./gradlew "${args[@]}"
 
       - name: Run tests
         if: env.SKIP_TESTS_INPUT != 'true'
-        run: ./gradlew --no-daemon test :tests:e2eTest --stacktrace $GRADLE_SCAN_FLAG
+        run: |
+          args=(--no-daemon test :tests:e2eTest --stacktrace)
+          if [[ -n "${GRADLE_SCAN_FLAG}" ]]; then
+            args+=("${GRADLE_SCAN_FLAG}")
+          fi
+          ./gradlew "${args[@]}"
 
       - name: Build Shadow JAR
-        run: ./gradlew --no-daemon shadowJar --stacktrace $GRADLE_SCAN_FLAG
+        run: |
+          args=(--no-daemon shadowJar --stacktrace)
+          if [[ -n "${GRADLE_SCAN_FLAG}" ]]; then
+            args+=("${GRADLE_SCAN_FLAG}")
+          fi
+          ./gradlew "${args[@]}"
 
       - name: Verify JAR
         shell: bash
         run: |
           set -euo pipefail
-          JAR_PATH=$(ls groovy-lsp/build/libs/groovy-lsp-*-all.jar | head -n 1)
+          JAR_PATH=$(find groovy-lsp/build/libs -maxdepth 1 -name 'groovy-lsp-*-all.jar' -print -quit)
           echo "Found JAR: $JAR_PATH"
           java -jar "$JAR_PATH" --help
 
@@ -138,7 +155,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist
-          JAR_PATH=$(ls groovy-lsp/build/libs/groovy-lsp-*-all.jar | head -n 1)
+          JAR_PATH=$(find groovy-lsp/build/libs -maxdepth 1 -name 'groovy-lsp-*-all.jar' -print -quit)
           SHORT_SHA=$(git rev-parse --short HEAD)
           NIGHTLY_NAME="groovy-lsp-${{ steps.nightly_version.outputs.nightly_version }}-${SHORT_SHA}.jar"
           cp "$JAR_PATH" "dist/${NIGHTLY_NAME}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,9 +77,9 @@ jobs:
       shell: bash
       run: |-
         if [[ "${{ github.event.inputs.disable_scan }}" == "true" ]]; then
-          echo "GRADLE_SCAN_FLAG=-Dorg.gradle.scan=false" >> $GITHUB_ENV
+          echo "GRADLE_SCAN_FLAG=-Dorg.gradle.scan=false" >> "$GITHUB_ENV"
         else
-          echo "GRADLE_SCAN_FLAG=" >> $GITHUB_ENV
+          echo "GRADLE_SCAN_FLAG=" >> "$GITHUB_ENV"
         fi
     - name: Set build environment variables
       id: set-env
@@ -98,13 +98,17 @@ jobs:
 
         echo "Release version: ${TAG}"
         echo "Commit SHA: ${COMMIT_SHA}"
-        echo "BUILD_VERSION=${TAG}" >> $GITHUB_ENV
-        echo "BUILD_COMMIT=${COMMIT_SHA}" >> $GITHUB_ENV
-        echo "BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
+        {
+          echo "BUILD_VERSION=${TAG}"
+          echo "BUILD_COMMIT=${COMMIT_SHA}"
+          echo "BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        } >> "$GITHUB_ENV"
         
         # Set outputs for downstream jobs
-        echo "build_version=${TAG}" >> $GITHUB_OUTPUT
-        echo "build_commit=${COMMIT_SHA}" >> $GITHUB_OUTPUT
+        {
+          echo "build_version=${TAG}"
+          echo "build_commit=${COMMIT_SHA}"
+        } >> "$GITHUB_OUTPUT"
     - name: Validate Release Script
       run: ./tools/release.sh validate --version "${{ env.BUILD_VERSION }}"
 
@@ -244,10 +248,12 @@ jobs:
           IS_DRAFT=${{ github.event_name == 'workflow_dispatch' && 'true' || 'false' }}
         fi
 
-        echo "version=${VERSION}" >> $GITHUB_OUTPUT
-        echo "version_no_v=${VERSION#v}" >> $GITHUB_OUTPUT
-        echo "is_prerelease=${IS_PRERELEASE}" >> $GITHUB_OUTPUT
-        echo "is_draft=${IS_DRAFT}" >> $GITHUB_OUTPUT
+        {
+          echo "version=${VERSION}"
+          echo "version_no_v=${VERSION#v}"
+          echo "is_prerelease=${IS_PRERELEASE}"
+          echo "is_draft=${IS_DRAFT}"
+        } >> "$GITHUB_OUTPUT"
 
         echo "Release settings:"
         echo "- Version: ${VERSION}"
@@ -262,7 +268,6 @@ jobs:
         name: "Groovy DevTools ${{ steps.release_info.outputs.version }}"
         body_path: release-notes.md
         generate_release_notes: true
-        files: |
         files: |
           dist/*
         fail_on_unmatched_files: false
@@ -282,8 +287,8 @@ jobs:
         cd dist
         for file in *; do
           if [[ -f "$file" ]]; then
-            size=$(ls -lh "$file" | awk '{print $5}')
-            echo "  - $file ($size)"
+            size=$(stat -c%s "$file" 2>/dev/null || stat -f%z "$file")
+            echo "  - $file (${size} bytes)"
           fi
         done
 

--- a/.github/workflows/runner-cleanup.yml
+++ b/.github/workflows/runner-cleanup.yml
@@ -72,10 +72,10 @@ jobs:
           echo "Running workflows: $RUNNING_WORKFLOWS"
           
           if [ "$RECENT_PRS" -gt 0 ] || [ "$RUNNING_WORKFLOWS" -gt 0 ]; then
-            echo "has_activity=true" >> $GITHUB_OUTPUT
+            echo "has_activity=true" >> "$GITHUB_OUTPUT"
             echo "✅ Recent activity detected - skipping cleanup"
           else
-            echo "has_activity=false" >> $GITHUB_OUTPUT
+            echo "has_activity=false" >> "$GITHUB_OUTPUT"
             echo "⚠️ No recent activity detected"
           fi
 
@@ -91,16 +91,16 @@ jobs:
           echo "Force cleanup: $FORCE"
           
           if [ "$HAS_RUNNERS" != "true" ]; then
-            echo "should_cleanup=false" >> $GITHUB_OUTPUT
+            echo "should_cleanup=false" >> "$GITHUB_OUTPUT"
             echo "📦 No runners to clean up"
           elif [ "$FORCE" == "true" ]; then
-            echo "should_cleanup=true" >> $GITHUB_OUTPUT
+            echo "should_cleanup=true" >> "$GITHUB_OUTPUT"
             echo "🔨 Force cleanup requested"
           elif [ "$HAS_ACTIVITY" == "true" ]; then
-            echo "should_cleanup=false" >> $GITHUB_OUTPUT
+            echo "should_cleanup=false" >> "$GITHUB_OUTPUT"
             echo "⏳ Skipping cleanup due to recent activity"
           else
-            echo "should_cleanup=true" >> $GITHUB_OUTPUT
+            echo "should_cleanup=true" >> "$GITHUB_OUTPUT"
             echo "🧹 Proceeding with cleanup"
           fi
 


### PR DESCRIPTION
## Summary
- fix shellcheck findings in workflows by quoting outputs, tightening globs, and avoiding word splitting
- replace ls-based jar discovery with find and clean up duplicate YAML keys

## Testing
- not run (workflow/script changes only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hardens GitHub Actions shell scripts for portability and safety; no functional behavior changes intended.
> 
> - Quote `GITHUB_OUTPUT`/`GITHUB_ENV`/`GITHUB_STEP_SUMMARY` writes and batch some outputs to avoid word splitting
> - Replace `ls`-based JAR discovery with `find` and use `stat` for size reporting (bytes), fix numeric comparisons and glob handling
> - Build Gradle commands via Bash arrays to conditionally include flags (`GRADLE_SCAN_FLAG`, `TEST_LOG_FLAG`) safely
> - Tighten/glob usage and add `--` where appropriate (VSIX listing, path globs)
> - Minor cleanup in release/nightly: consolidated `files` key, improved artifact reporting, and consistent cross-platform commands
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 574430d603ae6555dbb4354c3b48f604ed388579. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->