### PR TITLE
feat(jenkins): deterministic vars ordering

### DIFF
--- a/groovy-jenkins/src/test/kotlin/com/github/albertocavalcante/groovyjenkins/VarsGlobalVariableProviderTest.kt
+++ b/groovy-jenkins/src/test/kotlin/com/github/albertocavalcante/groovyjenkins/VarsGlobalVariableProviderTest.kt
@@ -32,4 +32,19 @@ class VarsGlobalVariableProviderTest {
         assertTrue(vars.any { it.name == "log" })
         assertTrue(vars.any { it.name == "Utils" })
     }
+
+    @Test
+    fun `should return variables in deterministic name order`() {
+        val varsDir = tempDir.resolve("vars")
+        Files.createDirectory(varsDir)
+
+        Files.writeString(varsDir.resolve("b.groovy"), "def call() { }")
+        Files.writeString(varsDir.resolve("A.groovy"), "def call() { }")
+        Files.writeString(varsDir.resolve("c.groovy"), "def call() { }")
+
+        val provider = VarsGlobalVariableProvider(tempDir)
+        val vars = provider.getGlobalVariables()
+
+        assertEquals(listOf("A", "b", "c"), vars.map { it.name })
+    }
 }


### PR DESCRIPTION
## Summary
- ensure vars/ global variable discovery is deterministic by sorting by name
- use Arrow Either.catch for functional error handling during vars scanning
- add a test to assert deterministic ordering

## Testing
- ./gradlew :groovy-jenkins:test --tests "com.github.albertocavalcante.groovyjenkins.VarsGlobalVariableProviderTest"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures stable ordering and safer error handling in vars discovery.
> 
> - Sorts discovered globals by name (case-insensitive, then original) in `VarsGlobalVariableProvider.getGlobalVariables`
> - Replaces try/catch with `Arrow` `Either.catch` and `getOrElse` for scanning errors; logs and returns `[]` on failure
> - Adds test `VarsGlobalVariableProviderTest.should return variables in deterministic name order` validating ordered output
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa45aa96fc7f620f87bece945e45985ecfd3353c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->