### PR TITLE
test: refine constructor signature detail

### DIFF
--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/symbols/SymbolLspExtensionsTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/symbols/SymbolLspExtensionsTest.kt
@@ -101,5 +101,35 @@ class SymbolLspExtensionsTest {
         require(documentSymbol != null)
         assertEquals("constructor", documentSymbol.name)
         assertEquals(SymbolKind.Constructor, documentSymbol.kind)
+        assertEquals("public constructor(String name)", documentSymbol.detail)
+        assertEquals("public constructor(String name)", constructorSymbol.signature)
+    }
+
+    @Test
+    fun `constructor symbol uses class name in signature`() {
+        val classNode = ClassNode("Widget", Modifier.PUBLIC, ClassHelper.OBJECT_TYPE)
+        val constructorNode = ConstructorNode(
+            Modifier.PUBLIC,
+            arrayOf(Parameter(ClassHelper.STRING_TYPE, "name")),
+            ClassNode.EMPTY_ARRAY,
+            BlockStatement(),
+        ).apply {
+            declaringClass = classNode
+            setLineNumber(1)
+            setColumnNumber(1)
+            setLastLineNumber(1)
+            setLastColumnNumber(10)
+        }
+        val uri = URI.create("file:///test.groovy")
+
+        val constructorSymbol = Symbol.Method.from(constructorNode, uri)
+
+        val documentSymbol = constructorSymbol.toDocumentSymbol()
+        assertNotNull(documentSymbol)
+        require(documentSymbol != null)
+        assertEquals("Widget", documentSymbol.name)
+        assertEquals(SymbolKind.Constructor, documentSymbol.kind)
+        assertEquals("public Widget(String name)", documentSymbol.detail)
+        assertEquals("public Widget(String name)", constructorSymbol.signature)
     }
 }

--- a/groovy-parser/src/main/kotlin/com/github/albertocavalcante/groovyparser/ast/symbols/Symbol.kt
+++ b/groovy-parser/src/main/kotlin/com/github/albertocavalcante/groovyparser/ast/symbols/Symbol.kt
@@ -67,11 +67,23 @@ sealed class Symbol {
 
         val signature: String
             get() = buildString {
+                val isConstructor = node.isConstructor
+                val constructorName = if (isConstructor) {
+                    owner?.nameWithoutPackage
+                        ?: owner?.name
+                        ?: node.declaringClass?.nameWithoutPackage
+                        ?: node.declaringClass?.name
+                        ?: "constructor"
+                } else {
+                    name
+                }
                 if (isStatic) append("static ")
                 if (isAbstract) append("abstract ")
                 append(visibility.keyword).append(" ")
-                append(returnType?.nameWithoutPackage ?: "def").append(" ")
-                append(name).append("(")
+                if (!isConstructor) {
+                    append(returnType?.nameWithoutPackage ?: "def").append(" ")
+                }
+                append(constructorName).append("(")
                 append(parameters.joinToString(", ") { "${it.type.nameWithoutPackage} ${it.name}" })
                 append(")")
             }


### PR DESCRIPTION
## Summary
- format constructor signatures without a return type and with class name fallback
- extend symbol tests to cover constructor signature detail and fallback

## Testing
- ./gradlew :groovy-lsp:test --tests SymbolLspExtensionsTest
- ./gradlew lintFix
- make e2e (timed out after 5m while running e2eTest; downloads still in progress)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates constructor signature formatting logic.
> 
> - `Symbol.Method.signature` now detects constructors, omits return type, and uses the owning class (or `declaringClass`/`constructor` fallback) for the name
> - Extends `SymbolLspExtensionsTest` to assert constructor `DocumentSymbol` detail/signature for both missing-owner and class-named cases
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7892d6a8b98232461d61467977277dfed0ca102d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->