### PR TITLE
fix(make): track client package.json changes for smart install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,14 +107,15 @@ version:
 # VS Code Extension (editors/code/)
 EXT_DIR := editors/code
 
-# Smart install: Only runs pnpm install if package.json/lock has changed or node_modules is missing
-$(EXT_DIR)/node_modules: $(EXT_DIR)/package.json $(EXT_DIR)/pnpm-lock.yaml
+# Smart install: Runs pnpm install if package.json/lock has changed (root OR client) or node_modules is missing
+# Note: postinstall in root package.json handles client deps via "cd client && pnpm install"
+$(EXT_DIR)/node_modules: $(EXT_DIR)/package.json $(EXT_DIR)/pnpm-lock.yaml $(EXT_DIR)/client/package.json $(EXT_DIR)/client/pnpm-lock.yaml
 	cd $(EXT_DIR) && pnpm install
 	@touch $@
 
-# Explicit clean install
+# Explicit clean install (force reinstall all deps)
 ext-install:
-	cd $(EXT_DIR) && pnpm install --frozen-lockfile
+	cd $(EXT_DIR) && pnpm install
 
 ext-build: $(EXT_DIR)/node_modules
 	cd $(EXT_DIR) && pnpm run compile


### PR DESCRIPTION
## Problem

After pulling changes that added `jdk-utils` to `editors/code/client/package.json`, running `make ext-vscode` failed because the Makefile's smart install rule only watched the root package files, not the client's:

```
Cannot find module 'jdk-utils' or its corresponding type declarations.
```

## Fix

Update the dependency rule to watch both root AND client package files:

```makefile
# Before: Only watches root
$(EXT_DIR)/node_modules: $(EXT_DIR)/package.json $(EXT_DIR)/pnpm-lock.yaml

# After: Watches root AND client
$(EXT_DIR)/node_modules: $(EXT_DIR)/package.json $(EXT_DIR)/pnpm-lock.yaml \
                         $(EXT_DIR)/client/package.json $(EXT_DIR)/client/pnpm-lock.yaml
```

Now when client dependencies change, Make properly triggers `pnpm install`.

## Also

Removed `--frozen-lockfile` from `ext-install` target to allow lock file updates during development.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates VS Code extension dependency install behavior.
> 
> - Smart install: `$(EXT_DIR)/node_modules` now depends on both root and client `package.json`/`pnpm-lock.yaml`, ensuring `pnpm install` runs when client deps change
> - `ext-install` now runs `pnpm install` without `--frozen-lockfile` to allow lockfile updates during development
> - Inline comments clarified around postinstall handling of client deps
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0dad85944114b07ca2fd5e26d94e13125e1e11b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->