### PR TITLE
feat(lsp): add worker router

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/worker/WorkerRouter.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/worker/WorkerRouter.kt
@@ -2,7 +2,7 @@ package com.github.albertocavalcante.groovylsp.worker
 
 import com.github.albertocavalcante.groovylsp.version.GroovyVersionInfo
 
-class WorkerRegistry(descriptors: List<WorkerDescriptor>) {
+class WorkerRouter(descriptors: List<WorkerDescriptor>) {
     private val selector = WorkerSelector(descriptors)
 
     fun select(
@@ -12,11 +12,4 @@ class WorkerRegistry(descriptors: List<WorkerDescriptor>) {
         requestedVersion = groovyVersionInfo.version,
         requiredFeatures = requiredFeatures,
     )
-}
-
-class WorkerRouter(private val registry: WorkerRegistry) {
-    fun select(
-        groovyVersionInfo: GroovyVersionInfo,
-        requiredFeatures: Set<WorkerFeature> = emptySet(),
-    ): WorkerDescriptor? = registry.select(groovyVersionInfo, requiredFeatures)
 }

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/worker/WorkerRouterTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/worker/WorkerRouterTest.kt
@@ -12,27 +12,26 @@ class WorkerRouterTest {
 
     @Test
     fun `selects worker matching resolved groovy version and required features`() {
-        val registry = WorkerRegistry(
+        val router = WorkerRouter(
             listOf(
                 descriptor(
                     id = "worker-ast",
                     range = GroovyVersionRange(
-                        GroovyVersion.parse("2.5.0")!!,
-                        GroovyVersion.parse("4.0.0")!!,
+                        parseVersion("2.5.0"),
+                        parseVersion("4.0.0"),
                     ),
                     features = setOf(WorkerFeature.AST),
                 ),
                 descriptor(
                     id = "worker-symbols",
                     range = GroovyVersionRange(
-                        GroovyVersion.parse("3.0.0")!!,
-                        GroovyVersion.parse("4.0.0")!!,
+                        parseVersion("3.0.0"),
+                        parseVersion("4.0.0"),
                     ),
                     features = setOf(WorkerFeature.AST, WorkerFeature.SYMBOLS),
                 ),
             ),
         )
-        val router = WorkerRouter(registry)
 
         val selected = router.select(
             groovyVersionInfo("3.0.9"),
@@ -44,19 +43,18 @@ class WorkerRouterTest {
 
     @Test
     fun `returns null when no worker matches`() {
-        val registry = WorkerRegistry(
+        val router = WorkerRouter(
             listOf(
                 descriptor(
                     id = "worker-legacy",
                     range = GroovyVersionRange(
-                        GroovyVersion.parse("2.0.0")!!,
-                        GroovyVersion.parse("2.5.0")!!,
+                        parseVersion("2.0.0"),
+                        parseVersion("2.5.0"),
                     ),
                     features = emptySet(),
                 ),
             ),
         )
-        val router = WorkerRouter(registry)
 
         val selected = router.select(
             groovyVersionInfo("3.0.0"),
@@ -67,9 +65,12 @@ class WorkerRouterTest {
     }
 
     private fun groovyVersionInfo(version: String) = GroovyVersionInfo(
-        version = GroovyVersion.parse(version)!!,
+        version = parseVersion(version),
         source = GroovyVersionSource.DEPENDENCY,
     )
+
+    private fun parseVersion(version: String): GroovyVersion =
+        requireNotNull(GroovyVersion.parse(version)) { "Invalid Groovy version: $version" }
 
     private fun descriptor(id: String, range: GroovyVersionRange, features: Set<WorkerFeature>) = WorkerDescriptor(
         id = id,


### PR DESCRIPTION
## Summary
- add WorkerRegistry/WorkerRouter to select workers using GroovyVersionInfo
- add unit tests for router selection and no-match behavior

## Testing
- ./gradlew :groovy-lsp:test --tests "com.github.albertocavalcante.groovylsp.worker.WorkerRouterTest"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Add worker routing abstraction**
> 
> - Introduces `WorkerRouter` that wraps `WorkerSelector` and exposes `select(groovyVersionInfo, requiredFeatures)` to resolve a `WorkerDescriptor` based on Groovy version and capabilities
> - Adds `WorkerRouterTest` covering selection when features and version match, and returning `null` when no worker fits
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26973d72b907d80ac76e226712b52d3faf8fafe5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->