### PR TITLE
docs: fix Gradle test pattern for backtick-quoted test names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,9 +94,9 @@ git worktree prune
 
 ```bash
 # Example TDD workflow
-./gradlew test --tests "*.MyTest.test my failing case"  # Must FAIL first
+./gradlew test --tests "*MyTest.*my failing case*"  # Must FAIL first
 # ... implement fix ...
-./gradlew test --tests "*.MyTest.test my failing case"  # Must PASS now
+./gradlew test --tests "*MyTest.*my failing case*"  # Must PASS now
 ```
 
 **Violations**: Implementing code before test fails = revert and start over.


### PR DESCRIPTION
## Summary

Fixes the TDD example in AGENTS.md to use correct wildcard pattern for backtick-quoted test names.

## Problem

The example `./gradlew test --tests "*.MyTest.test my failing case"` doesn't match Kotlin/JUnit backtick-quoted test methods like `fun \`test my failing case\`()`.

## Solution

Use wildcards: `*MyTest.*my failing case*`

## Context

Raised by CodeRabbit in PR #478 review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Docs update in `AGENTS.md`**
> 
> - Updates TDD example commands to use the correct Gradle `--tests` wildcard pattern `*MyTest.*my failing case*` (replacing `*.MyTest.test my failing case`) so backtick-quoted Kotlin/JUnit test names are matched.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6454fee42e2409b9343f2ece9e618bd65a63e7b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->