### PR TITLE
feat(ext): improve Java detection UX with jdk-utils and login shell fallback

### DIFF
--- a/editors/code/client/package.json
+++ b/editors/code/client/package.json
@@ -6,6 +6,7 @@
     "vscode": "^1.100.0"
   },
   "dependencies": {
+    "jdk-utils": "^0.6.0",
     "vscode-languageclient": "^9.0.1",
     "vscode-languageserver-protocol": "^3.17.5"
   },

--- a/editors/code/client/pnpm-lock.yaml
+++ b/editors/code/client/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      jdk-utils:
+        specifier: ^0.6.0
+        version: 0.6.0
       vscode-languageclient:
         specifier: ^9.0.1
         version: 9.0.1
@@ -370,6 +373,10 @@ packages:
   jackspeak@4.1.1:
     resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
     engines: {node: 20 || >=22}
+
+  jdk-utils@0.6.0:
+    resolution: {integrity: sha512-/CHgo6Q5xyfW/+vWXLz7cAb+iwIye3mNo7SV8UTHsbLhRykk+N7LzKXRlCvdeoblyuTrA8pb00iZX8De3txvWQ==}
+    hasBin: true
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -967,6 +974,8 @@ snapshots:
   jackspeak@4.1.1:
     dependencies:
       '@isaacs/cliui': 8.0.2
+
+  jdk-utils@0.6.0: {}
 
   js-yaml@4.1.1:
     dependencies:

--- a/editors/code/client/src/java/finder.ts
+++ b/editors/code/client/src/java/finder.ts
@@ -1,46 +1,216 @@
 import * as path from 'path';
-import * as fs from 'fs';
+import { exec } from 'child_process';
+import { promisify } from 'util';
 import { workspace } from 'vscode';
+import { findRuntimes, getRuntime, getSources, IJavaRuntime } from 'jdk-utils';
+
+const execAsync = promisify(exec);
+
+// Minimum supported Java version for Groovy Language Server
+export const MINIMUM_JAVA_VERSION = 17;
+
+export type JavaSource = 'setting' | 'java_home' | 'jdk_manager' | 'system' | 'login_shell';
+
+export interface JavaResolution {
+    path: string;
+    version: number;
+    source: JavaSource;
+}
 
 /**
- * Finds Java executable from multiple sources
+ * Finds Java installation from multiple sources using jdk-utils.
+ * Falls back to login shell for lazy-loading shell functions (SDKMAN, etc.)
  */
