### PR TITLE
refactor: remove commented-out debug logging

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/CompletionProvider.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/CompletionProvider.kt
@@ -666,7 +666,6 @@ object CompletionProvider {
         builder: CompletionsBuilder,
     ) {
         val gdkMethods = compilationService.gdkProvider.getMethodsForType(className)
-        // logger.debug("Found {} GDK methods for type {}", gdkMethods.size, className)
 
         gdkMethods.forEach { gdkMethod ->
             builder.method(
@@ -701,7 +700,6 @@ object CompletionProvider {
         builder: CompletionsBuilder,
     ) {
         val classpathMethods = compilationService.classpathService.getMethods(className)
-        // logger.debug("Found {} classpath methods for type {}", classpathMethods.size, className)
 
         classpathMethods.forEach { method ->
             // Only add public instance methods


### PR DESCRIPTION
Remove 2 dead code lines flagged by SonarCloud in `CompletionProvider.kt`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes stray commented-out debug logging from completion method helpers.
> 
> - Deletes commented debug lines in `addGdkMethodsForSingleType` and `addClasspathMethodsForSingleType` within `CompletionProvider.kt`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89adff1d996191514d574fd3498bb77805d3b287. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->