### PR TITLE
feat: add cross-platform smoke tests and simplify JAR naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,13 +421,13 @@ jobs:
 
       # Verify JAR (already built by e2eTest via shadowJar dependency)
       - name: Verify JAR
-        if: (matrix.os == 'ubuntu-latest' && matrix.java == 17) || matrix.os == 'self-hosted'
+        if: (matrix.os == 'ubuntu-24.04' && matrix.java == 17) || matrix.os == 'self-hosted'
         run: |-
           echo "Testing JAR with --help flag..."
           java -jar groovy-lsp/build/libs/groovy-lsp-*-all.jar --help
 
       - name: Upload JAR artifact
-        if: (matrix.os == 'ubuntu-latest' && matrix.java == 17) || matrix.os == 'self-hosted'
+        if: (matrix.os == 'ubuntu-24.04' && matrix.java == 17) || matrix.os == 'self-hosted'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: groovy-lsp-jar-${{ matrix.os }}-java${{ matrix.java }}
@@ -461,6 +461,51 @@ jobs:
             **/build/test-recording.jfr
           retention-days: 7
           if-no-files-found: ignore  # Don't fail if files don't exist (e.g., tests passed quickly)
+
+  # Cross-platform smoke tests - verify JAR works on key platforms
+  # Lighter weight than release matrix, runs on every main merge for faster feedback
+  smoke-test:
+    name: Smoke Test (${{ matrix.os }})
+    needs: build
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # Key platforms for quick validation (full matrix in release.yml)
+        os: [ubuntu-24.04, macos-15, windows-2022]
+    steps:
+      - name: Download JAR artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: groovy-lsp-jar-*
+          merge-multiple: true
+          path: dist
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Verify Java version
+        run: java -version
+
+      - name: Run smoke test
+        shell: bash
+        run: |
+          JAR_FILE=$(find dist -name "*.jar" -type f | head -1)
+          if [[ -z "$JAR_FILE" ]]; then
+            echo "::error::No JAR file found in dist/"
+            exit 1
+          fi
+          echo "Testing JAR: $JAR_FILE"
+          java -jar "$JAR_FILE" --help
+          echo "✅ Smoke test passed on ${{ matrix.os }}!"
+
   validate:
     name: Validation Check
     runs-on: ${{ github.event.inputs.runner_label == 'self-hosted' && 'self-hosted' || vars.CI_RUNNER_LABEL == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,66 @@ jobs:
         name: "release-artifacts-${{ matrix.os }}"
         path: dist/*
         retention-days: 7
+
+  # Cross-platform smoke tests to verify JAR works on all supported platforms
+  smoke-test:
+    name: Smoke Test (${{ matrix.os }}, JDK ${{ matrix.java }})
+    needs: build-release
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, windows-2022, windows-11-arm]
+        java: [17, 21]
+        include:
+          # JDK 11 should fail due to bytecode version mismatch (target is JDK 17)
+          - os: ubuntu-24.04
+            java: 11
+            expected_fail: true
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: release-artifacts-*
+          merge-multiple: true
+          path: dist
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+
+      - name: Verify Java version
+        run: java -version
+
+      - name: Run smoke test
+        id: smoke
+        shell: bash
+        continue-on-error: ${{ matrix.expected_fail == true }}
+        run: |
+          JAR_FILE=$(find dist -name "gls-*.jar" -type f | head -1)
+          if [[ -z "$JAR_FILE" ]]; then
+            echo "::error::No JAR file found in dist/"
+            exit 1
+          fi
+          echo "Testing JAR: $JAR_FILE"
+          java -jar "$JAR_FILE" --help
+          echo "✅ Smoke test passed!"
+
+      - name: Verify expected failure (JDK 11)
+        if: matrix.expected_fail == true
+        shell: bash
+        run: |
+          if [[ "${{ steps.smoke.outcome }}" == "success" ]]; then
+            echo "::error::JDK 11 smoke test unexpectedly succeeded! Check if bytecode target changed."
+            exit 1
+          fi
+          echo "✅ JDK 11 correctly failed with bytecode version mismatch"
+
   create-release:
     name: Create Release
     permissions:
@@ -189,30 +249,29 @@ jobs:
         ## Groovy DevTools ${VERSION}
 
         This release includes:
-        - **gls** (Groovy Language Server) - JAR download
+        - **gls** (Groovy Language Server) - Platform-independent JAR
         - **gvy** (IDE extension) - VS Code, Open VSX
 
         ### Installation
 
-        Download the appropriate JAR for your platform:
+        Download and run the JAR:
 
         \`\`\`bash
-        # Download JAR (replace linux-amd64 with your platform)
-        curl -LO https://github.com/${{ github.repository }}/releases/download/${VERSION}/gls-${VERSION#v}-linux-amd64.jar
+        # Download JAR
+        curl -LO https://github.com/${{ github.repository }}/releases/download/${VERSION}/gls-${VERSION#v}.jar
 
         # Verify checksum
         curl -LO https://github.com/${{ github.repository }}/releases/download/${VERSION}/checksums.txt
         sha256sum -c checksums.txt --ignore-missing
 
-        # Run the Language Server
-        java -jar gls-${VERSION#v}-linux-amd64.jar
+        # Run the Language Server (requires JDK 17+)
+        java -jar gls-${VERSION#v}.jar
         \`\`\`
 
-        ### Supported Platforms
+        ### Requirements
 
-        - **Linux AMD64** \`gls-${VERSION#v}-linux-amd64.jar\`
-        - **macOS AMD64** \`gls-${VERSION#v}-darwin-amd64.jar\`
-        - **Windows AMD64** \`gls-${VERSION#v}-windows-amd64.jar\`
+        - **Java 17+** (JDK 17, 21, or later)
+        - Works on all platforms: Linux, macOS, Windows (x64 and ARM64)
 
         ### Usage
 
@@ -308,7 +367,7 @@ jobs:
         with:
           homebrew-tap: albertocavalcante/homebrew-tap
           formula-name: gls
-          download-url: https://github.com/albertocavalcante/groovy-devtools/releases/download/${{ needs.create-release.outputs.tag_name }}/gls-${{ needs.create-release.outputs.version_no_v }}-generic.jar
+          download-url: https://github.com/albertocavalcante/groovy-devtools/releases/download/${{ needs.create-release.outputs.tag_name }}/gls-${{ needs.create-release.outputs.version_no_v }}.jar
           commit-message: "chore: update gls to {{version}}"
         env:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,7 +21,7 @@ pre-commit:
       run: shellcheck --rcfile tools/lint/shellcheckrc {staged_files}
     workflow-lint:
       glob: '.github/workflows/*.{yml,yaml}'
-      run: ghalint -c tools/lint/ghalint.yaml run
+      run: ghalint -c tools/lint/ghalint.yaml run && actionlint {staged_files}
 
 commit-msg:
   commands:

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -107,17 +107,8 @@ cmd_build() {
     local VERSION_NO_PRFIX="${VERSION#vscode-groovy-v}"
     local VERSION_NO_V="${VERSION_NO_PRFIX#v}"
     
-    # Platform detection for local builds (CI usually handles this via matrix)
-    OS_TYPE=$(uname -s)
-    local PLATFORM="generic"
-    case "${OS_TYPE}" in
-        Linux*)     PLATFORM="linux-amd64";;
-        Darwin*)    PLATFORM="darwin-amd64";;
-        CYGWIN*|MINGW*|MSYS*) PLATFORM="windows-amd64";;
-        *)          PLATFORM="generic";;
-    esac
-
-    local TARGET_JAR="${DIST_DIR}/gls-${VERSION_NO_V}-${PLATFORM}.jar"
+    # Java JARs are platform-independent - no need for platform suffix
+    local TARGET_JAR="${DIST_DIR}/gls-${VERSION_NO_V}.jar"
     log_info "Copying JAR to ${TARGET_JAR}"
     cp "${JAR_FILE}" "${TARGET_JAR}"
 


### PR DESCRIPTION
## Summary

Improves the release workflow by:

1. **Simplifying JAR naming** - Removes platform suffix since Java JARs are platform-independent
   - Before: `gls-0.4.8-linux-amd64.jar`
   - After: `gls-0.4.8.jar`

2. **Adding cross-platform smoke tests** - Verifies the JAR works across all supported platforms

### Platform Matrix (11 combinations)

| OS | Architecture | Runner |
|----|--------------|--------|
| Ubuntu 24.04 | AMD64 | `ubuntu-24.04` |
| Ubuntu 24.04 | ARM64 | `ubuntu-24.04-arm` |
| macOS 15 | ARM64 (Apple Silicon) | `macos-15` |
| Windows Server 2022 | AMD64 | `windows-2022` |
| Windows 11 | ARM64 | `windows-11-arm` |

### JDK Matrix

| JDK | Expected Result |
|-----|-----------------|
| 17 | ✅ Pass (target bytecode) |
| 21 | ✅ Pass (newer, compatible) |
| 11 | ❌ Expected Fail (bytecode mismatch) |

### Test Action
```bash
java -jar gls-*.jar --help
```

---

Fixes misleading platform-specific JAR names and ensures JAR compatibility across all platforms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces cross-platform validation and unifies artifact naming for clearer releases and broader coverage.
> 
> - **CI**: Adds `smoke-test` job (Ubuntu 24.04, macOS 15, Windows 2022) running `java -jar ... --help`; updates JAR verify/upload conditions to `ubuntu-24.04`.
> - **Release workflow**: Adds matrix `smoke-test` across Linux/macOS/Windows (x64/ARM) and JDKs 17/21; includes an expected-fail case for JDK 11. Updates release notes to a single platform-independent `gls-<version>.jar` and JDK 17+ requirement.
> - **Artifact naming**: `tools/release.sh` now outputs `gls-<version>.jar` (no platform suffix).
> - **Homebrew**: Updates formula `download-url` to the unified JAR.
> - **Dev tooling**: `lefthook.yml` runs `actionlint` for workflow files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cbb14e169287fcf5d39cddff5758ed18c127816. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->