### PR TITLE
fix(ci): rebuild shadow jar for verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ env:
   PRIMARY_OS: >-
     ${{ (github.event.inputs.runner_label == 'local-macos' || vars.CI_RUNNER_LABEL == 'local-macos') && 'local-macos' ||
         (github.event.inputs.runner_label == 'magalu' || vars.CI_RUNNER_LABEL == 'magalu') && 'magalu' ||
-        (vars.CI_PRIMARY_OS || 'macos-15') }}
+        (vars.CI_PRIMARY_OS || (github.event_name == 'pull_request' && 'macos-15' || 'ubuntu-24.04')) }}
 concurrency:
   # PRs: group by head_ref (cancel outdated runs for same branch)
   # Main pushes: group by SHA (allows parallel runs per commit for fast regression detection)


### PR DESCRIPTION
## Summary
- resolve shadow JAR once and reuse the path for verify + upload in CI
- align primary OS defaults to avoid macOS-only verify on main pushes
- fix shadow JAR lookup patterns to match actual artifact name (gls-*-all.jar)
- align nightly workflow JAR lookup with actual artifact name

## Testing
- not run (workflow change)
