### PR TITLE
feat(core): expose declaration AST node in resolution API (#529)

### DIFF
--- a/groovyparser-core/src/main/kotlin/com/github/albertocavalcante/groovyparser/resolution/declarations/ResolvedValueDeclaration.kt
+++ b/groovyparser-core/src/main/kotlin/com/github/albertocavalcante/groovyparser/resolution/declarations/ResolvedValueDeclaration.kt
@@ -1,5 +1,6 @@
 package com.github.albertocavalcante.groovyparser.resolution.declarations
 
+import com.github.albertocavalcante.groovyparser.ast.Node
 import com.github.albertocavalcante.groovyparser.resolution.types.ResolvedType
 
 /**
@@ -11,4 +12,12 @@ interface ResolvedValueDeclaration : ResolvedDeclaration {
      * The type of this value.
      */
     val type: ResolvedType
+
+    /**
+     * The AST node representing this declaration, if available.
+     * Used for navigation to the declaration's source location (go-to-definition).
+     * Returns null for declarations from reflection (e.g., JDK classes).
+     */
+    val declarationNode: Node?
+        get() = null
 }

--- a/groovyparser-core/src/main/kotlin/com/github/albertocavalcante/groovyparser/resolution/groovymodel/GroovyParserFieldDeclaration.kt
+++ b/groovyparser-core/src/main/kotlin/com/github/albertocavalcante/groovyparser/resolution/groovymodel/GroovyParserFieldDeclaration.kt
@@ -1,5 +1,6 @@
 package com.github.albertocavalcante.groovyparser.resolution.groovymodel
 
+import com.github.albertocavalcante.groovyparser.ast.Node
 import com.github.albertocavalcante.groovyparser.ast.body.FieldDeclaration
 import com.github.albertocavalcante.groovyparser.resolution.TypeSolver
 import com.github.albertocavalcante.groovyparser.resolution.declarations.ResolvedFieldDeclaration
