### PR TITLE
fix(ci): align nightly jar name

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -147,7 +147,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          JAR_PATH=$(find groovy-lsp/build/libs -maxdepth 1 -name 'groovy-lsp-*-all.jar' -print -quit)
+          JAR_PATH=$(find groovy-lsp/build/libs -maxdepth 1 -name 'gls-*-all.jar' -print -quit)
           echo "Found JAR: $JAR_PATH"
           java -jar "$JAR_PATH" --help
 
@@ -157,7 +157,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist
-          JAR_PATH=$(find groovy-lsp/build/libs -maxdepth 1 -name 'groovy-lsp-*-all.jar' -print -quit)
+          JAR_PATH=$(find groovy-lsp/build/libs -maxdepth 1 -name 'gls-*-all.jar' -print -quit)
           SHORT_SHA=$(git rev-parse --short HEAD)
           NIGHTLY_NAME="groovy-lsp-${{ steps.nightly_version.outputs.nightly_version }}-${SHORT_SHA}.jar"
           cp "$JAR_PATH" "dist/${NIGHTLY_NAME}"


### PR DESCRIPTION
## Summary
- align nightly shadow JAR lookup with actual artifact name (gls-*-all.jar)

## Testing
- not run (workflow change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns nightly artifact lookup with the actual Shadow JAR filename.
> 
> - Updates `Verify JAR` and `Prepare nightly artifacts` steps in `nightly.yml` to find `gls-*-all.jar`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b6937a769a596d57a06e823f52965a7e0ab4059. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->