### PR TITLE
refactor(lsp): simplify LRU cache

### DIFF
--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/cache/LRUCacheTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/cache/LRUCacheTest.kt
@@ -1,0 +1,50 @@
+package com.github.albertocavalcante.groovylsp.cache
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class LRUCacheTest {
+
+    @Test
+    fun `evicts least recently used on put`() {
+        val cache = LRUCache<String, Int>(2)
+
+        cache.put("A", 1)
+        cache.put("B", 2)
+        cache.get("A")
+        cache.put("C", 3)
+
+        assertEquals(listOf("A", "C"), cache.keys())
+    }
+
+    @Test
+    fun `updates access order on get`() {
+        val cache = LRUCache<String, Int>(3)
+
+        cache.put("A", 1)
+        cache.put("B", 2)
+        cache.put("C", 3)
+
+        assertEquals(listOf("A", "B", "C"), cache.keys())
+
+        cache.get("A")
+        assertEquals(listOf("B", "C", "A"), cache.keys())
+
+        cache.get("B")
+        assertEquals(listOf("C", "A", "B"), cache.keys())
+    }
+
+    @Test
+    fun `snapshot preserves access order`() {
+        val cache = LRUCache<String, Int>(3)
+
+        cache.put("A", 1)
+        cache.put("B", 2)
+        cache.put("C", 3)
+        cache.get("A")
+
+        val snapshot = cache.snapshot()
+
+        assertEquals(listOf("B", "C", "A"), snapshot.keys.toList())
+    }
+}


### PR DESCRIPTION
## Summary
- simplify LRU cache to use LinkedHashMap access-order eviction
- remove queue/timestamp bookkeeping and keep thread safety via locks
- add tests for eviction and access-order determinism

## Testing
- ./gradlew :groovy-lsp:test --tests "com.github.albertocavalcante.groovylsp.cache.LRUCacheTest"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies the LRU cache by leveraging access-order `LinkedHashMap` with built-in eldest-entry eviction while preserving thread safety via `ReentrantReadWriteLock`.
> 
> - Replaces manual `ConcurrentHashMap` + queue/timestamp bookkeeping with `LinkedHashMap` overriding `removeEldestEntry`
> - Simplifies `get/put/remove/clear` to lock-guarded map ops; `get` uses write lock to update access order
> - `keys()` and `snapshot()` now reflect access order from the underlying map
> - Adds `LRUCacheTest` covering eviction on insert, access-order updates on `get`, and snapshot order
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cfa7f4555f4e562d215ac90dc0307c0d1a0b9f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->