### PR TITLE
fix(e2e): update server status check to use health/quiescent fields

### DIFF
--- a/tests/e2e/resources/scenarios/_completion-import-class.yaml
+++ b/tests/e2e/resources/scenarios/_completion-import-class.yaml
@@ -37,10 +37,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 30000
 
   # Request completion for StringUtils

--- a/tests/e2e/resources/scenarios/_folding-range-basic.yaml
+++ b/tests/e2e/resources/scenarios/_folding-range-basic.yaml
@@ -13,10 +13,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 60000
 
   - openDocument:

--- a/tests/e2e/resources/scenarios/_hover-type-inference.yaml
+++ b/tests/e2e/resources/scenarios/_hover-type-inference.yaml
@@ -24,10 +24,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 30000
 
   # Hover on 'num'

--- a/tests/e2e/resources/scenarios/_implementation-multifile.yaml
+++ b/tests/e2e/resources/scenarios/_implementation-multifile.yaml
@@ -17,10 +17,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 60000
 
   # ============================================================================

--- a/tests/e2e/resources/scenarios/_references-find-usages.yaml
+++ b/tests/e2e/resources/scenarios/_references-find-usages.yaml
@@ -42,10 +42,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 30000
 
   # Test 1: Find references for 'performAction' from definition site

--- a/tests/e2e/resources/scenarios/_rename-symbol.yaml
+++ b/tests/e2e/resources/scenarios/_rename-symbol.yaml
@@ -40,10 +40,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 30000
 
   # Rename 'performAction' to 'doSomething'

--- a/tests/e2e/resources/scenarios/_semantic-tokens-basic.yaml
+++ b/tests/e2e/resources/scenarios/_semantic-tokens-basic.yaml
@@ -22,10 +22,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 60000
 
   - openDocument:

--- a/tests/e2e/resources/scenarios/_workspace-symbols.yaml
+++ b/tests/e2e/resources/scenarios/_workspace-symbols.yaml
@@ -21,10 +21,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 30000
 
   # Search for 'Unique'

--- a/tests/e2e/resources/scenarios/code-action-basic.yaml
+++ b/tests/e2e/resources/scenarios/code-action-basic.yaml
@@ -10,10 +10,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 60000
 
   - openDocument:

--- a/tests/e2e/resources/scenarios/codelens-spock.yaml
+++ b/tests/e2e/resources/scenarios/codelens-spock.yaml
@@ -37,10 +37,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 180000
   - waitNotification:
       method: textDocument/publishDiagnostics

--- a/tests/e2e/resources/scenarios/completion-basic.yaml
+++ b/tests/e2e/resources/scenarios/completion-basic.yaml
@@ -9,10 +9,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 180000
   - openDocument:
       path: src/Main.groovy

--- a/tests/e2e/resources/scenarios/completion-gdk.yaml
+++ b/tests/e2e/resources/scenarios/completion-gdk.yaml
@@ -9,10 +9,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 180000
 
   # Test GDK completion on List

--- a/tests/e2e/resources/scenarios/completion-negative-jenkins.yaml
+++ b/tests/e2e/resources/scenarios/completion-negative-jenkins.yaml
@@ -12,10 +12,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 180000
 
   # Test 1: Regular .groovy file should NOT have Jenkins 'echo' step

--- a/tests/e2e/resources/scenarios/definition-class-reference.yaml
+++ b/tests/e2e/resources/scenarios/definition-class-reference.yaml
@@ -9,10 +9,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 180000
   - openDocument:
       path: 'Classes.groovy'

--- a/tests/e2e/resources/scenarios/definition-local-variable.yaml
+++ b/tests/e2e/resources/scenarios/definition-local-variable.yaml
@@ -9,10 +9,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 180000
   - openDocument:
       path: 'Sample.groovy'

--- a/tests/e2e/resources/scenarios/definition-method-call.yaml
+++ b/tests/e2e/resources/scenarios/definition-method-call.yaml
@@ -28,10 +28,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 30000
 
   # Request definition on 'targetMethod' call at line 9 (0-indexed)

