### PR TITLE
feat: add make targets to install extension to VS Code forks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,14 @@ help:
 	@echo "  ext-build   - Build the extension"
 	@echo "  ext-test    - Run extension tests"
 	@echo "  ext-package - Package the extension (.vsix)"
+	@echo ""
+	@echo "Install Extension to Editors:"
+	@echo "  ext-vscode    - Install to VS Code"
+	@echo "  ext-cursor    - Install to Cursor"
+	@echo "  ext-windsurf  - Install to Windsurf"
+	@echo "  ext-agy       - Install to Antigravity"
+	@echo "  ext-kiro      - Install to Kiro"
+	@echo "  ext-editors   - Install to all available editors"
 
 
 # Quick JAR build without tests (most common during development)
@@ -116,6 +124,46 @@ ext-test: $(EXT_DIR)/node_modules
 
 ext-package: $(EXT_DIR)/node_modules
 	cd $(EXT_DIR) && pnpm run package
+
+# Install extension to editors (VS Code forks)
+# Usage: make ext-vscode, make ext-cursor, make ext-agy, make ext-kiro, make ext-editors
+EXT_VSIX := $(shell ls -t $(EXT_DIR)/gvy-*.vsix 2>/dev/null | head -1)
+
+ext-vscode: ext-package
+	@if [ -z "$(EXT_VSIX)" ]; then echo "❌ No VSIX found. Run 'make ext-package' first."; exit 1; fi
+	code --install-extension $(EXT_VSIX) --force
+	@echo "✅ Installed to VS Code"
+
+ext-cursor: ext-package
+	@if [ -z "$(EXT_VSIX)" ]; then echo "❌ No VSIX found. Run 'make ext-package' first."; exit 1; fi
+	cursor --install-extension $(EXT_VSIX) --force
+	@echo "✅ Installed to Cursor"
+
+ext-agy: ext-package
+	@if [ -z "$(EXT_VSIX)" ]; then echo "❌ No VSIX found. Run 'make ext-package' first."; exit 1; fi
+	agy --install-extension $(EXT_VSIX) --force
+	@echo "✅ Installed to Antigravity"
+
+ext-kiro: ext-package
+	@if [ -z "$(EXT_VSIX)" ]; then echo "❌ No VSIX found. Run 'make ext-package' first."; exit 1; fi
+	kiro --install-extension $(EXT_VSIX) --force
+	@echo "✅ Installed to Kiro"
+
+ext-windsurf: ext-package
+	@if [ -z "$(EXT_VSIX)" ]; then echo "❌ No VSIX found. Run 'make ext-package' first."; exit 1; fi
+	@command -v windsurf >/dev/null 2>&1 && windsurf --install-extension $(EXT_VSIX) --force \
+		|| command -v surf >/dev/null 2>&1 && surf --install-extension $(EXT_VSIX) --force \
+		|| (echo "❌ Neither 'windsurf' nor 'surf' command found"; exit 1)
+	@echo "✅ Installed to Windsurf"
+
+ext-editors: ext-package
+	@if [ -z "$(EXT_VSIX)" ]; then echo "❌ No VSIX found. Run 'make ext-package' first."; exit 1; fi
+	@echo "Installing $(EXT_VSIX) to all available editors..."
+	@command -v code >/dev/null 2>&1 && code --install-extension $(EXT_VSIX) --force && echo "✅ VS Code" || echo "⏭️  VS Code not found"
+	@command -v cursor >/dev/null 2>&1 && cursor --install-extension $(EXT_VSIX) --force && echo "✅ Cursor" || echo "⏭️  Cursor not found"
+	@(command -v windsurf >/dev/null 2>&1 && windsurf --install-extension $(EXT_VSIX) --force || command -v surf >/dev/null 2>&1 && surf --install-extension $(EXT_VSIX) --force) && echo "✅ Windsurf" || echo "⏭️  Windsurf not found"
+	@command -v agy >/dev/null 2>&1 && agy --install-extension $(EXT_VSIX) --force && echo "✅ Antigravity" || echo "⏭️  Antigravity not found"
+	@command -v kiro >/dev/null 2>&1 && kiro --install-extension $(EXT_VSIX) --force && echo "✅ Kiro" || echo "⏭️  Kiro not found"
 
 # Release
 release: release-build


### PR DESCRIPTION
## Summary

Adds Makefile targets to install the packaged extension to various VS Code forks.

## New Targets

| Target | Editor | CLI Commands |
|--------|--------|--------------|
| `make ext-vscode` | VS Code | `code` |
| `make ext-cursor` | Cursor | `cursor` |
| `make ext-windsurf` | Windsurf | `windsurf` or `surf` |
| `make ext-agy` | Antigravity | `agy` |
| `make ext-kiro` | Kiro | `kiro` |
| `make ext-editors` | All available | Installs to all, skips missing |

## Usage

```bash
# Install to specific editor
make ext-cursor

# Install to all available editors
make ext-editors
```

All targets:
- Depend on `ext-package` (builds VSIX first)
- Use `--force` to update existing installations
- Show clear ✅/⏭️ messages for success/skip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Makefile targets to install the packaged VS Code extension to multiple editors and updates `help` output accordingly.
> 
> - New targets: `ext-vscode`, `ext-cursor`, `ext-windsurf`, `ext-agy`, `ext-kiro`, `ext-editors`
> - All depend on `ext-package` and install the latest `editors/code/gvy-*.vsix` via each editor's CLI with `--force`
> - `ext-windsurf` tries `windsurf` then `surf`; `ext-editors` installs to all detected editors and prints success/skip messages
> - `help` now documents these install targets
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 747850bbb0802ad5b663bfce730ba180d5ad10c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->