### PR TITLE
fix: use correct spotless task name in make jar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ help:
 
 # Quick JAR build without tests (most common during development)
 jar:
-	./gradlew build -x test -x koverVerify -x detekt -x spotlessKotlinCheck -x spotlessMarkdownCheck $(GRADLE_ARGS)
+	./gradlew build -x test -x koverVerify -x detekt -x spotlessCheck $(GRADLE_ARGS)
 
 # Full build with tests
 build:


### PR DESCRIPTION
## Problem

`make jar` / `make ext-install` was failing with two issues:

### 1. Non-existent Gradle task
```
Task 'spotlessMarkdownCheck' not found in root project
```

### 2. Fragile path calculation
After build succeeded, the JAR wasn't found because `findLocalGroovyLspJar()` used hardcoded relative paths (`../..`) that were wrong.

## Solution

### 1. Fix Makefile
Changed `-x spotlessKotlinCheck -x spotlessMarkdownCheck` to `-x spotlessCheck`

### 2. Robust monorepo detection
Added `findMonorepoRoot()` that **walks up the directory tree** looking for `groovy-lsp/build.gradle.kts` marker.

```javascript
function findMonorepoRoot() {
  let current = __dirname;
  while (current !== root) {
    if (fs.existsSync(path.join(current, 'groovy-lsp', 'build.gradle.kts'))) {
      return current;
    }
    current = path.dirname(current);
  }
  return null;
}
```

This approach is **robust to future refactoring** - if we move `editors/code` elsewhere, it will still find the monorepo root.

## Testing

```bash
make ext-install  # Now finds JAR after build
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Build/Makefile**
> - Update `jar` target to exclude `spotlessCheck` instead of non-existent `spotlessKotlinCheck`/`spotlessMarkdownCheck`.
> 
> **VS Code extension server prep (`editors/code/tools/prepare-server.js`)**
> - Add `findMonorepoRoot()` to walk up directories and detect the monorepo via `groovy-lsp/build.gradle.kts`.
> - Use this helper in `findLocalGroovyLspJar`, `detectMonorepoEnvironment`, and `getMonorepoRoot` for more robust monorepo detection and local JAR discovery.
> - Adjust search paths to prefer monorepo `groovy-lsp/build/libs` when available and improve JSDoc/return types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c32555143e1d8f848ed2a692f9827d5ade4a6c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build configuration to enforce code quality checks.
  * Improved local development tooling with more robust monorepo detection to enhance reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->