### PR TITLE
chore(lint): clean detekt baselines and test warnings

### DIFF
--- a/groovy-lsp/detekt-baseline.xml
+++ b/groovy-lsp/detekt-baseline.xml
@@ -31,12 +31,7 @@
     <ID>MagicNumber:JenkinsDocProvider.kt$JenkinsDocProvider$100</ID>
     <ID>MagicNumber:SourceNavigationService.kt$SourceNavigationService$3</ID>
     <ID>MaxLineLength:CompletionProvider.kt$CompletionProvider$// This helps in class bodies: "class Foo { def BrazilWorldCup2026 }" is valid, but "class Foo { BrazilWorldCup2026 }" is not.</ID>
-    <ID>MaxLineLength:DefinitionResolverFallbackTest.kt$DefinitionResolverFallbackTest.ImportNodeResolutionTest$"jar:file:///home/user/.m2/repository/com/google/code/gson/gson/2.10.1/gson-2.10.1.jar!/com/google/gson/Gson.class"</ID>
-    <ID>MaxLineLength:DefinitionResolverFallbackTest.kt$DefinitionResolverFallbackTest.SourceNavigationSuccessTest$"jar:file:///home/user/.m2/repository/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar!/org/apache/commons/lang3/StringUtils.class"</ID>
-    <ID>MaxLineLength:DefinitionResolverFallbackTest.kt$DefinitionResolverFallbackTest.SourceNavigationSuccessTest$"jar:file:///home/user/.m2/repository/org/slf4j/slf4j-api/2.0.9/slf4j-api-2.0.9.jar!/org/slf4j/Logger.class"</ID>
     <ID>MaxLineLength:Main.kt$"${file.path}:${d.range.start.line + 1}:${d.range.start.character + 1}: [$severity] ${d.message}"</ID>
-    <ID>MaximumLineLength:DefinitionResolverFallbackTest.kt$DefinitionResolverFallbackTest.ImportNodeResolutionTest$ </ID>
-    <ID>MaximumLineLength:DefinitionResolverFallbackTest.kt$DefinitionResolverFallbackTest.SourceNavigationSuccessTest$ </ID>
     <ID>MaximumLineLength:Main.kt$ </ID>
     <ID>NestedBlockDepth:CompletionProvider.kt$CompletionProvider$private fun detectCompletionContext( nodeAtCursor: org.codehaus.groovy.ast.ASTNode?, astModel: com.github.albertocavalcante.groovyparser.ast.GroovyAstModel, context: SymbolCompletionContext, ): ContextType?</ID>
     <ID>NestedBlockDepth:CompletionProvider.kt$CompletionProvider$suspend fun getContextualCompletions( uri: String, line: Int, character: Int, compilationService: GroovyCompilationService, content: String, ): List&lt;CompletionItem></ID>
@@ -87,8 +82,5 @@
     <ID>TooManyFunctions:DefinitionResolver.kt$DefinitionResolver</ID>
     <ID>TooManyFunctions:GroovyCompilationService.kt$GroovyCompilationService</ID>
     <ID>TooManyFunctions:GroovyTextDocumentService.kt$GroovyTextDocumentService : TextDocumentService</ID>
-    <ID>UnusedParameter:MultipleDiagnosticsPropertyTest.kt$MultipleDiagnosticsPropertyTest$onlyRegistered: Boolean</ID>
-    <ID>UnusedPrivateProperty:JenkinsDocProvider.kt$JenkinsDocProvider$private val logger = LoggerFactory.getLogger(JenkinsDocProvider::class.java)</ID>
-    <ID>UnusedPrivateProperty:JenkinsStepCompletionProvider.kt$JenkinsStepCompletionProvider$private val logger = LoggerFactory.getLogger(JenkinsStepCompletionProvider::class.java)</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/documentation/JenkinsDocProvider.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/documentation/JenkinsDocProvider.kt
@@ -7,7 +7,6 @@ import com.github.albertocavalcante.groovyparser.ast.GroovyAstModel
 import kotlinx.coroutines.runBlocking
 import org.codehaus.groovy.ast.ASTNode
 import org.codehaus.groovy.ast.expr.MethodCallExpression
