### PR TITLE
refactor: reduce cognitive complexity in DefaultBuildFileWatcher

### DIFF
--- a/groovy-build-tool/src/main/kotlin/com/github/albertocavalcante/groovylsp/buildtool/gradle/GradleBuildFileWatcher.kt
+++ b/groovy-build-tool/src/main/kotlin/com/github/albertocavalcante/groovylsp/buildtool/gradle/GradleBuildFileWatcher.kt
@@ -3,21 +3,31 @@ package com.github.albertocavalcante.groovylsp.buildtool.gradle
 import com.github.albertocavalcante.groovylsp.buildtool.BuildToolFileWatcher
 import com.github.albertocavalcante.groovylsp.buildtool.DEFAULT_BUILD_FILE_CHANGE_DELAY_MS
 import com.github.albertocavalcante.groovylsp.buildtool.DefaultBuildFileWatcher
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import java.nio.file.Path
 
 /**
  * Watches Gradle related build files for changes and triggers dependency re-resolution.
  * Monitors build.gradle, build.gradle.kts, settings.gradle, and settings.gradle.kts files.
+ *
+ * @param coroutineScope The coroutine scope for launching watch operations.
+ * @param onBuildFileChanged Callback invoked when a Gradle build file changes.
+ * @param debounceDelayMs Delay in milliseconds before invoking the callback.
+ *                        Defaults to [DEFAULT_BUILD_FILE_CHANGE_DELAY_MS].
+ * @param dispatcher The coroutine dispatcher for I/O operations. Defaults to [Dispatchers.IO].
  */
 class GradleBuildFileWatcher(
     coroutineScope: CoroutineScope,
     onBuildFileChanged: (Path) -> Unit,
     debounceDelayMs: Long = DEFAULT_BUILD_FILE_CHANGE_DELAY_MS,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : BuildToolFileWatcher by DefaultBuildFileWatcher(
     logLabel = "Gradle",
     coroutineScope = coroutineScope,
     onBuildFileChanged = onBuildFileChanged,
     buildFileNames = GradleBuildFiles.fileNames,
     debounceDelayMs = debounceDelayMs,
+    dispatcher = dispatcher,
 )

--- a/groovy-build-tool/src/main/kotlin/com/github/albertocavalcante/groovylsp/buildtool/maven/MavenBuildFileWatcher.kt
+++ b/groovy-build-tool/src/main/kotlin/com/github/albertocavalcante/groovylsp/buildtool/maven/MavenBuildFileWatcher.kt
@@ -3,20 +3,30 @@ package com.github.albertocavalcante.groovylsp.buildtool.maven
 import com.github.albertocavalcante.groovylsp.buildtool.BuildToolFileWatcher
 import com.github.albertocavalcante.groovylsp.buildtool.DEFAULT_BUILD_FILE_CHANGE_DELAY_MS
 import com.github.albertocavalcante.groovylsp.buildtool.DefaultBuildFileWatcher
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import java.nio.file.Path
 
 /**
  * Watches Maven pom.xml files for changes and triggers dependency re-resolution.
+ *
+ * @param coroutineScope The coroutine scope for launching watch operations.
+ * @param onBuildFileChanged Callback invoked when a Maven build file changes.
+ * @param debounceDelayMs Delay in milliseconds before invoking the callback.
+ *                        Defaults to [DEFAULT_BUILD_FILE_CHANGE_DELAY_MS].
+ * @param dispatcher The coroutine dispatcher for I/O operations. Defaults to [Dispatchers.IO].
  */
 class MavenBuildFileWatcher(
     coroutineScope: CoroutineScope,
     onBuildFileChanged: (Path) -> Unit,
     debounceDelayMs: Long = DEFAULT_BUILD_FILE_CHANGE_DELAY_MS,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : BuildToolFileWatcher by DefaultBuildFileWatcher(
     logLabel = "Maven",
     coroutineScope = coroutineScope,
     onBuildFileChanged = onBuildFileChanged,
     buildFileNames = MavenBuildFiles.fileNames,
     debounceDelayMs = debounceDelayMs,
+    dispatcher = dispatcher,
 )


### PR DESCRIPTION
## Summary

Refactors `DefaultBuildFileWatcher.processWatchEvent()` to reduce cognitive complexity from 17 to 15 or below by extracting method logic into focused helper functions.

## Changes

### Complexity Reduction
- Extracted `shouldHandleBuildFile()` - Simple boolean check for file filtering
- Extracted `handleBuildFileEvent()` - Dispatches to handlers based on event type
- Extracted `handleBuildFileModification()` - Handles create/modify events
- Extracted `scheduleDebouncedCallback()` - Schedules debounced callbacks

### Code Quality Improvements
- Added `dispatcher` parameter to `DefaultBuildFileWatcher` (defaults to `Dispatchers.IO`)
  - Enables future testability improvements
  - Follows Kotlin coroutine best practices (no hardcoded dispatchers)
- Added comprehensive KDoc to all classes and new methods
- Updated `GradleBuildFileWatcher` and `MavenBuildFileWatcher` with matching KDoc
- Fixed `SwallowedException` lint warning in `stopWatching()`
- Fixed `MaxLineLength` warnings in KDoc

## Testing

- All 7 existing tests pass (GradleBuildFileWatcherTest + MavenBuildFileWatcherTest)
- No functional changes to file watching behavior
- Lint clean

## Metrics

- Cognitive Complexity: 17 → ≤15
- Code Smells: Reduced by 2 (hardcoded dispatcher warnings resolved)
- Maintainability: Improved through focused, single-responsibility methods

## Review Notes

This is a pure refactoring PR with no behavior changes. The extracted methods follow the single responsibility principle and have clear, descriptive names and documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the build file watcher for clarity and testability without changing behavior.
> 
> - Extracts `shouldHandleBuildFile`, `handleBuildFileEvent`, `handleBuildFileModification`, and `scheduleDebouncedCallback` from `processWatchEvent`, simplifying event handling and debouncing
> - Adds injectable `dispatcher` to `DefaultBuildFileWatcher` (used for debounced callbacks) and threads it through `GradleBuildFileWatcher` and `MavenBuildFileWatcher`; defaults remain `Dispatchers.IO`
> - Improves KDoc across watchers and tweaks logging/annotations (e.g., `SwallowedException` suppression, clearer close handling)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1e80536fbc56b2ff99a19a473a731391dce78c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->