### PR TITLE
fix(build): exclude Ktor/kotlinx-serialization from shadowJar minimize

### DIFF
--- a/groovy-lsp/build.gradle.kts
+++ b/groovy-lsp/build.gradle.kts
@@ -300,6 +300,9 @@ tasks.shadowJar {
             exclude(dependency("com.github.ajalt.clikt:.*"))
             exclude(dependency("com.github.ajalt.mordant:.*"))
             exclude(dependency("net.java.dev.jna:.*"))
+            // Ktor and kotlinx-serialization use ServiceLoader for runtime providers
+            exclude(dependency("io.ktor:.*"))
+            exclude(dependency("org.jetbrains.kotlinx:kotlinx-serialization-.*"))
         }
     }
 }


### PR DESCRIPTION
The shadowJar minimize feature was stripping out Ktor's JSON serialization
service provider classes because they're loaded via ServiceLoader reflection
at runtime. This caused ServiceConfigurationError in e2e tests when
PluginDownloader initialized the HTTP client with ContentNegotiation.json().

Added exclusions for io.ktor and kotlinx-serialization dependencies to
preserve ServiceLoader provider files in META-INF/services.

Fixes the completion-gdk and other e2e test failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents runtime ServiceLoader providers from being stripped by `shadowJar` minimization.
> 
> - Adds minimize exclusions for `io.ktor:*` and `org.jetbrains.kotlinx:kotlinx-serialization-*` to retain provider files in `META-INF/services`
> - Addresses e2e `ServiceConfigurationError` when initializing Ktor JSON content negotiation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42a29f4ffb382dfbecd75e6d030210f198e1b237. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build artifact generation to ensure runtime dependencies function correctly during application execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->