### PR TITLE
refactor: inject coroutine dispatchers for testability

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/GroovyLanguageServer.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/GroovyLanguageServer.kt
@@ -81,7 +81,11 @@ class GroovyLanguageServer(
     )
     private val startupManager = ProjectStartupManager(compilationService, availableBuildTools, coroutineScope)
     private val testRequestDelegate =
-        TestRequestDelegate(coroutineScope, compilationService) { startupManager.buildToolManager }
+        TestRequestDelegate(
+            coroutineScope,
+            compilationService,
+            buildToolManagerProvider = { startupManager.buildToolManager },
+        )
 
     // State
     private var savedInitParams: InitializeParams? = null

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/testing/TestRequestDelegate.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/testing/TestRequestDelegate.kt
@@ -4,6 +4,7 @@ import com.github.albertocavalcante.groovylsp.async.future
 import com.github.albertocavalcante.groovylsp.buildtool.BuildToolManager
 import com.github.albertocavalcante.groovylsp.buildtool.TestCommand
 import com.github.albertocavalcante.groovylsp.compilation.GroovyCompilationService
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -20,6 +21,7 @@ class TestRequestDelegate(
     private val coroutineScope: CoroutineScope,
     private val compilationService: GroovyCompilationService,
     private val buildToolManagerProvider: () -> BuildToolManager?,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     private val logger = LoggerFactory.getLogger(TestRequestDelegate::class.java)
 
@@ -27,7 +29,7 @@ class TestRequestDelegate(
         logger.info("Received groovy/discoverTests request for: ${params.workspaceUri}")
 
         return coroutineScope.future {
-            withContext(Dispatchers.IO) {
+            withContext(ioDispatcher) {
                 val provider = TestDiscoveryProvider(compilationService)
                 val result = provider.discoverTests(params.workspaceUri)
                 logger.info("discoverTests returning ${result.size} test suites: ${result.map { it.suite }}")

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/services/ProjectStartupManager.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/services/ProjectStartupManager.kt
@@ -13,6 +13,7 @@ import com.github.albertocavalcante.groovylsp.worker.WorkerFeature
 import com.github.albertocavalcante.groovylsp.worker.WorkerRouter
 import com.github.albertocavalcante.groovylsp.worker.WorkerRouterFactory
 import com.github.albertocavalcante.groovylsp.worker.defaultWorkerDescriptors
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -45,6 +46,7 @@ class ProjectStartupManager(
     private val availableBuildTools: List<BuildTool>,
     private val coroutineScope: CoroutineScope,
     private val workerRouter: WorkerRouter = WorkerRouter(defaultWorkerDescriptors()),
+    private val indexingDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
     private val logger = LoggerFactory.getLogger(ProjectStartupManager::class.java)
     private val groovyVersionResolver = GroovyVersionResolver()
@@ -305,7 +307,7 @@ class ProjectStartupManager(
             initialMessage = "Indexing ${sourceUris.size} Groovy files...",
         )
 
-        coroutineScope.launch(Dispatchers.Default) {
+        coroutineScope.launch(indexingDispatcher) {
             try {
                 compilationService.indexAllWorkspaceSources(sourceUris) { indexed, total ->
                     val percentage = if (total > 0) (indexed * PERCENTAGE_MULTIPLIER / total) else 0


### PR DESCRIPTION
Replace hardcoded `Dispatchers.IO/Default` with injectable parameters for better testability.

**Files changed:**
- `TestRequestDelegate.kt` - added `ioDispatcher` parameter
- `ProjectStartupManager.kt` - added `indexingDispatcher` parameter
- `GroovyLanguageServer.kt` - updated call site

SonarCloud: avoid hardcoded dispatchers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces injectable coroutine dispatchers to decouple concurrency from implementation and improve testability.
> 
> - Adds `ioDispatcher` to `TestRequestDelegate` and uses it in `discoverTests` instead of hardcoded `Dispatchers.IO`
> - Adds `indexingDispatcher` to `ProjectStartupManager` and uses it for workspace indexing instead of hardcoded `Dispatchers.Default`
> - Updates `GroovyLanguageServer` to pass named `buildToolManagerProvider` when constructing `TestRequestDelegate`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 401b8eb2640354b91ad071b155dc5f8e0c296e3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced constructor dependency injection for improved configurability of coroutine dispatchers.
  * Updated initialization patterns for better parameter explicitness and flexibility in test request handling and workspace indexing processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->