### PR TITLE
feat(core): functionality for contextual completions (#530)

### DIFF
--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/engine/impl/core/features/CoreCompletionServiceTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/engine/impl/core/features/CoreCompletionServiceTest.kt
@@ -2,6 +2,7 @@ package com.github.albertocavalcante.groovylsp.engine.impl.core.features
 
 import com.github.albertocavalcante.groovylsp.engine.adapters.ParseUnit
 import com.github.albertocavalcante.groovylsp.engine.adapters.UnifiedNode
+import com.github.albertocavalcante.groovylsp.engine.adapters.UnifiedNodeKind
 import com.github.albertocavalcante.groovylsp.engine.adapters.UnifiedSymbol
 import com.github.albertocavalcante.groovyparser.GroovyParser
 import com.github.albertocavalcante.groovyparser.ParserConfiguration
@@ -9,6 +10,7 @@ import kotlinx.coroutines.runBlocking
 import org.eclipse.lsp4j.CompletionParams
 import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -64,6 +66,48 @@ class CoreCompletionServiceTest {
         assertTrue(result.isLeft)
         // Should still return basic completions even without context
         assertFalse(result.left.isEmpty())
+    }
+
+    @Test
+    fun `getCompletions includes symbols from context`(): Unit = runBlocking {
+        val service = CoreCompletionService()
+        val params = CompletionParams(TextDocumentIdentifier("file:///test.groovy"), Position(2, 0))
+
+        // Create a mock ParseUnit with some symbols
+        val parseUnit = object : ParseUnit {
+            override val uri: String = "file:///test.groovy"
+            override val isSuccessful: Boolean = true
+            override val diagnostics: List<Diagnostic> = emptyList()
+            override fun nodeAt(position: Position): UnifiedNode? = null
+            override fun allSymbols(): List<UnifiedSymbol> = listOf(
+                UnifiedSymbol(
+                    "myVariable",
+                    UnifiedNodeKind.VARIABLE,
+                    Range(Position(0, 0), Position(0, 10)),
+                    Range(Position(0, 0), Position(0, 10)),
+                ),
+                UnifiedSymbol(
+                    "myMethod",
+                    UnifiedNodeKind.METHOD,
+                    Range(Position(1, 0), Position(1, 10)),
+                    Range(Position(1, 0), Position(1, 10)),
+                ),
+            )
+        }
+
+        val result = service.getCompletions(params, parseUnit, "")
+
+        assertTrue(result.isLeft)
+        val labels = result.left.map { it.label }
+        val kinds = result.left.associate { it.label to it.kind }
+
+        assertTrue(labels.contains("myVariable"))
+        assertTrue(labels.contains("myMethod"))
+
+        // Verify kinds mapping
+        // Need to import CompletionItemKind
+        assertTrue(kinds["myVariable"] == org.eclipse.lsp4j.CompletionItemKind.Variable)
+        assertTrue(kinds["myMethod"] == org.eclipse.lsp4j.CompletionItemKind.Method)
     }
 
     // Helper to create a ParseUnit from code


### PR DESCRIPTION
## Problem

`CoreCompletionService` only provided static keyword and type completions, missing context-aware suggestions like defined variables and methods.

## Solution

Enhanced `CoreCompletionService` to include symbols from the current `ParseUnit`:
1. Iterates over `context.allSymbols()`.
2. Maps `UnifiedNodeKind` to LSP `CompletionItemKind`.
3. Adds these symbols to the completion list.

## Verification

- Added `CoreCompletionServiceTest` case "getCompletions includes symbols from context" which verifies that mock symbols are correctly mapped and returned.
- Verified existing tests pass.

## References

- Issue #530
- Part of Core Engine Migration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds context-aware completions to the core engine and verifies mapping via unit tests.
> 
> - Enhances `CoreCompletionService` to append symbols from `context.allSymbols()` to completion items, mapping `UnifiedNodeKind` to LSP `CompletionItemKind` via `mapSymbolKind`
> - Keeps existing keyword and basic type suggestions intact
> - Adds test `CoreCompletionServiceTest` to assert symbols are returned and correctly typed (e.g., `VARIABLE` -> `Variable`, `METHOD` -> `Method`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 908accbb92b79c670e08c71b127ff8ab21b08ae7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->