### PR TITLE
test: add document highlight and type definition tests

### DIFF
--- a/tests/e2e/resources/scenarios/_document-highlight-basic.yaml
+++ b/tests/e2e/resources/scenarios/_document-highlight-basic.yaml
@@ -55,28 +55,28 @@ steps:
   - assert:
       source: highlightResult
       checks:
-        - jsonPath: $
+        - jsonPath: $.items
           expect:
             type: SIZE
             value: 3
             message: "Should find 3 highlights for 'foo'"
         
         # Verify Declaration (Line 2)
-        - jsonPath: $[?(@.range.start.line == 2)]
+        - jsonPath: $.items[?(@.range.start.line == 2)]
           expect:
             type: SIZE
             value: 1
             message: "Should highlight declaration on line 2"
 
         # Verify Usage 1 (Line 3)
-        - jsonPath: $[?(@.range.start.line == 3)]
+        - jsonPath: $.items[?(@.range.start.line == 3)]
           expect:
             type: SIZE
             value: 1
             message: "Should highlight usage on line 3"
 
         # Verify Usage 2 (Line 4)
-        - jsonPath: $[?(@.range.start.line == 4)]
+        - jsonPath: $.items[?(@.range.start.line == 4)]
           expect:
             type: SIZE
             value: 1

--- a/tests/e2e/resources/scenarios/type-definition-basic.yaml
+++ b/tests/e2e/resources/scenarios/type-definition-basic.yaml
@@ -49,14 +49,14 @@ steps:
   - assert:
       source: typeDefResult
       checks:
-        - jsonPath: $
+        - jsonPath: $.items
           expect:
             type: SIZE
             value: 1
             message: "Should find 1 type definition"
         
         # Verify it points to line 0 (class MyType)
-        - jsonPath: $[0].range.start.line
+        - jsonPath: $.items[0].range.start.line
           expect:
             type: EQUALS
             value: 0


### PR DESCRIPTION
## Summary

Adds E2E test coverage for navigation features.

### Changes

**Type Definition**
- **File:** `type-definition-basic.yaml`
- **Status:** ✅ **WORKING** (Path A - Verified)
- **Note:** Initially thought to be a bug (#421), but the failure was due to an incorrect line number in the test request. Fixed in `daf276c`.

**Document Highlight**
- **File:** `_document-highlight-basic.yaml`
- **Status:** ⚠️ **DEFERRED** (Path B)
- **Issue:** #420 (Not Implemented)
- **Action:** Test disabled and committed as spec.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds navigation-focused E2E coverage.
> 
> - Adds `type-definition-basic.yaml` to validate `textDocument/typeDefinition` (navigates from `MyType p` to class `MyType`, expects 1 location at line 0)
> - Adds `_document-highlight-basic.yaml` defining `textDocument/documentHighlight` expectations for `foo` (3 occurrences); test included but disabled/deferred per issue #420
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8040cf06630c6fddba5295f3230cdb465baa1b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->