### PR TITLE
feat(jenkins): stabilize metadata ordering

### DIFF
--- a/groovy-jenkins/src/test/kotlin/com/github/albertocavalcante/groovyjenkins/metadata/MetadataMergerTest.kt
+++ b/groovy-jenkins/src/test/kotlin/com/github/albertocavalcante/groovyjenkins/metadata/MetadataMergerTest.kt
@@ -243,6 +243,45 @@ class MetadataMergerTest {
         assertTrue(merged.agentTypes.containsKey("docker"))
     }
 
+    @Test
+    fun `merge sorts step keys deterministically`() {
+        val bundled = createBundledMetadata(
+            steps = linkedMapOf(
+                "zeta" to stepMetadata("zeta"),
+                "alpha" to stepMetadata("alpha"),
+            ),
+        )
+        val stable = linkedMapOf(
+            "beta" to stepMetadata("beta"),
+        )
+
+        val merged = MetadataMerger.merge(bundled, stable)
+
+        assertEquals(listOf("alpha", "beta", "zeta"), merged.steps.keys.toList())
+    }
+
+    @Test
+    fun `merge sorts global variable keys deterministically`() {
+        val bundled = createBundledMetadata(
+            globalVariables = linkedMapOf(
+                "params" to GlobalVariableMetadata(
+                    name = "params",
+                    type = "ParamsVariable",
+                    documentation = "Build parameters",
+                ),
+                "env" to GlobalVariableMetadata(
+                    name = "env",
+                    type = "EnvActionImpl",
+                    documentation = "Environment variables",
+                ),
+            ),
+        )
+
+        val merged = MetadataMerger.merge(bundled, emptyMap())
+
+        assertEquals(listOf("env", "params"), merged.globalVariables.keys.toList())
+    }
+
     // Helper to create test metadata
     private fun createBundledMetadata(
         steps: Map<String, JenkinsStepMetadata> = emptyMap(),
@@ -256,5 +295,12 @@ class MetadataMergerTest {
         postConditions = postConditions,
         declarativeOptions = declarativeOptions,
         agentTypes = agentTypes,
+    )
+
+    private fun stepMetadata(name: String) = JenkinsStepMetadata(
+        name = name,
+        plugin = "test-plugin",
+        parameters = emptyMap(),
+        documentation = "Step $name",
     )
 }


### PR DESCRIPTION
## Summary
- enforce deterministic ordering for merged Jenkins metadata maps
- add a small combinator for repeatable semigroup merges
- add tests for stable step/global variable ordering

## Testing
- ./gradlew :groovy-jenkins:test --tests "com.github.albertocavalcante.groovyjenkins.metadata.MetadataMergerTest"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Deterministic metadata ordering and merge utilities**
> 
> - Sort merged `steps`, `globalVariables`, `postConditions`, `declarativeOptions`, and `agentTypes` by key via `sortByKey`/`mergeAndSort` in `MetadataMerger`
> - Introduce `combineAll` to perform repeatable semigroup merges; refactor `mergeWithPriority` and `mergeAll` to use it
> - Add tests verifying deterministic key ordering for `steps` and `globalVariables`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f85905fd02597e2773a4769cac0727c036f4c6e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal metadata merging logic with consistent sorting and dedicated helper functions to ensure deterministic behavior across metadata fields.

* **Tests**
  * Added tests to verify deterministic sorting of merged metadata keys, ensuring consistent and predictable metadata organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->