### PR TITLE
fix: add version number to release-please PR titles

### DIFF
--- a/tools/release-please/README.md
+++ b/tools/release-please/README.md
@@ -33,7 +33,7 @@ By setting this to `false` (and managing versions in lockstep via the manifest),
 The `pull-request-title-pattern` option customizes the title of release PRs.
 
 ```json
-"pull-request-title-pattern": "chore: release ${version}"
+"pull-request-title-pattern": "chore: release v${version}"
 ```
 
 #### Available Variables

--- a/tools/release-please/config.json
+++ b/tools/release-please/config.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
     "separate-pull-requests": false,
-    "pull-request-title-pattern": "chore: release ${version}",
+    "pull-request-title-pattern": "chore: release v${version}",
     "packages": {
         ".": {
             "release-type": "simple",


### PR DESCRIPTION
Adds `pull-request-title-pattern` to include the version number in release PR titles.

**Before:** "chore: release main"
**After:** "chore: release v0.4.8"

This fixes the confusing PR titles that don't show the version being released.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates release configuration and documentation to ensure release PR titles include the version.
> 
> - Set `pull-request-title-pattern` to `"chore: release v${version}"` in `tools/release-please/config.json`
> - Document PR title customization, available variables, and default pattern in `tools/release-please/README.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa50fb6bb79ebd4c59041ef38b689034467fd5b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->