--- a/tests/e2e/resources/scenarios/discover-tests.yaml
+++ b/tests/e2e/resources/scenarios/discover-tests.yaml
@@ -20,10 +20,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 180000
 
   # Custom groovy/discoverTests request - uses typed GroovyLanguageServerProtocol proxy

--- a/tests/e2e/resources/scenarios/document-highlight-basic.yaml
+++ b/tests/e2e/resources/scenarios/document-highlight-basic.yaml
@@ -10,10 +10,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 60000
 
   - openDocument:

--- a/tests/e2e/resources/scenarios/document-symbol-basic.yaml
+++ b/tests/e2e/resources/scenarios/document-symbol-basic.yaml
@@ -8,10 +8,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 180000
   - openDocument:
       path: src/Symbols.groovy

--- a/tests/e2e/resources/scenarios/formatting-basic.yaml
+++ b/tests/e2e/resources/scenarios/formatting-basic.yaml
@@ -11,10 +11,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 60000
 
   # Test 1: Formatting returns edits (basic functionality test)

--- a/tests/e2e/resources/scenarios/implementation-basic.yaml
+++ b/tests/e2e/resources/scenarios/implementation-basic.yaml
@@ -18,10 +18,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 60000
 
   - openDocument:

--- a/tests/e2e/resources/scenarios/implementation-comprehensive.yaml
+++ b/tests/e2e/resources/scenarios/implementation-comprehensive.yaml
@@ -13,10 +13,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 60000
 
   # ============================================================================

--- a/tests/e2e/resources/scenarios/implementation-transitive.yaml
+++ b/tests/e2e/resources/scenarios/implementation-transitive.yaml
@@ -20,10 +20,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 60000
 
   # ============================================================================

--- a/tests/e2e/resources/scenarios/references-basic.yaml
+++ b/tests/e2e/resources/scenarios/references-basic.yaml
@@ -11,10 +11,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 60000
 
   # Test 1: Find references to a class

--- a/tests/e2e/resources/scenarios/rename-basic.yaml
+++ b/tests/e2e/resources/scenarios/rename-basic.yaml
@@ -11,10 +11,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 60000
 
   # Test 1: Rename a local variable

--- a/tests/e2e/resources/scenarios/signature-help-basic.yaml
+++ b/tests/e2e/resources/scenarios/signature-help-basic.yaml
@@ -10,10 +10,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 60000
 
   - openDocument:

--- a/tests/e2e/resources/scenarios/signature-help-gdk.yaml
+++ b/tests/e2e/resources/scenarios/signature-help-gdk.yaml
@@ -8,9 +8,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
-            value: Ready
+            type: EQUALS
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 60000
   - openDocument:
       path: test.groovy

--- a/tests/e2e/resources/scenarios/signature-help.yaml
+++ b/tests/e2e/resources/scenarios/signature-help.yaml
@@ -9,10 +9,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 60000
   - openDocument:
       path: src/Main.groovy

--- a/tests/e2e/resources/scenarios/type-definition-basic.yaml
+++ b/tests/e2e/resources/scenarios/type-definition-basic.yaml
@@ -10,10 +10,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 60000
 
   - openDocument:

--- a/tests/e2e/resources/scenarios/workspace-symbol-basic.yaml
+++ b/tests/e2e/resources/scenarios/workspace-symbol-basic.yaml
@@ -11,10 +11,14 @@ steps:
   - waitNotification:
       method: groovy/status
       checks:
-        - jsonPath: $.status
+        - jsonPath: $.health
           expect:
             type: EQUALS
-            value: Ready
+            value: ok
+        - jsonPath: $.quiescent
+          expect:
+            type: EQUALS
+            value: true
       timeoutMs: 60000
 
   # Open a file to populate the workspace symbols


### PR DESCRIPTION
## Description

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns e2e tests with the new `groovy/status` schema for server readiness.
> 
> - Replaces `checks` from `$.status == Ready` to `$.health == ok` and `$.quiescent == true` across multiple scenario YAMLs
> - No other test logic modified; only readiness gating updated
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e98ed7597497490bb39f34ea2ccc20f304655a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test scenarios across multiple language features to align with enhanced health check validation mechanisms. Tests now verify refined health status indicators and quiescent state flags, improving system readiness validation for code completion, navigation, refactoring, and other IDE operations across all test scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->