### PR TITLE
feat(lsp): add classpath indexer

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/services/ClasspathIndex.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/services/ClasspathIndex.kt
@@ -1,0 +1,38 @@
+package com.github.albertocavalcante.groovylsp.services
+
+import io.github.classgraph.ClassGraph
+import org.slf4j.LoggerFactory
+
+data class IndexedClass(val simpleName: String, val fullName: String)
+
+interface ClasspathIndex {
+    fun index(classLoader: ClassLoader): List<IndexedClass>
+}
+
+class JvmClasspathIndex : ClasspathIndex {
+    private val logger = LoggerFactory.getLogger(JvmClasspathIndex::class.java)
+
+    override fun index(classLoader: ClassLoader): List<IndexedClass> {
+        val results = mutableListOf<IndexedClass>()
+
+        ClassGraph()
+            .enableClassInfo()
+            .overrideClassLoaders(classLoader)
+            .scan().use { scanResult ->
+                scanResult.allClasses.forEach { classInfo ->
+                    val simpleName = classInfo.simpleName
+                    val fullName = classInfo.name
+
+                    // Skip anonymous classes and synthetic classes
+                    if (simpleName.contains('$') || classInfo.isSynthetic) {
+                        return@forEach
+                    }
+
+                    results.add(IndexedClass(simpleName, fullName))
+                }
+            }
+
+        logger.debug("JvmClasspathIndex produced {} classes", results.size)
+        return results
+    }
+}

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/services/ClasspathServiceTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/services/ClasspathServiceTest.kt
@@ -182,4 +182,27 @@ class ClasspathServiceTest {
         assertThat(snapshot["List"]).containsExactly("java.awt.List", "java.util.List")
         assertThat(snapshot["Map"]).containsExactly("java.util.Map")
     }
+
+    @Test
+    fun `uses provided classpath index`() {
+        val fakeIndex = FakeClasspathIndex(
+            listOf(
+                IndexedClass("Fake", "com.example.Fake"),
+                IndexedClass("Fake", "com.example.Fake"),
+                IndexedClass("Fake", "com.other.Fake"),
+            ),
+        )
+        val service = ClasspathService(fakeIndex)
+
+        val results = service.findClassesByPrefix("Fake")
+
+        assertThat(results.map { it.fullName }).containsExactly(
+            "com.example.Fake",
+            "com.other.Fake",
+        )
+    }
+}
+
+private class FakeClasspathIndex(private val entries: List<IndexedClass>) : ClasspathIndex {
+    override fun index(classLoader: ClassLoader): List<IndexedClass> = entries
 }


### PR DESCRIPTION
## Summary
- introduce a pluggable ClasspathIndex abstraction with a JVM-backed implementation
- make ClasspathService depend on the indexer for easier K/N-friendly swaps
- add a test proving custom indexers can be injected and deterministic

## Testing
- ./gradlew :groovy-lsp:test --tests "com.github.albertocavalcante.groovylsp.services.ClasspathServiceTest"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a pluggable indexing layer and refactors classpath scanning to improve testability and platform flexibility.
> 
> - Adds `ClasspathIndex` with `JvmClasspathIndex` (ClassGraph-based) that produces `IndexedClass` entries from a provided `ClassLoader`
> - Refactors `ClasspathService` to depend on `ClasspathIndex` (constructor injection, defaulting to `JvmClasspathIndex`); replaces inlined ClassGraph scan with `classpathIndex.index(...)`
> - New tests in `ClasspathServiceTest` using a `FakeClasspathIndex` verify injectable indexers and deterministic de-duplication/order in `ClassIndex`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb44645f531026821c1d4e8a8fdd104e82bf443d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved classpath indexing architecture with enhanced modularity.

* **Tests**
  * Added test coverage for the classpath indexing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->