### PR TITLE
test: add references and rename E2E tests

### DIFF
--- a/tests/e2e/resources/scenarios/references-basic.yaml
+++ b/tests/e2e/resources/scenarios/references-basic.yaml
@@ -51,8 +51,9 @@ steps:
       checks:
         - jsonPath: $
           expect:
-            type: NOT_EMPTY
-            message: "Should find references to Calculator class"
+            type: SIZE
+            value: 5
+            message: "Should find 5 references to Calculator class (decl + 2 usages with constructor/type duality)"
 
   # Test 2: Find references to a method
   - request:
@@ -73,8 +74,9 @@ steps:
       checks:
         - jsonPath: $
           expect:
-            type: NOT_EMPTY
-            message: "Should find references to add method"
+            type: SIZE
+            value: 3
+            message: "Should find 3 references to add method (def + 2 usages)"
 
   - shutdown: {}
   - exit: {}

--- a/tests/e2e/resources/scenarios/rename-basic.yaml
+++ b/tests/e2e/resources/scenarios/rename-basic.yaml
@@ -41,10 +41,11 @@ steps:
   - assert:
       source: renameResult
       checks:
-        - jsonPath: $
+        - jsonPath: $.documentChanges[0].edits
           expect:
-            type: NOT_EMPTY
-            message: "Should return workspace edits for rename"
+            type: SIZE
+            value: 3
+            message: "Should return 3 text edits for renamed variable (decl + 2 usages)"
 
   - shutdown: {}
   - exit: {}


### PR DESCRIPTION
## Summary

Expanded E2E test coverage to include `textDocument/references` and `textDocument/rename`.

### Changes

**New Features Tested**
- **References:** `references-basic.yaml`
  - Verifies finding references for classes and methods.
- **Rename:** `rename-basic.yaml`
  - Verifies renaming variables and receiving correct workspace edits.

### Notes
- `prepareRename` was excluded from the rename test as it currently returns an internal error (likely not implemented or misconfigured). Basic rename functionality works correctly.

### Tests Verified
All new tests pass locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds two E2E scenario tests to validate LSP features for references and rename.
> 
> - New `references-basic.yaml`: opens a Groovy file, queries `textDocument/references` for a class and a method, and asserts expected counts (class: 5 including decl; method: 3 including decl)
> - New `rename-basic.yaml`: performs `textDocument/rename` on a local variable and asserts 3 workspace text edits (declaration + 2 usages)
> - Both scenarios wait for `groovy/status` Ready signal before running and cleanly shutdown
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fc9b8ce68f45e469d548990c243d219d19bc152. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->