### PR TITLE
feat(lsp): stabilize classpath completions

### DIFF
--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/services/ClasspathServiceTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/services/ClasspathServiceTest.kt
@@ -168,4 +168,18 @@ class ClasspathServiceTest {
         val names = results.map { it.simpleName }
         assertThat(names).isSorted
     }
+
+    @Test
+    fun `should return deterministic class variants`() {
+        val index = ClasspathService.ClassIndex()
+        index.add("List", "java.util.List")
+        index.add("List", "java.awt.List")
+        index.add("List", "java.util.List")
+        index.add("Map", "java.util.Map")
+
+        val snapshot = index.snapshot()
+
+        assertThat(snapshot["List"]).containsExactly("java.awt.List", "java.util.List")
+        assertThat(snapshot["Map"]).containsExactly("java.util.Map")
+    }
 }


### PR DESCRIPTION
## Summary
- make classpath completion results deterministic via a deduping index
- ensure simple-name ordering stays stable while preserving existing sort semantics
- add a focused test for deterministic class variants

## Testing
- ./gradlew :groovy-lsp:test --tests "com.github.albertocavalcante.groovylsp.services.ClasspathServiceTest"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves stability and determinism of classpath-based completions.
> 
> - Replace `ConcurrentHashMap<String, MutableList<String>>` with `ClassIndex` using a `MutableSet` to dedupe and `snapshot()` to return sorted variants
> - Update `findClassesByPrefix` to use `snapshot()` and stable sorting by simple name; adjust logging to use `size()`
> - Add focused unit test for deterministic class variants; keep existing sorting behavior test
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 861c45bcc3ed2a15c186ea7e1fe370f85d1f7ed8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the class indexing mechanism for more consistent and efficient class resolution.

* **Tests**
  * Added test coverage to ensure deterministic behavior in class resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->