-import org.slf4j.LoggerFactory
 import java.net.URI
 
 /**
@@ -24,8 +23,6 @@ class JenkinsDocProvider(
     private val jenkinsPluginManager: JenkinsPluginManager = JenkinsPluginManager(),
     private val jenkinsContext: JenkinsContext? = null,
 ) : PluggableDocProvider {
-
-    private val logger = LoggerFactory.getLogger(JenkinsDocProvider::class.java)
 
     override val name: String = "Jenkins Documentation Provider"
     override val priority: Int = 100 // High priority - check before generic Groovy

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/GroovyLanguageServerFeatureMatrixTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/GroovyLanguageServerFeatureMatrixTest.kt
@@ -151,6 +151,7 @@ class GroovyLanguageServerFeatureMatrixTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `workspace symbol search returns matches`() = runBlocking {
         val result: Either<List<SymbolInformation>, List<WorkspaceSymbol>> =
             server.workspaceService.symbol(WorkspaceSymbolParams("Greeter")).get()

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/documentation/DocExtractorTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/documentation/DocExtractorTest.kt
@@ -60,7 +60,7 @@ class DocExtractorTest {
             Parameter(ClassHelper.int_TYPE, "b"),
         )
         val classNode = ClassNode("Script", 0, null)
-        val node = MethodNode("add", 0, ClassHelper.DYNAMIC_TYPE, params, null, BlockStatement())
+        val node = MethodNode("add", 0, ClassHelper.dynamicType(), params, null, BlockStatement())
         node.declaringClass = classNode
         node.lineNumber = lineOf(source, "def add")
 

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/engine/NativeLanguageEngineTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/engine/NativeLanguageEngineTest.kt
@@ -265,9 +265,7 @@ class NativeLanguageEngineTest {
         for (diagnostic in diagnostics) {
             count++
         }
-        assertEquals(0, count, "Valid code should have zero diagnostics")
-
-        // Should be a proper list
-        assertTrue(diagnostics is List, "Diagnostics should be a List")
+        assertEquals(diagnostics.size, count, "Diagnostics list should be iterable")
+        assertTrue(diagnostics.isEmpty(), "Valid code should have zero diagnostics")
     }
 }

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/codeaction/MultipleDiagnosticsPropertyTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/codeaction/MultipleDiagnosticsPropertyTest.kt
@@ -120,7 +120,7 @@ class MultipleDiagnosticsPropertyTest {
     fun diagnosticLists(): Arbitrary<DiagnosticList> {
         // Generate lists of 1-5 diagnostics with registered handlers
         return Arbitraries.integers().between(1, 5).flatMap { count ->
-            generateDiagnosticList(count, onlyRegistered = true)
+            generateDiagnosticList(count)
         }
     }
 
@@ -135,7 +135,7 @@ class MultipleDiagnosticsPropertyTest {
     /**
      * Generates a list of diagnostics with appropriate content.
      */
