### PR TITLE
chore: absorb worktree improvements (doc/config updates)

### DIFF
--- a/.agent/workflows/defer.md
+++ b/.agent/workflows/defer.md
@@ -18,10 +18,13 @@ Use this workflow when you encounter work that should NOT be addressed in the cu
 
 ## Step 1: Create Issue
 
+> [!IMPORTANT]
+> **Always use a temp file for the issue body.** Inline `--body` gets truncated with complex content.
+
 ```bash
-gh issue create -R albertocavalcante/groovy-lsp \
-  --title "[area] Brief description" \
-  --body "## Problem
+# 1. Write body to temp file
+cat > /tmp/issue-body.md << 'EOF'
+## Problem
 [Describe the limitation or improvement needed]
 
 ## Context
@@ -32,8 +35,16 @@ gh issue create -R albertocavalcante/groovy-lsp \
 
 ## References
 - PR #NNN (if applicable)
-" \
+EOF
+
+# 2. Create issue with --body-file
+gh issue create -R albertocavalcante/groovy-lsp \
+  --title "[area] Brief description" \
+  --body-file /tmp/issue-body.md \
   --label "enhancement" --label "P3-nice" --label "size/M"
+
+# 3. Clean up
+rm /tmp/issue-body.md
 ```
 
 ### Label Formula

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,8 +70,9 @@ git fetch origin main
 # Step 2: Create worktree with new branch from origin/main
 git worktree add -b fix/my-feature ../groovy-lsp-my-feature origin/main
 
-# Step 3: Work ONLY in the new worktree directory
+# Step 3: Enable direnv in the new worktree
 cd ../groovy-lsp-my-feature
+direnv allow
 
 # Step 4: Push and create PR
 git push -u origin fix/my-feature

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,8 @@ dependencyResolutionManagement {
 rootProject.name = "groovy-lsp-root"
 
 include("groovy-formatter")
+// TODO(#524): Restructure parser modules under parser/ folder.
+//   See: https://github.com/albertocavalcante/gvy/issues/524
 include("groovy-parser")
 include("groovy-common")
 include("groovy-lsp")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves contributor docs and minor build config notes.
> 
> - **/defer workflow**: Switches `gh issue create` to use a temp file with `--body-file`, adds explicit create/cleanup steps
> - **AGENTS.md**: Updates worktree setup to include enabling `direnv` in the new worktree
> - **settings.gradle.kts**: Adds TODO comment referencing issue to restructure parser modules
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 355ba85caaff6025f44a47eba79ed99e44b009fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->