@@ -19,6 +20,9 @@ class GroovyParserFieldDeclaration(
 
     override val type: ResolvedType
         get() = GroovyParserTypeResolver.resolveType(fieldDecl.type, typeSolver)
+
+    override val declarationNode: Node
+        get() = fieldDecl
 
     override fun isStatic(): Boolean = fieldDecl.isStatic
 

--- a/groovyparser-core/src/main/kotlin/com/github/albertocavalcante/groovyparser/resolution/groovymodel/GroovyParserParameterDeclaration.kt
+++ b/groovyparser-core/src/main/kotlin/com/github/albertocavalcante/groovyparser/resolution/groovymodel/GroovyParserParameterDeclaration.kt
@@ -1,5 +1,6 @@
 package com.github.albertocavalcante.groovyparser.resolution.groovymodel
 
+import com.github.albertocavalcante.groovyparser.ast.Node
 import com.github.albertocavalcante.groovyparser.ast.body.Parameter
 import com.github.albertocavalcante.groovyparser.resolution.TypeSolver
 import com.github.albertocavalcante.groovyparser.resolution.declarations.ResolvedParameterDeclaration
@@ -15,6 +16,9 @@ class GroovyParserParameterDeclaration(private val param: Parameter, private val
 
     override val type: ResolvedType
         get() = GroovyParserTypeResolver.resolveType(param.type, typeSolver)
+
+    override val declarationNode: Node
+        get() = param
 
     override fun isVariadic(): Boolean = false // Not supported in AST yet
 

--- a/groovyparser-core/src/test/kotlin/com/github/albertocavalcante/groovyparser/resolution/DeclarationNodeExposureTest.kt
+++ b/groovyparser-core/src/test/kotlin/com/github/albertocavalcante/groovyparser/resolution/DeclarationNodeExposureTest.kt
@@ -1,0 +1,109 @@
+package com.github.albertocavalcante.groovyparser.resolution
+
+import com.github.albertocavalcante.groovyparser.GroovyParser
+import com.github.albertocavalcante.groovyparser.ast.Node
+import com.github.albertocavalcante.groovyparser.ast.body.ClassDeclaration
+import com.github.albertocavalcante.groovyparser.ast.body.Parameter
+import com.github.albertocavalcante.groovyparser.ast.expr.VariableExpr
+import com.github.albertocavalcante.groovyparser.ast.stmt.BlockStatement
+import com.github.albertocavalcante.groovyparser.resolution.typesolvers.CombinedTypeSolver
+import com.github.albertocavalcante.groovyparser.resolution.typesolvers.ReflectionTypeSolver
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests that resolved declarations expose their source AST nodes
+ * for navigation purposes (go-to-definition).
+ */
+class DeclarationNodeExposureTest {
+
+    private val typeSolver = CombinedTypeSolver(ReflectionTypeSolver())
+    private val parser = GroovyParser()
+
+    @Test
+    fun `parameter declaration exposes its AST node`() {
+        val cu = parser.parse(
+            """
+            class Test {
+                void greet(String name) {
+                    println name
+                }
+            }
+            """.trimIndent(),
+        ).result.get()
+
+        val classDecl = cu.types.first() as ClassDeclaration
+        val method = classDecl.methods.first()
+        val block = method.body as? BlockStatement ?: error("No block statement found")
+        val stmt = block.statements.first()
+
+        // Find the variable expression (usage of 'name' parameter)
+        val nameExpr = findVariableExpr(stmt, "name")
+            ?: error("No VariableExpr 'name' found in println statement")
+
+        val resolver = GroovySymbolResolver(typeSolver)
+        val symbolRef = resolver.solveSymbol("name", nameExpr)
+
+        assertTrue(symbolRef.isSolved, "Symbol 'name' should be resolved")
+
+        val declaration = symbolRef.getDeclaration()
+        assertNotNull(declaration.declarationNode, "Declaration should expose its AST node")
+
+        // The node should be the Parameter node
+        val declNode = declaration.declarationNode
+        assertTrue(declNode is Parameter, "Declaration node should be a Parameter")
+        assertEquals("name", (declNode as Parameter).name)
+    }
+
+    @Test
+    fun `field declaration exposes its AST node`() {
+        val cu = parser.parse(
+            """
+            class Test {
+                String message = 'hello'
+                
+                void print() {
+                    println message
+                }
+            }
+            """.trimIndent(),
+        ).result.get()
+
+        val classDecl = cu.types.first() as ClassDeclaration
+        val method = classDecl.methods.first()
+        val block = method.body as? BlockStatement ?: error("No block statement found")
+        val stmt = block.statements.first()
+
+        // Find the variable expression (usage of 'message' field)
+        val messageExpr = findVariableExpr(stmt, "message")
+            ?: error("No VariableExpr 'message' found in println statement")
+
+        val resolver = GroovySymbolResolver(typeSolver)
+        val symbolRef = resolver.solveSymbol("message", messageExpr)
+
+        assertTrue(symbolRef.isSolved, "Symbol 'message' should be resolved")
+
+        val declaration = symbolRef.getDeclaration()
+        assertNotNull(declaration.declarationNode, "Declaration should expose its AST node")
+
+        // Verify the node has the correct source position
+        val declNode = declaration.declarationNode
+        assertNotNull(declNode?.range, "Declaration node should have a range")
+    }
+
+    /**
+     * Recursively finds a VariableExpr with the given name in the AST.
+     */
+    private fun findVariableExpr(node: Node, name: String): VariableExpr? {
+        if (node is VariableExpr && node.name == name) {
+            return node
+        }
+        for (child in node.getChildNodes()) {
+            val found = findVariableExpr(child, name)
+            if (found != null) return found
+        }
+        return null
+    }
+}


### PR DESCRIPTION
## Problem

`CoreDefinitionService` could resolve symbols but could not navigate to their source definition because `ResolvedValueDeclaration` only exposed the type, not the AST node.

## Solution

Extended the resolution API to expose the underlying AST node:
1. Added `declarationNode` property to `ResolvedValueDeclaration` interface.
2. Implemented it for `GroovyParserParameterDeclaration` and `GroovyParserFieldDeclaration`.
3. Updated `CoreDefinitionService` to use this property for precise navigation.

## Verification

- Added `DeclarationNodeExposureTest` verifying AST node access for parameters and fields.
- `CoreDefinitionServiceTest` passed.
- `groovyparser-core` tests passed.

## References

- Issue #529

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves go-to-definition by navigating to the declaration's source range using exposed AST nodes.
> 
> - Add `declarationNode` to `ResolvedValueDeclaration` for accessing the underlying AST node
> - Implement `declarationNode` in `GroovyParserParameterDeclaration` and `GroovyParserFieldDeclaration`
> - Update `CoreDefinitionService` to resolve references and jump to the declaration node's range
> - Add `DeclarationNodeExposureTest` validating AST node exposure for parameters and fields
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52d8d277c45b6fa407a3a63cc429f02a64b4904f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced go-to-definition functionality to reliably navigate to field and parameter declarations by leveraging source location data that was previously inaccessible, improving code navigation accuracy.

* **Tests**
  * Added test coverage validating declaration source exposure for go-to-definition navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->