### PR TITLE
refactor(ci): derive push matrix from primary OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,7 @@ jobs:
         #   - github-hosted: GitHub-hosted (macos-15 for PRs, multi-platform for main)
         # NOTE: Using macos-15 instead of ubuntu-latest due to runner stability issues
         # See: https://github.com/actions/runner-images/issues/13182
-        os: ${{ fromJSON( (github.event.inputs.runner_label == 'local-macos' || vars.CI_RUNNER_LABEL == 'local-macos') && '["local-macos"]' || (github.event.inputs.runner_label == 'magalu' || vars.CI_RUNNER_LABEL == 'magalu') && '["magalu"]' || (github.event_name == 'pull_request' && format('["{0}"]', vars.CI_PRIMARY_OS || 'macos-15') || '["macos-15", "ubuntu-24.04"]') ) }}
+        os: ${{ fromJSON( (github.event.inputs.runner_label == 'local-macos' || vars.CI_RUNNER_LABEL == 'local-macos') && '["local-macos"]' || (github.event.inputs.runner_label == 'magalu' || vars.CI_RUNNER_LABEL == 'magalu') && '["magalu"]' || (github.event_name == 'pull_request' && format('["{0}"]', vars.CI_PRIMARY_OS || 'macos-15') || format('["{0}", "{1}"]', vars.CI_PRIMARY_OS || 'macos-15', (vars.CI_PRIMARY_OS == 'ubuntu-24.04') && 'macos-15' || 'ubuntu-24.04')) ) }}
         java: ${{ fromJSON( (github.event.inputs.runner_label == 'local-macos' || vars.CI_RUNNER_LABEL == 'local-macos' || github.event.inputs.runner_label == 'magalu' || vars.CI_RUNNER_LABEL == 'magalu') && '[17]' || (github.event_name == 'pull_request' && '[17]' || '[17, 21]') ) }}
         exclude:
           - os: ubuntu-24.04


### PR DESCRIPTION
## Summary
- derive main push matrix OS list from `CI_PRIMARY_OS`, keeping the non-primary OS as the secondary runner

## Testing
- not run (workflow change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies CI OS matrix selection to be driven by the primary OS variable.
> 
> - Updates `jobs.build.strategy.matrix.os` to derive main-push matrix from `CI_PRIMARY_OS`, auto-selecting the complementary secondary OS (`macos-15` if primary is `ubuntu-24.04`, otherwise `ubuntu-24.04`)
> - Preserves overrides for `local-macos` and `magalu`, and retains single-OS behavior for PRs via `CI_PRIMARY_OS`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d3718f03fc4e0a557cb330a367504080508fdec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->