### PR TITLE
fix(ci): skip JDK 17 on Windows ARM in release smoke tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,10 @@ jobs:
         retention-days: 7
 
   # Cross-platform smoke tests to verify JAR works on all supported platforms
+  # TODO(#461): Migrate to JDK 21 baseline and drop JDK 17 support entirely.
+  #   Temurin doesn't provide JDK 17 for Windows ARM, requiring matrix exclusions.
+  #   JDK 21 is the current LTS and available on all platforms.
+  #   See: https://github.com/albertocavalcante/groovy-devtools/issues/461
   smoke-test:
     name: Smoke Test (${{ matrix.os }}, JDK ${{ matrix.java }})
     needs: build-release
@@ -154,6 +158,10 @@ jobs:
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, windows-2022, windows-11-arm]
         java: [17, 21]
+        exclude:
+          # Temurin doesn't provide JDK 17 for Windows ARM — only JDK 21+ available
+          - os: windows-11-arm
+            java: 17
         include:
           # JDK 11 should fail due to bytecode version mismatch (target is JDK 17)
           - os: ubuntu-24.04


### PR DESCRIPTION
## Summary

Fixes the v0.4.8 release failure caused by Temurin not providing JDK 17 for Windows ARM.

## Changes

- Exclude `windows-11-arm` + `java: 17` from the smoke test matrix
- Add `TODO(#461)` to track future JDK 21 baseline migration

## Context

The release failed with:
```
##[error]Could not find satisfied version for SemVer '17'. 
Available versions: 23.0.2+7, 23.0.1+11, 21.0.9+10.0.LTS, ...
```

Windows ARM only has JDK 21+ available from Temurin. This PR excludes that combination and links to #461 for the broader migration.

## Testing

After merge, re-run release with:
```bash
gh workflow run release.yml -f tag=v0.4.8
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoids release failures due to unavailable Temurin JDK 17 on Windows ARM and documents the path to a JDK 21 baseline.
> 
> - Excludes `windows-11-arm` + `java: 17` from `smoke-test` matrix
> - Adds `TODO(#461)` to migrate baseline to JDK 21 (available on all platforms)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe3575b54480097594eaffb8d4b9df0af5e014bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to exclude JDK 17 testing on Windows ARM platforms due to compiler availability constraints, while maintaining JDK 21 testing across all platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->