### PR TITLE
feat(lsp): route parsing via worker sessions

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/worker/WorkerSessionManager.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/worker/WorkerSessionManager.kt
@@ -1,0 +1,34 @@
+package com.github.albertocavalcante.groovylsp.worker
+
+import com.github.albertocavalcante.groovyparser.GroovyParserFacade
+import com.github.albertocavalcante.groovyparser.api.ParseRequest
+import com.github.albertocavalcante.groovyparser.api.ParseResult
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicReference
+
+interface WorkerSession {
+    fun parse(request: ParseRequest): ParseResult
+}
+
+class InProcessWorkerSession(private val parser: GroovyParserFacade) : WorkerSession {
+    override fun parse(request: ParseRequest): ParseResult = parser.parse(request)
+}
+
+class WorkerSessionManager(
+    private val defaultSession: WorkerSession,
+    private val sessionFactory: (WorkerDescriptor) -> WorkerSession,
+) {
+    private val sessions = ConcurrentHashMap<String, WorkerSession>()
+    private val activeSession = AtomicReference(defaultSession)
+
+    fun select(worker: WorkerDescriptor?) {
+        if (worker == null) {
+            activeSession.set(defaultSession)
+            return
+        }
+        val session = sessions.getOrPut(worker.id) { sessionFactory(worker) }
+        activeSession.set(session)
+    }
+
+    fun parse(request: ParseRequest): ParseResult = activeSession.get().parse(request)
+}

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/worker/WorkerSessionManagerTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/worker/WorkerSessionManagerTest.kt
@@ -1,0 +1,68 @@
+package com.github.albertocavalcante.groovylsp.worker
+
+import com.github.albertocavalcante.groovylsp.test.parseGroovyVersion
+import com.github.albertocavalcante.groovylsp.version.GroovyVersionRange
+import com.github.albertocavalcante.groovyparser.api.ParseRequest
+import com.github.albertocavalcante.groovyparser.api.ParseResult
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import java.net.URI
+import kotlin.test.assertSame
+
+class WorkerSessionManagerTest {
+
+    @Test
+    fun `select uses worker session when set`() {
+        val defaultResult = mockk<ParseResult>()
+        val workerResult = mockk<ParseResult>()
+        val defaultSession = StubSession(defaultResult)
+        val workerSession = StubSession(workerResult)
+        val manager = WorkerSessionManager(
+            defaultSession = defaultSession,
+            sessionFactory = { workerSession },
+        )
+        val request = ParseRequest(URI.create("file:///test.groovy"), "class Test {}")
+
+        manager.select(descriptor("worker"))
+        val result = manager.parse(request)
+
+        assertSame(workerResult, result)
+        assertSame(request, workerSession.lastRequest)
+    }
+
+    @Test
+    fun `select falls back to default session when cleared`() {
+        val defaultResult = mockk<ParseResult>()
+        val workerResult = mockk<ParseResult>()
+        val defaultSession = StubSession(defaultResult)
+        val workerSession = StubSession(workerResult)
+        val manager = WorkerSessionManager(
+            defaultSession = defaultSession,
+            sessionFactory = { workerSession },
+        )
+        val request = ParseRequest(URI.create("file:///test.groovy"), "class Test {}")
+
+        manager.select(descriptor("worker"))
+        manager.select(null)
+        val result = manager.parse(request)
+
+        assertSame(defaultResult, result)
+        assertSame(request, defaultSession.lastRequest)
+    }
+
+    private class StubSession(private val result: ParseResult) : WorkerSession {
+        var lastRequest: ParseRequest? = null
+
+        override fun parse(request: ParseRequest): ParseResult {
+            lastRequest = request
+            return result
+        }
+    }
+
+    private fun descriptor(id: String): WorkerDescriptor = WorkerDescriptor(
+        id = id,
+        supportedRange = GroovyVersionRange(parseGroovyVersion("1.0.0"), parseGroovyVersion("4.0.0")),
+        capabilities = WorkerCapabilities(),
+        connector = WorkerConnector.InProcess,
+    )
+}


### PR DESCRIPTION
## Summary
- add worker session abstractions with in-process implementation
- route GroovyCompilationService parsing through the session manager
- add tests covering worker session selection behavior

## Testing
- ./gradlew :groovy-lsp:test --tests "com.github.albertocavalcante.groovylsp.worker.WorkerSessionManagerTest"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements a worker-session abstraction and switches parsing to go through a session manager, enabling pluggable workers.
> 
> - Add `WorkerSession` interface, `InProcessWorkerSession`, and `WorkerSessionManager` with session selection and caching
> - Update `GroovyCompilationService` to use `workerSessionManager.parse(...)` for compile, transient compile, indexing, and suspicious-script reparse
> - Hook worker selection via `updateSelectedWorker` to update the active session
> - Add `WorkerSessionManagerTest` covering selection and default fallback behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b3afa29a47d78c423c7f3a15589a8eea2b20960. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->