### PR TITLE
refactor: remove useless null checks and elvis operators

### DIFF
--- a/groovy-jenkins/src/main/kotlin/com/github/albertocavalcante/groovyjenkins/metadata/MetadataMerger.kt
+++ b/groovy-jenkins/src/main/kotlin/com/github/albertocavalcante/groovyjenkins/metadata/MetadataMerger.kt
@@ -23,7 +23,7 @@ object MetadataMerger {
     private val stepMetadataSemigroup: Semigroup<JenkinsStepMetadata> = Semigroup { a, b ->
         // b overrides a, but we merge parameters
         a.copy(
-            plugin = b.plugin ?: a.plugin,
+            plugin = b.plugin,
             documentation = b.documentation ?: a.documentation,
             parameters = a.parameters + b.parameters, // Right overrides Left keys
         )

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/compilation/GroovyCompilationService.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/compilation/GroovyCompilationService.kt
@@ -342,15 +342,10 @@ class GroovyCompilationService(private val parentClassLoader: ClassLoader = Clas
         )
 
         val astModel = parseResult.astModel
-        if (astModel != null) {
-            val index = SymbolIndex().buildFromVisitor(astModel)
-            symbolStorageCache.put(uri, index)
-            logger.debug("Indexed workspace file: $uri")
-            index
-        } else {
-            logger.debug("Failed to build AST model for indexing: $uri")
-            null
-        }
+        val index = SymbolIndex().buildFromVisitor(astModel)
+        symbolStorageCache.put(uri, index)
+        logger.debug("Indexed workspace file: $uri")
+        index
     } catch (e: Exception) {
         logger.warn("Failed to index workspace file: $uri", e)
         null

--- a/jupyter/kernel-core/src/main/kotlin/com/github/albertocavalcante/groovyjupyter/handlers/ExecuteHandler.kt
+++ b/jupyter/kernel-core/src/main/kotlin/com/github/albertocavalcante/groovyjupyter/handlers/ExecuteHandler.kt
@@ -113,7 +113,7 @@ class ExecuteHandler(
                 val errorContent = mapOf(
                     "ename" to (result.errorName ?: "Error"),
                     "evalue" to (result.errorValue ?: ""),
-                    "traceback" to (result.traceback ?: emptyList<String>()),
+                    "traceback" to result.traceback,
                 )
                 val errorMsg = request.createReply(MessageType.ERROR).apply {
                     content = errorContent
@@ -126,7 +126,7 @@ class ExecuteHandler(
                     "execution_count" to executionCount,
                     "ename" to (result.errorName ?: "Error"),
                     "evalue" to (result.errorValue ?: ""),
-                    "traceback" to (result.traceback ?: emptyList<String>()),
+                    "traceback" to result.traceback,
                 )
                 val replyMsg = request.createReply(MessageType.EXECUTE_REPLY).apply {
                     content = replyContent


### PR DESCRIPTION
## Summary

Removes 4 useless null checks flagged by SonarCloud.

## Changes

| File | Issue | Fix |
|------|-------|-----|
| `ExecuteHandler.kt` | `traceback ?: emptyList()` (×2) | `traceback` has default value |
| `GroovyCompilationService.kt` | `if (astModel != null)` | `astModel` is non-null |
| `MetadataMerger.kt` | `b.plugin ?: a.plugin` | `plugin` is non-null String |

## Testing

```
./gradlew :groovy-jenkins:test :groovy-lsp:compileKotlin
BUILD SUCCESSFUL
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Refactor: simplify null-handling**
> 
> - `ExecuteHandler`: use `traceback` directly in error messages (remove `?: emptyList()`).
> - `GroovyCompilationService.performIndexing`: drop `astModel` null guard; always build/cache `SymbolIndex` from `astModel`.
> - `MetadataMerger`: always set `plugin = b.plugin` in step merge (remove `?: a.plugin`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0813e2c64d6ec7f0c621e8c9ec2f387b604b86d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->