-export function findJava(): string {
+export async function findJava(): Promise<JavaResolution | null> {
+    // 1. Check groovy.java.home setting first (highest priority)
+    const configuredHome = workspace.getConfiguration('groovy').get<string>('java.home');
+    if (configuredHome) {
+        const expandedPath = expandHomeDir(configuredHome);
+        const runtime = await getRuntime(expandedPath, { withVersion: true });
+        if (runtime?.version?.major && runtime.version.major >= MINIMUM_JAVA_VERSION) {
+            return {
+                path: runtime.homedir,
+                version: runtime.version.major,
+                source: 'setting'
+            };
+        }
+        // Setting configured but invalid - we'll report this later
+        if (runtime?.version?.major) {
+            return {
+                path: runtime.homedir,
+                version: runtime.version.major,
+                source: 'setting'
+            };
+        }
+    }
+
+    // 2. Use jdk-utils to scan JAVA_HOME, PATH, SDKMAN, jEnv, jabba, asdf, common paths
+    try {
+        const runtimes = await findRuntimes({ checkJavac: true, withVersion: true, withTags: true });
+        const validRuntimes = runtimes.filter(r => r.version?.major && r.version.major >= MINIMUM_JAVA_VERSION);
+
+        if (validRuntimes.length > 0) {
+            // Sort by source priority (env vars > JDK managers > common paths)
+            validRuntimes.sort((a, b) => getSourcePriority(a) - getSourcePriority(b));
+            const best = validRuntimes[0];
+            return {
+                path: best.homedir,
+                version: best.version!.major,
+                source: categorizeSource(getSources(best))
+            };
+        }
+
+        // Also check if there's any Java at all (even if version is too low)
+        if (runtimes.length > 0) {
+            const anyRuntime = runtimes[0];
+            if (anyRuntime.version?.major) {
+                return {
+                    path: anyRuntime.homedir,
+                    version: anyRuntime.version.major,
+                    source: categorizeSource(getSources(anyRuntime))
+                };
+            }
+        }
+    } catch {
+        // jdk-utils failed, continue to login shell fallback
+    }
+
+    // 3. Login shell fallback for lazy-loading shell functions (SDKMAN lazy init, etc.)
+    const loginShellResult = await tryLoginShell();
+    if (loginShellResult) {
+        return { ...loginShellResult, source: 'login_shell' };
+    }
+
+    return null;
+}
+
+/**
+ * Legacy function for backward compatibility - returns just the Java executable path
+ */
+export function findJavaSync(): string {
     const executableFile = process.platform === 'win32' ? 'java.exe' : 'java';
 
     // 1. Check configuration setting first
     const javaHome = workspace.getConfiguration('groovy').get<string>('java.home');
     if (javaHome) {
-        const javaPath = path.join(javaHome, 'bin', executableFile);
-        if (validateJavaPath(javaPath)) {
-            return javaPath;
-        }
+        const javaPath = path.join(expandHomeDir(javaHome), 'bin', executableFile);
+        return javaPath;
     }
 
     // 2. Check JAVA_HOME environment variable
     const envJavaHome = process.env.JAVA_HOME;
     if (envJavaHome) {
-        const javaPath = path.join(envJavaHome, 'bin', executableFile);
-        if (validateJavaPath(javaPath)) {
-            return javaPath;
-        }
+        return path.join(envJavaHome, 'bin', executableFile);
     }
 
-    // 3. Check PATH
-    if (process.env.PATH) {
-        const paths = process.env.PATH.split(path.delimiter);
-        for (const p of paths) {
-            const javaPath = path.join(p, executableFile);
-            if (validateJavaPath(javaPath)) {
-                return javaPath;
-            }
-        }
-    }
-
-    // 4. Fallback to system PATH
+    // 3. Fallback to system PATH
     return 'java';
 }
 
-function validateJavaPath(javaPath: string): boolean {
-    return fs.existsSync(javaPath) && fs.statSync(javaPath).isFile();
+/**
+ * Tries to find Java via login shell.
+ * This handles lazy-loading shell functions like SDKMAN's lazy init pattern.
+ */
+async function tryLoginShell(): Promise<{ path: string; version: number } | null> {
+    // Windows doesn't use login shells the same way
+    if (process.platform === 'win32') return null;
+
+    const shell = process.env.SHELL || '/bin/bash';
+    try {
+        // Login shell (-l) loads user's config files (.zshrc, .bashrc, etc.)
+        // This triggers lazy-loading shell functions like SDKMAN
+        const { stdout } = await execAsync(`${shell} -l -c "which java 2>/dev/null"`, {
+            timeout: 10000 // 10 second timeout
+        });
+        const javaPath = stdout.trim();
+        if (!javaPath || javaPath.includes('not found') || javaPath.includes('no java')) {
+            return null;
+        }
+
+        // Resolve symlinks and get the actual JAVA_HOME
+        const { stdout: realPath } = await execAsync(`${shell} -l -c "readlink -f '${javaPath}' 2>/dev/null || realpath '${javaPath}' 2>/dev/null || echo '${javaPath}'"`, {
+            timeout: 5000
+        });
+        const resolvedPath = realPath.trim();
+
+        // Get JAVA_HOME (go up two directories from bin/java)
+        const javaHome = path.dirname(path.dirname(resolvedPath));
+
+        // Validate with jdk-utils
+        const runtime = await getRuntime(javaHome, { withVersion: true });
+        if (runtime?.version?.major) {
+            return { path: runtime.homedir, version: runtime.version.major };
+        }
+
+        // Fallback: try to get version directly
+        const { stdout: versionOut, stderr: versionErr } = await execAsync(`${shell} -l -c "java -version 2>&1"`, {
+            timeout: 10000
+        });
+        const versionOutput = versionOut || versionErr;
+        const versionMatch = versionOutput.match(/version "(\d+)(?:\.(\d+))?/);
+        if (versionMatch) {
+            const majorVersion = parseInt(versionMatch[1], 10);
+            if (!isNaN(majorVersion)) {
+                return { path: javaHome, version: majorVersion };
+            }
+        }
+    } catch {
+        // Login shell approach failed
+    }
+    return null;
+}
+
+/**
+ * Expands ~ to home directory
+ */
+function expandHomeDir(p: string): string {
+    if (p.startsWith('~')) {
+        return path.join(process.env.HOME || process.env.USERPROFILE || '', p.slice(1));
+    }
+    return p;
+}
+
+/**
+ * Returns priority score for JDK source (lower is better)
+ */
+function getSourcePriority(runtime: IJavaRuntime): number {
+    const sources = getSources(runtime);
+    const envVars = ['JDK_HOME', 'JAVA_HOME', 'PATH'];
+    const jdkManagers = ['SDKMAN', 'jEnv', 'jabba', 'asdf'];
+
+    // Check environment variables first (highest priority)
+    for (let i = 0; i < envVars.length; i++) {
+        if (sources.includes(envVars[i])) {
+            return i;
+        }
+    }
+
+    // JDK managers next
+    if (sources.some(source => jdkManagers.includes(source))) {
+        return envVars.length + 1;
+    }
+
+    // Common system paths
+    if (sources.length === 0) {
+        return envVars.length + 2;
+    }
+
+    // Other sources
+    return envVars.length + 3;
+}
+
+/**
+ * Categorizes JDK source for display purposes
+ */
+function categorizeSource(sources: string[]): JavaSource {
+    if (sources.includes('JAVA_HOME') || sources.includes('JDK_HOME')) {
+        return 'java_home';
+    }
+    if (sources.some(s => ['SDKMAN', 'jEnv', 'jabba', 'asdf'].includes(s))) {
+        return 'jdk_manager';
+    }
+    if (sources.includes('PATH')) {
+        return 'system';
+    }
+    return 'system';
 }

--- a/editors/code/client/src/java/validator.ts
+++ b/editors/code/client/src/java/validator.ts
@@ -1,91 +1,262 @@
-import { exec } from 'child_process';
-import { promisify } from 'util';
 import { workspace, window, commands } from 'vscode';
-import { findJava } from './finder';
-
-const execAsync = promisify(exec);
-
-// Minimum supported Java version for Groovy Language Server
-const MINIMUM_JAVA_VERSION = 17;
+import { findJava, findJavaSync, JavaResolution, MINIMUM_JAVA_VERSION } from './finder';
 
 export interface JavaValidationResult {
     isValid: boolean;
-    version?: number;
-    path?: string;
+    resolution?: JavaResolution;
     error?: string;
 }
 
 /**
- * Validates Java installation and version compatibility
+ * Validates Java installation and version compatibility using jdk-utils.
+ * Falls back to login shell for lazy-loading patterns (SDKMAN, etc.)
  */
 export async function validateJava(): Promise<JavaValidationResult> {
-    const javaPath = findJava();
-
     try {
-        const { stdout, stderr } = await execAsync(`"${javaPath}" -version`);
-        const versionOutput = stdout || stderr;
-        const versionMatch = versionOutput.match(/version "(\d+)(?:\.(\d+))?/);
+        const resolution = await findJava();
 
-        if (!versionMatch) {
+        if (!resolution) {
             return {
                 isValid: false,
-                error: 'Failed to determine Java version'
+                error: 'No Java installation found'
             };
         }
 
-        const majorVersion = parseInt(versionMatch[1], 10);
-
-        if (isNaN(majorVersion) || majorVersion < MINIMUM_JAVA_VERSION) {
+        if (resolution.version < MINIMUM_JAVA_VERSION) {
             return {
                 isValid: false,
-                version: majorVersion,
-                path: javaPath,
-                error: `Java ${MINIMUM_JAVA_VERSION}+ required, found Java ${majorVersion}`
+                resolution,
+                error: `Java ${MINIMUM_JAVA_VERSION}+ required, found Java ${resolution.version}`
             };
         }
 
         return {
             isValid: true,
-            version: majorVersion,
-            path: javaPath
+            resolution
         };
-
     } catch (error) {
         return {
             isValid: false,
-            error: `Failed to execute Java: ${error instanceof Error ? error.message : 'Unknown error'}`
+            error: `Failed to validate Java: ${error instanceof Error ? error.message : 'Unknown error'}`
         };
     }
 }
 
 /**
- * Shows appropriate error message for Java validation failure
+ * Gets the Java executable path for starting the language server.
+ * Returns the path from resolution if available, otherwise falls back to sync finder.
+ */
+export function getJavaExecutable(resolution?: JavaResolution): string {
+    if (resolution?.path) {
+        const executableFile = process.platform === 'win32' ? 'java.exe' : 'java';
+        return `${resolution.path}/bin/${executableFile}`;
+    }
+    return findJavaSync();
+}
+
+/**
+ * Shows appropriate error message for Java validation failure with platform-specific guidance.
  */
 export async function showJavaError(result: JavaValidationResult): Promise<void> {
     if (result.isValid) return;
 
-    const settingsJavaHome = workspace.getConfiguration('groovy').get<string>('java.home');
-    const openSettingsButtonText = 'Open Settings';
-    const downloadJavaButtonText = 'Download Java';
+    const resolution = result.resolution;
+    const platform = process.platform;
 
-    let message: string;
-    const actions: string[] = [openSettingsButtonText];
-
-    if (settingsJavaHome && result.error?.includes('Failed to execute')) {
-        message = `The groovy.java.home setting does not point to a valid Java installation: ${result.error}`;
-    } else if (result.version && result.version < MINIMUM_JAVA_VERSION) {
-        message = `Groovy Language Server requires Java ${MINIMUM_JAVA_VERSION}+ but found Java ${result.version}. Please update your Java installation or configure a different Java path.`;
-        actions.push(downloadJavaButtonText);
-    } else {
-        message = `Could not locate valid Java ${MINIMUM_JAVA_VERSION}+ installation. ${result.error || ''}`;
-        actions.push(downloadJavaButtonText);
+    // Special case: Java found via login shell but won't work in non-interactive context
+    if (resolution?.source === 'login_shell') {
+        await showLoginShellMessage(resolution);
+        return;
     }
 
-    const selection = await window.showErrorMessage(message, ...actions);
+    // Version too low
+    if (resolution && resolution.version < MINIMUM_JAVA_VERSION) {
+        await showVersionError(resolution, platform);
+        return;
+    }
 
-    if (selection === openSettingsButtonText) {
+    // Configured path is invalid
+    const settingsJavaHome = workspace.getConfiguration('groovy').get<string>('java.home');
+    if (settingsJavaHome && result.error) {
+        await showConfiguredPathError(settingsJavaHome, result.error);
+        return;
+    }
+
+    // Java not found at all
+    await showNotFoundError(platform);
+}
+
+/**
+ * Shows message when Java was found via login shell (SDKMAN lazy-loading, etc.)
+ */
+async function showLoginShellMessage(resolution: JavaResolution): Promise<void> {
+    const message = `Java ${resolution.version} found, but requires shell initialization`;
+
+    const detail = [
+        'Java is managed by a tool (like SDKMAN) that requires shell setup.',
+        'VS Code cannot access it directly without configuration.',
+        '',
+        'To fix this permanently, click "Use This Path" to set:',
+        `  groovy.java.home = "${resolution.path}"`
+    ].join('\n');
+
+    const selection = await window.showWarningMessage(
+        message,
+        { modal: false, detail },
+        'Use This Path',
+        'Open Settings'
+    );
+
+    if (selection === 'Use This Path') {
+        await workspace.getConfiguration('groovy').update('java.home', resolution.path, true);
+        const reloadSelection = await window.showInformationMessage(
+            `groovy.java.home set to "${resolution.path}". Reload window to apply?`,
+            'Reload Now',
+            'Later'
+        );
+        if (reloadSelection === 'Reload Now') {
+            commands.executeCommand('workbench.action.reloadWindow');
+        }
+    } else if (selection === 'Open Settings') {
         commands.executeCommand('workbench.action.openSettings', 'groovy.java.home');
-    } else if (selection === downloadJavaButtonText) {
+    }
+}
+
+/**
+ * Shows error when Java version is too low
+ */
+async function showVersionError(resolution: JavaResolution, platform: string): Promise<void> {
+    const message = `Java ${resolution.version} found, but Java ${MINIMUM_JAVA_VERSION}+ is required`;
+
+    const installHints = getInstallHints(platform);
+    const sourceHint = getSourceHint(resolution);
+
+    const detail = [
+        sourceHint,
+        '',
+        'Update your Java installation:',
+        ...installHints,
+        '',
+        `Or configure a different Java in Settings → groovy.java.home`
+    ].join('\n');
+
+    const selection = await window.showErrorMessage(
+        message,
+        { modal: false, detail },
+        'Download Java',
+        'Open Settings'
+    );
+
+    handleErrorAction(selection);
+}
+
+/**
+ * Shows error when configured groovy.java.home path is invalid
+ */
+async function showConfiguredPathError(configuredPath: string, error: string): Promise<void> {
+    const message = `The configured Java path is invalid`;
+
+    const detail = [
+        `groovy.java.home is set to: ${configuredPath}`,
+        '',
+        `Error: ${error}`,
+        '',
+        'Please verify the path points to a valid JDK installation,',
+        'or remove the setting to use auto-detection.'
+    ].join('\n');
+
+    const selection = await window.showErrorMessage(
+        message,
+        { modal: false, detail },
+        'Open Settings',
+        'Download Java'
+    );
+
+    handleErrorAction(selection);
+}
+
+/**
+ * Shows error when no Java installation is found
+ */
+async function showNotFoundError(platform: string): Promise<void> {
+    const message = `Java ${MINIMUM_JAVA_VERSION}+ is required but could not be found`;
+
+    const installHints = getInstallHints(platform);
+
+    const detail = [
+        'Install Java using one of these methods:',
+        ...installHints,
+        '',
+        'After installing, either:',
+        '  • Restart VS Code, or',
+        '  • Set the path in Settings → groovy.java.home'
+    ].join('\n');
+
+    const selection = await window.showErrorMessage(
+        message,
+        { modal: false, detail },
+        'Download Java',
+        'Open Settings'
+    );
+
+    handleErrorAction(selection);
+}
+
+/**
+ * Returns platform-specific installation hints
+ */
+function getInstallHints(platform: string): string[] {
+    switch (platform) {
+        case 'darwin':
+            return [
+                '  • Homebrew: brew install --cask temurin',
+                '  • SDKMAN: sdk install java 21-tem',
+                '  • Download from adoptium.net'
+            ];
+        case 'linux':
+            return [
+                '  • apt: sudo apt install openjdk-21-jdk',
+                '  • dnf: sudo dnf install java-21-openjdk',
+                '  • SDKMAN: sdk install java 21-tem',
+                '  • Download from adoptium.net'
+            ];
+        case 'win32':
+            return [
+                '  • winget: winget install EclipseAdoptium.Temurin.21.JDK',
+                '  • choco: choco install temurin21',
+                '  • Download from adoptium.net'
+            ];
+        default:
+            return ['  • Download from adoptium.net'];
+    }
+}
+
+/**
+ * Returns a hint about where the Java was found
+ */
+function getSourceHint(resolution: JavaResolution): string {
+    switch (resolution.source) {
+        case 'setting':
+            return `Found via groovy.java.home setting: ${resolution.path}`;
+        case 'java_home':
+            return `Found via JAVA_HOME: ${resolution.path}`;
+        case 'jdk_manager':
+            return `Found via JDK manager (SDKMAN/jEnv/etc.): ${resolution.path}`;
+        case 'login_shell':
+            return `Found via shell initialization: ${resolution.path}`;
+        case 'system':
+        default:
+            return `Found on system: ${resolution.path}`;
+    }
+}
+
+/**
+ * Handles common error action buttons
+ */
+function handleErrorAction(selection: string | undefined): void {
+    if (selection === 'Open Settings') {
+        commands.executeCommand('workbench.action.openSettings', 'groovy.java.home');
+    } else if (selection === 'Download Java') {
         commands.executeCommand('vscode.open', 'https://adoptium.net/');
     }
 }

--- a/editors/code/client/src/server/client.ts
+++ b/editors/code/client/src/server/client.ts
@@ -6,7 +6,7 @@ import {
     ServerOptions,
     State
 } from 'vscode-languageclient/node';
-import { validateJava, showJavaError } from '../java/validator';
+import { validateJava, showJavaError, getJavaExecutable } from '../java/validator';
 import { setClient } from '../ui/statusBar';
 import { getConfiguration } from '../configuration/settings';
 import { ServerResolver } from '../services/ServerResolver';
@@ -84,7 +84,7 @@ async function createServerOptions(): Promise<ServerOptions> {
         throw new Error(`Java validation failed: ${javaValidation.error}`);
     }
 
-    const javaExecutable = javaValidation.path!;
+    const javaExecutable = getJavaExecutable(javaValidation.resolution);
 
     // Server launch options
     const serverOptions: ServerOptions = {


### PR DESCRIPTION
## Summary

Improves Java detection and error messaging UX using the battle-tested `jdk-utils` library (same as vscode-java).

## Changes

### Java Detection (finder.ts)
- **jdk-utils integration**: Leverages the same library that vscode-java uses (30M+ installs) for robust JDK detection
- **Detects Java from**: `JAVA_HOME`, `PATH`, SDKMAN, jEnv, jabba, asdf, and common system paths
- **Login shell fallback**: Handles lazy-loading shell functions (like SDKMAN's lazy init pattern) by trying `$SHELL -l -c "which java"`
- **Source prioritization**: Prefers env vars > JDK managers > system paths

### Error Messages (validator.ts)
- **Platform-aware hints**: Different installation commands for macOS, Linux, and Windows
- **Actionable buttons**: "Download Java" and "Open Settings" actions
- **Login shell detection**: Shows "Use This Path" to auto-configure `groovy.java.home`
- **Clear context**: Shows where Java was found and why it failed

## Example Error Messages

### Java Not Found (macOS)
```
Java 17+ is required but could not be found.

Install Java using one of these methods:
  • Homebrew: brew install --cask temurin
  • SDKMAN: sdk install java 21-tem
  • Download from adoptium.net

After installing, either:
  • Restart VS Code, or
  • Set the path in Settings → groovy.java.home

[Download Java] [Open Settings]
```

### Java Found via Login Shell
```
Java 21 found, but requires shell initialization

Java is managed by a tool (like SDKMAN) that requires shell setup.
VS Code cannot access it directly without configuration.

To fix this permanently, click "Use This Path" to set:
  groovy.java.home = "/Users/user/.sdkman/candidates/java/21-tem"

[Use This Path] [Open Settings]
```

## Testing

- [x] TypeScript compiles successfully
- [x] ESLint passes
- [ ] Manual testing with SDKMAN lazy-loading setup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes Java resolution and startup reliability while improving user-facing guidance.
> 
> - Replaces ad‑hoc detection with `jdk-utils` in `src/java/finder.ts` (prioritized sources, version gating, `login_shell` fallback) and adds `MINIMUM_JAVA_VERSION`
> - Introduces `JavaResolution` and `findJava()` (async) plus `findJavaSync()`; categorizes sources and expands `~`
> - Revamps validation in `src/java/validator.ts`: platform-aware install hints, "Use This Path" flow for login-shell discoveries, clearer errors; adds `getJavaExecutable()`
> - Updates server launch in `src/server/client.ts` to use `getJavaExecutable` from validation result
> - Adds dependency `jdk-utils` in `package.json` and lockfile
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1935ba1ff729b0ad6c51505e7ecbe9e31f49c0fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Java discovery now checks multiple configuration sources to locate installations
  * Enhanced error messages provide specific guidance and actionable options when Java configuration issues occur
  * Improved support for various Java installation scenarios and system-level configurations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->