-    private fun generateDiagnosticList(count: Int, onlyRegistered: Boolean): Arbitrary<DiagnosticList> {
+    private fun generateDiagnosticList(count: Int): Arbitrary<DiagnosticList> {
         val registeredRules = FixHandlerRegistry.getRegisteredRules().toList()
 
         return Arbitraries.integers().between(0, registeredRules.size - 1)

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/definition/DefinitionResolverFallbackTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/definition/DefinitionResolverFallbackTest.kt
@@ -46,6 +46,8 @@ class DefinitionResolverFallbackTest {
         return node
     }
 
+    private fun buildUri(vararg parts: String): URI = URI.create(parts.joinToString(separator = ""))
+
     @Nested
     inner class SourceNavigationSuccessTest {
         /**
@@ -68,11 +70,13 @@ class DefinitionResolverFallbackTest {
             every { compilationService.getAllSymbolStorages() } returns emptyMap()
             every { compilationService.getAst(documentUri) } returns null
 
-            val jarUri = URI.create(
-                "jar:file:///home/user/.m2/repository/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar!/org/apache/commons/lang3/StringUtils.class",
+            val jarUri = buildUri(
+                "jar:file:///home/user/.m2/repository/org/apache/commons/commons-lang3/3.12.0/",
+                "commons-lang3-3.12.0.jar!/org/apache/commons/lang3/StringUtils.class",
             )
-            val extractedSourceUri = URI.create(
-                "file:///home/user/.gls/cache/extracted-sources/org/apache/commons/lang3/StringUtils.java",
+            val extractedSourceUri = buildUri(
+                "file:///home/user/.gls/cache/extracted-sources/org/apache/commons/lang3/",
+                "StringUtils.java",
             )
 
             every { compilationService.findClasspathClass("org.apache.commons.lang3.StringUtils") } returns jarUri
@@ -113,10 +117,14 @@ class DefinitionResolverFallbackTest {
             every { compilationService.getAllSymbolStorages() } returns emptyMap()
             every { compilationService.getAst(documentUri) } returns null
 
-            val jarUri = URI.create(
-                "jar:file:///home/user/.m2/repository/org/slf4j/slf4j-api/2.0.9/slf4j-api-2.0.9.jar!/org/slf4j/Logger.class",
+            val jarUri = buildUri(
+                "jar:file:///home/user/.m2/repository/org/slf4j/slf4j-api/2.0.9/",
+                "slf4j-api-2.0.9.jar!/org/slf4j/Logger.class",
             )
-            val sourceUri = URI.create("file:///home/user/.gls/cache/extracted-sources/org/slf4j/Logger.java")
+            val sourceUri = buildUri(
+                "file:///home/user/.gls/cache/extracted-sources/org/slf4j/",
+                "Logger.java",
+            )
             every { compilationService.findClasspathClass("org.slf4j.Logger") } returns jarUri
 
             coEvery {
@@ -309,11 +317,13 @@ class DefinitionResolverFallbackTest {
             every { astVisitor.getAllClassNodes() } returns emptyList()
             every { compilationService.getAllSymbolStorages() } returns emptyMap()
 
-            val jarUri = URI.create(
-                "jar:file:///home/user/.m2/repository/com/google/code/gson/gson/2.10.1/gson-2.10.1.jar!/com/google/gson/Gson.class",
+            val jarUri = buildUri(
+                "jar:file:///home/user/.m2/repository/com/google/code/gson/gson/2.10.1/",
+                "gson-2.10.1.jar!/com/google/gson/Gson.class",
             )
-            val extractedSourceUri = URI.create(
-                "file:///home/user/.gls/cache/extracted-sources/com/google/gson/Gson.java",
+            val extractedSourceUri = buildUri(
+                "file:///home/user/.gls/cache/extracted-sources/com/google/gson/",
+                "Gson.java",
             )
             every { compilationService.findClasspathClass("com.google.gson.Gson") } returns jarUri
 

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/inlayhints/InlayHintsProviderTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/inlayhints/InlayHintsProviderTest.kt
@@ -66,7 +66,7 @@ class InlayHintsProviderTest {
             val varExpr = VariableExpression("name").apply {
                 lineNumber = 1
                 columnNumber = 5
-                type = ClassHelper.DYNAMIC_TYPE
+                type = ClassHelper.dynamicType()
             }
             val constExpr = ConstantExpression("hello").apply {
                 type = ClassHelper.STRING_TYPE

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/symbols/SymbolLspExtensionsTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/symbols/SymbolLspExtensionsTest.kt
@@ -17,6 +17,7 @@ import java.net.URI
 class SymbolLspExtensionsTest {
 
     @Test
+    @Suppress("DEPRECATION")
     fun `class symbol converts to document and symbol information`() {
         val classNode = ClassNode("Greeter", Modifier.PUBLIC, ClassHelper.OBJECT_TYPE).apply {
             setLineNumber(1)
@@ -44,6 +45,7 @@ class SymbolLspExtensionsTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `method symbol includes signature in detail`() {
         val classNode = ClassNode("Greeter", Modifier.PUBLIC, ClassHelper.OBJECT_TYPE)
         val methodNode = MethodNode(

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/typedefinition/TypeDefinitionProviderTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/typedefinition/TypeDefinitionProviderTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.net.URI
 import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class TypeDefinitionProviderTest {
@@ -66,6 +67,6 @@ class TypeDefinitionProviderTest {
         )
 
         // Then
-        assertTrue(provider is TypeDefinitionProvider)
+        assertEquals(TypeDefinitionProvider::class, provider::class)
     }
 }

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/test/LspTestFixture.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/test/LspTestFixture.kt
@@ -70,9 +70,14 @@ class LspTestFixture {
         assertTrue(hover != null, "Hover should not be null at $line:$char")
 
         val content = if (hover!!.contents.isLeft) {
-            hover.contents.left.first().let {
-                // Handle LSP4J string unions safely
-                if (it is org.eclipse.lsp4j.MarkedString) it.value else (it as String)
+            // Handle LSP4J string unions safely.
+            val marked = hover.contents.left.first()
+            if (marked.isLeft) {
+                marked.left
+            } else {
+                @Suppress("DEPRECATION")
+                val legacy = marked.right
+                legacy.value
             }
         } else {
             hover.contents.right.value

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/types/SimpleTypeTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/types/SimpleTypeTest.kt
@@ -3,7 +3,6 @@ package com.github.albertocavalcante.groovylsp.types
 import com.github.albertocavalcante.groovyparser.ast.NodeRelationshipTracker
 import com.github.albertocavalcante.groovyparser.ast.visitor.RecursiveAstVisitor
 import groovy.lang.GroovyClassLoader
-import org.codehaus.groovy.ast.ModuleNode
 import org.codehaus.groovy.control.CompilationUnit
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.codehaus.groovy.control.Phases
@@ -36,7 +35,7 @@ class SimpleTypeTest {
         val module = sourceUnit.ast
 
         assertNotNull(module, "Should have compiled AST")
-        assertTrue(module is ModuleNode, "Should be ModuleNode")
+        assertTrue(module.classes.isNotEmpty(), "Should contain class nodes")
 
         // Try AST visitor
         val tracker = NodeRelationshipTracker()

--- a/parser/native/detekt-baseline.xml
+++ b/parser/native/detekt-baseline.xml
@@ -13,18 +13,12 @@
     <ID>MagicNumber:AstPositionQuery.kt$AstPositionQuery$5</ID>
     <ID>MagicNumber:AstPositionQuery.kt$AstPositionQuery$6</ID>
     
-    <ID>MaxLineLength:SymbolExtractor.kt$SymbolExtractor$// println("DEBUG: Checking class ${classNode.name}, line=${classNode.lineNumber}-${classNode.lastLineNumber}, cursor=$line")</ID>
     
     <ID>NestedBlockDepth:SymbolExtractor.kt$SymbolExtractor$fun extractVariableSymbols(methodNode: Any): List&lt;VariableSymbol></ID>
     <ID>SwallowedException:SymbolExtractor.kt$SymbolExtractor$e: Exception</ID>
     <ID>ThrowsCount:TypeInferencerTest.kt$TypeInferencerTest$private fun inferTypeFromFirstDeclaration(code: String): String</ID>
     <ID>TooGenericExceptionCaught:SymbolExtractor.kt$SymbolExtractor$e: Exception</ID>
     <ID>UnusedParameter:SymbolExtractor.kt$SymbolExtractor$character: Int</ID>
-    <ID>UnusedPrivateProperty:KitchenSinkCoverageTest.kt$KitchenSinkCoverageTest$val caseStmt = assertNotNull( allNodes.filterIsInstance&lt;org.codehaus.groovy.ast.stmt.CaseStatement>().firstOrNull(), "Should find CaseStatement", )</ID>
-    <ID>UnusedPrivateProperty:KitchenSinkCoverageTest.kt$KitchenSinkCoverageTest$val gstring = assertNotNull(allNodes.filterIsInstance&lt;GStringExpression>().firstOrNull(), "Should find GStringExpression")</ID>
-    <ID>UnusedPrivateProperty:KitchenSinkCoverageTest.kt$KitchenSinkCoverageTest$val innerClass = assertNotNull(classNodes.find { it.name == "com.example.KitchenSink\$Inner" }, "Should find Inner class")</ID>
-    <ID>UnusedPrivateProperty:KitchenSinkCoverageTest.kt$KitchenSinkCoverageTest$val switchStmt = assertNotNull( allNodes.filterIsInstance&lt;SwitchStatement>().firstOrNull(), "Should find SwitchStatement (Testing coverage/bug)", )</ID>
-    <ID>UnusedPrivateProperty:KitchenSinkCoverageTest.kt$KitchenSinkCoverageTest$val tryCatch = assertNotNull(allNodes.filterIsInstance&lt;TryCatchStatement>().firstOrNull(), "Should find TryCatchStatement")</ID>
     <ID>UseCheckOrError:TypeInferencerTest.kt$TypeInferencerTest$throw IllegalStateException("Failed to parse AST")</ID>
     <ID>UseCheckOrError:TypeInferencerTest.kt$TypeInferencerTest$throw IllegalStateException("First statement is not a declaration: $statement")</ID>
     <ID>UseCheckOrError:TypeInferencerTest.kt$TypeInferencerTest$throw IllegalStateException("No statements found")</ID>

--- a/parser/native/src/main/kotlin/com/github/albertocavalcante/groovyparser/ast/SymbolExtractor.kt
+++ b/parser/native/src/main/kotlin/com/github/albertocavalcante/groovyparser/ast/SymbolExtractor.kt
@@ -212,7 +212,6 @@ object SymbolExtractor {
         // Find the class we're currently in (if any)
         val currentClass = classes.find { classSymbol ->
             val classNode = classSymbol.astNode as org.codehaus.groovy.ast.ClassNode
-            // println("DEBUG: Checking class ${classNode.name}, line=${classNode.lineNumber}-${classNode.lastLineNumber}, cursor=$line")
             line >= classSymbol.line && line <= classNode.lastLineNumber // Relaxed check
         }
 


### PR DESCRIPTION
## Summary
- clean up small detekt baseline items in groovy-lsp and parser/native
- remove unused test/code artifacts and split long test URIs
- keep detekt baselines aligned with current code

## Testing
- ./gradlew :groovy-lsp:compileTestKotlin
- ./gradlew :groovy-lsp:detekt :parser:native:detekt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Detekt baselines trimmed**
> 
> - Remove obsolete entries from `groovy-lsp/detekt-baseline.xml` and `parser/native/detekt-baseline.xml`
> 
> **Minor code cleanup**
> 
> - Remove unused `logger` from `JenkinsDocProvider`
> - Drop leftover debug comment in `parser/native/.../SymbolExtractor.kt`
> 
> **Test refinements to reduce warnings and flakiness**
> 
> - Replace `ClassHelper.DYNAMIC_TYPE` with `ClassHelper.dynamicType()` in tests
> - Add `@Suppress("DEPRECATION")` where LSP4J deprecated unions are used; improve hover content union handling in `LspTestFixture`
> - Split very long JAR/file URIs using `buildUri(...)` in `DefinitionResolverFallbackTest`
> - Tighten assertions (e.g., diagnostics iteration/count, class equality in factory, SimpleTypeTest class presence)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 045430f265b030e893063811f3fbee08d6fd304e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->