### PR TITLE
fix: narrow editors server ignore

### DIFF
--- a/editors/code/.gitignore
+++ b/editors/code/.gitignore
@@ -1,8 +1,8 @@
 # Language Server JAR (downloaded/copied during build)
-server/
-server/*.jar
-server/groovy-lsp.jar
-server/.groovy-lsp-version
+/server/
+/server/*.jar
+/server/groovy-lsp.jar
+/server/.groovy-lsp-version
 
 # Build outputs
 out/


### PR DESCRIPTION
## Summary
- scope editors/code server ignore patterns to the top-level server directory
- allow nested server directories (like client/src/server) to be tracked

## Testing
- not run (gitignore change only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Narrows ignore rules to avoid unintentionally ignoring nested `server` directories.
> 
> - Update `editors/code/.gitignore` to use `'/server/'`-scoped patterns (`/server/`, `/server/*.jar`, `/server/groovy-lsp.jar`, `/server/.groovy-lsp-version`) so only the root `server` folder is ignored
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7bf0999a657281fd029bcfd2b2a41290abc3653. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->