### PR TITLE
fix(lsp): scope Jenkins options completions

### DIFF
--- a/groovy-jenkins/src/main/kotlin/com/github/albertocavalcante/groovyjenkins/metadata/MergedJenkinsMetadata.kt
+++ b/groovy-jenkins/src/main/kotlin/com/github/albertocavalcante/groovyjenkins/metadata/MergedJenkinsMetadata.kt
@@ -25,6 +25,7 @@ data class MergedJenkinsMetadata(
     val globalVariables: Map<String, MergedGlobalVariable>,
     val sections: Map<String, SectionEnrichment>,
     val directives: Map<String, DirectiveEnrichment>,
+    val declarativeOptions: Map<String, MergedDeclarativeOption> = emptyMap(),
 ) {
     /**
      * Retrieve step metadata by name.
@@ -37,6 +38,12 @@ data class MergedJenkinsMetadata(
      * @return The variable metadata, or null if not found
      */
     fun getGlobalVariable(name: String): MergedGlobalVariable? = globalVariables[name]
+
+    /**
+     * Retrieve declarative option metadata by name.
+     * @return The option metadata, or null if not found
+     */
+    fun getDeclarativeOption(name: String): MergedDeclarativeOption? = declarativeOptions[name]
 }
 
 /**
@@ -82,6 +89,16 @@ data class MergedParameter(
     val required: Boolean = false, // Default to false if enrichment doesn't specify
     val validValues: List<String>?,
     val examples: List<String>,
+)
+
+/**
+ * Merged metadata for declarative pipeline options (e.g., disableConcurrentBuilds).
+ */
+data class MergedDeclarativeOption(
+    val name: String,
+    val plugin: String,
+    val parameters: Map<String, MergedParameter>,
+    val documentation: String?,
 )
 
 /**

--- a/groovy-jenkins/src/main/kotlin/com/github/albertocavalcante/groovyjenkins/metadata/MetadataMerger.kt
+++ b/groovy-jenkins/src/main/kotlin/com/github/albertocavalcante/groovyjenkins/metadata/MetadataMerger.kt
@@ -210,12 +210,34 @@ object MetadataMerger {
             )
         }
 
+        val mergedOptions = bundled.declarativeOptions.mapValues { (optionName, option) ->
+            val mergedParams = option.parameters.mapValues { (paramName, param) ->
+                MergedParameter(
+                    name = paramName,
+                    type = param.type,
+                    defaultValue = param.default,
+                    description = param.documentation,
+                    required = param.required,
+                    validValues = null,
+                    examples = emptyList(),
+                )
+            }
+
+            MergedDeclarativeOption(
+                name = option.name.ifEmpty { optionName },
+                plugin = option.plugin,
+                parameters = mergedParams,
+                documentation = option.documentation,
+            )
+        }
+
         return MergedJenkinsMetadata(
             jenkinsVersion = bundled.jenkinsVersion ?: "unknown",
             steps = mergedSteps,
             globalVariables = mergedGlobalVars,
             sections = enrichment.sections,
             directives = enrichment.directives,
+            declarativeOptions = mergedOptions,
         )
     }
 }

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/JenkinsBundledCompletionTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/JenkinsBundledCompletionTest.kt
@@ -88,6 +88,57 @@ class JenkinsBundledCompletionTest {
     }
 
     @Test
+    fun `jenkinsfile should suggest map keys for declarative options`() = runBlocking {
+        val uri = "file:///tmp/jenkins-test/Jenkinsfile"
+        val content = """
+            pipeline {
+              agent any
+              options {
+                disableConcurrentBuilds(
+                  
+                )
+              }
+            }
+        """.trimIndent()
+
+        openDocument(uri, content)
+
+        // Position inside the disableConcurrentBuilds map literal area
+        val items = requestCompletionsAt(uri, Position(4, 6))
+
+        val abortPrevious = items.find { it.label == "abortPrevious:" }
+        assertNotNull(abortPrevious, "Should suggest abortPrevious map key for disableConcurrentBuilds")
+        assertEquals(CompletionItemKind.Property, abortPrevious.kind)
+        assertEquals("boolean", abortPrevious.detail)
+        assertTrue(abortPrevious.insertText?.contains("abortPrevious:") == true)
+        assertTrue(abortPrevious.insertText?.contains("true,false") == true)
+    }
+
+    @Test
+    fun `options block should not suggest groovy keywords or steps`() = runBlocking {
+        val uri = "file:///tmp/jenkins-test/Jenkinsfile"
+        val content = """
+            pipeline {
+              agent any
+              options {
+                
+              }
+            }
+        """.trimIndent()
+
+        openDocument(uri, content)
+
+        val items = requestCompletionsAt(uri, Position(3, 4))
+        val labels = items.map { it.label }
+
+        assertTrue(labels.contains("disableConcurrentBuilds"), "Should suggest declarative options")
+        assertTrue(labels.contains("timestamps"), "Should suggest declarative options")
+        assertTrue(labels.none { it == "abstract" }, "Should not suggest Groovy keywords in options block")
+        assertTrue(labels.none { it == "class" }, "Should not suggest Groovy keywords in options block")
+        assertTrue(labels.none { it == "sh" }, "Should not suggest pipeline steps in options block")
+    }
+
+    @Test
     fun `jenkinsfile should provide rich hover for Jenkins steps`() = runBlocking {
         val uri = "file:///tmp/jenkins-test/Jenkinsfile"
         val content = """


### PR DESCRIPTION
## Summary
- merge declarative option metadata for Jenkins completions
- scope options block completions to options/params only
- add tests for option map keys and noise suppression

## Testing
- ./gradlew :groovy-lsp:test --tests "*JenkinsBundledCompletionTest*options block should not suggest groovy keywords or steps*"
- ./gradlew :groovy-lsp:test --tests "*JenkinsBundledCompletionTest*" --tests "*JenkinsStepCompletionProviderTest*"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces declarative options into Jenkins metadata and updates LSP completions to be context-aware inside `options {}` blocks.
> 
> - Adds `declarativeOptions` to `MergedJenkinsMetadata`, `MergedDeclarativeOption` model, and `getDeclarativeOption()` accessor
> - `MetadataMerger` now builds merged declarative options and parameters
> - LSP completion: detect Jenkins `options` block; provide option names and map-key parameter completions; suppress generic Groovy keywords and step/global completions in this context
> - `JenkinsStepCompletionProvider`: new `getDeclarativeOptionCompletions()`; parameter completions now support options when steps are absent
> - `GroovyTextDocumentService`: wires options-block detection to tailor completion lists
> - Tests added for option map keys, suppression in `options` blocks, and option-parameter completion behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72701be9cae694db8cd42783f83a67232187318d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added code completion support for Jenkins declarative pipeline options (e.g., `abortPrevious`, `disableConcurrentBuilds`) within the `options {}` block in Jenkinsfiles.
  * Enabled parameter completion for declarative options with documentation.
  * Improved completion context: the editor now excludes irrelevant Groovy keywords and step suggestions when inside the options block.

* **Tests**
  * Added test coverage for declarative options completion and parameter handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->