### PR TITLE
fix(completion): refine import completions

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/CompletionProvider.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/CompletionProvider.kt
@@ -548,6 +548,9 @@ object CompletionProvider {
         val replaceEndCharacter: Int,
     )
 
+    /**
+     * Detects whether the cursor is in an import statement and extracts prefix/replacement info.
+     */
     private fun detectImportCompletionContext(ctx: CompletionContext): ImportCompletionContext? {
         val lines = ctx.content.split('\n')
         if (ctx.line !in lines.indices) return null
@@ -752,6 +755,9 @@ object CompletionProvider {
         }
     }
 
+    /**
+     * Adds import-specific completions (static keyword and matching class names).
+     */
     private fun CompletionsBuilder.addImportCompletions(
         ctx: ImportCompletionContext,
         compilationService: GroovyCompilationService,
@@ -764,7 +770,11 @@ object CompletionProvider {
         }
 
         val prefix = ctx.prefix.trim()
-        if (prefix.isBlank()) return
+        if (prefix.isBlank()) {
+            // TODO(#575): Provide curated suggestions for empty import prefixes.
+            //   See: https://github.com/albertocavalcante/gvy/issues/575
+            return
+        }
 
         val classpathService = compilationService.classpathService
         val candidates = if (prefix.contains('.')) {

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/services/ClasspathService.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/services/ClasspathService.kt
@@ -204,6 +204,9 @@ class ClasspathService(
     }
 
     internal class QualifiedNameIndex {
+        /**
+         * Thread-safe index of fully qualified class names for prefix lookups.
+         */
         private val index = ConcurrentSkipListSet<String>()
 
         fun add(fullName: String) {

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/ImportCompletionTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/ImportCompletionTest.kt
@@ -55,6 +55,7 @@ class ImportCompletionTest {
             "build",
             "buildDockerAndPublishImage",
             "archiveArtifacts",
+            // Ensure internal dummy identifiers do not leak into import completions.
             "BrazilWorldCup2026",
             "class",
             "def",


### PR DESCRIPTION
## Summary
- scope completions in import lines to static + qualified class names
- avoid unrelated keyword/local symbol suggestions in import context
- expand import completion tests for negative cases and static imports

## Testing
- ./gradlew :groovy-lsp:test --tests "com.github.albertocavalcante.groovylsp.providers.completion.ImportCompletionTest"

## Lint
- ./gradlew lintFix (fails in parser/core: existing detekt violations)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves accuracy of import-line completions and supports qualified class lookups.
> 
> - Adds import context detection in `CompletionProvider` and `addImportCompletions` to suggest only `static` and matching class names; applies precise `textEdit` replacement ranges
> - Introduces `MAX_IMPORT_COMPLETION_RESULTS` limit and leverages classpath search by simple or qualified prefix
> - Extends `ClasspathService` with a thread-safe qualified-name index and `findClassesByQualifiedPrefix`, clearing/rebuilding indexes on classpath update
> - Adds `ImportCompletionTest` covering qualified prefix suggestions, static import behavior, edit range replacement, and ignoring comments (CRLF)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a20ef928f7ec320cc2107000abe52e8b798278e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smart import auto-completion that suggests available classes, recognizes qualified prefixes (e.g., java.util.List) and supports static import suggestions.
  * Improved class discovery to enable searching by fully-qualified name prefixes.

* **Tests**
  * Added tests covering import completion behavior, qualified-prefix handling, and static import scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->