### PR TITLE
test: mark constructors with LSP kind

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/symbols/SymbolLspExtensions.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/symbols/SymbolLspExtensions.kt
@@ -51,7 +51,7 @@ private fun Symbol.displayName(): String = when (this) {
 
 private fun Symbol.toSymbolKind(): SymbolKind = when (this) {
     is Symbol.Class -> SymbolKind.Class
-    is Symbol.Method -> SymbolKind.Method
+    is Symbol.Method -> if (node.isConstructor) SymbolKind.Constructor else SymbolKind.Method
     is Symbol.Field -> SymbolKind.Field
     is Symbol.Property -> SymbolKind.Property
     is Symbol.Variable -> SymbolKind.Variable

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/symbols/SymbolLspExtensionsTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/symbols/SymbolLspExtensionsTest.kt
@@ -100,5 +100,6 @@ class SymbolLspExtensionsTest {
         assertNotNull(documentSymbol)
         require(documentSymbol != null)
         assertEquals("constructor", documentSymbol.name)
+        assertEquals(SymbolKind.Constructor, documentSymbol.kind)
     }
 }

--- a/tests/e2e/resources/scenarios/document-symbol-basic.yaml
+++ b/tests/e2e/resources/scenarios/document-symbol-basic.yaml
@@ -47,7 +47,7 @@ steps:
         - jsonPath: "$.[?(@.right.name == 'Widget' && @.right.kind == 'Class')]"
           expect:
             type: NOT_EMPTY
-        - jsonPath: "$.[?(@.right.name == 'Widget' && @.right.kind == 'Method')]"
+        - jsonPath: "$.[?(@.right.name == 'Widget' && @.right.kind == 'Constructor')]"
           expect:
             type: NOT_EMPTY
         - jsonPath: "$.[?(@.right.name == 'compute' && @.right.kind == 'Method')]"


### PR DESCRIPTION
## Summary
- return the LSP Constructor kind for constructor symbols
- align constructor assertions in unit and e2e tests

## Testing
- ./gradlew :groovy-lsp:test --tests SymbolLspExtensionsTest
- ./gradlew :tests:e2eTest -Dgroovy.lsp.e2e.filter=document-symbol-basic
- ./gradlew lintFix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks constructor methods as `SymbolKind.Constructor` instead of `Method` and updates symbol display accordingly.
> 
> - Updates `toSymbolKind()` to return `Constructor` for method symbols where `node.isConstructor`
> - Aligns unit and e2e tests to assert `Constructor` kind for constructors (`SymbolLspExtensionsTest`, `document-symbol-basic.yaml`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2dd2c738381105f96bb08091e9d06bac7a25485f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->