### PR TITLE
docs: add lint config guide

### DIFF
--- a/tools/lint/README.md
+++ b/tools/lint/README.md
@@ -1,0 +1,19 @@
+# Lint Configs
+
+This directory contains shared lint configuration files.
+
+- `actionlint.yml`: Actionlint config for GitHub Actions workflows.
+- `ghalint.yaml`: Ghalint config for GitHub Actions security policies.
+- `detekt.yml`: Detekt rules for Kotlin sources.
+- `shellcheckrc`: ShellCheck settings for shell scripts.
+
+## How to run
+
+- actionlint:
+  - `actionlint -color -config-file tools/lint/actionlint.yml`
+- ghalint:
+  - `ghalint -c tools/lint/ghalint.yaml run`
+- detekt (via Gradle):
+  - `./gradlew detekt`
+- shellcheck:
+  - `shellcheck --rcfile tools/lint/shellcheckrc path/to/script.sh`


### PR DESCRIPTION
## Summary
- add a short guide for lint configs in tools/lint

## Testing
- not run (docs only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds concise documentation for running shared lint tools.
> 
> - New `tools/lint/README.md` describes `actionlint.yml`, `ghalint.yaml`, `detekt.yml`, and `shellcheckrc`, with example commands to run each tool
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8709a787846683d69405cbac880c4b5012e53cc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->