### PR TITLE
fix(lsp): improve hover and inlay hints

### DIFF
--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/engine/adapters/CoreParserAdapterTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/engine/adapters/CoreParserAdapterTest.kt
@@ -1,6 +1,8 @@
 package com.github.albertocavalcante.groovylsp.engine.adapters
 
+import com.github.albertocavalcante.groovyparser.GroovyParser
 import com.github.albertocavalcante.groovyparser.ParseResult
+import com.github.albertocavalcante.groovyparser.ParserConfiguration
 import com.github.albertocavalcante.groovyparser.Problem
 import com.github.albertocavalcante.groovyparser.ProblemSeverity
 import com.github.albertocavalcante.groovyparser.ast.CompilationUnit
@@ -9,6 +11,7 @@ import org.eclipse.lsp4j.DiagnosticSeverity
 import org.eclipse.lsp4j.Position
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import com.github.albertocavalcante.groovyparser.Position as CorePosition
@@ -175,5 +178,26 @@ class CoreParserAdapterTest {
         val symbols = adapter.allSymbols()
 
         assertEquals(0, symbols.size)
+    }
+
+    @Test
+    fun `nodeAt finds nodes beyond the first line`() {
+        val code = """
+            def hello = "hello"
+            def sum(a, b) {
+                a + b
+            }
+            def main() {
+                sum(1, 2)
+            }
+        """.trimIndent()
+
+        val parser = GroovyParser(ParserConfiguration())
+        val result = parser.parse(code)
+
+        val adapter = CoreParserAdapter(result, "file:///test.groovy")
+
+        val node = adapter.nodeAt(Position(4, 4)) // On "main"
+        assertNotNull(node, "Expected node at method declaration")
     }
 }


### PR DESCRIPTION
## Summary
- Improve core hover node lookup so script symbols resolve beyond the first line
- Always show parameter name inlay hints even when argument names match
- Add TODO to track deterministic JDK source indexing for parameter names

## Testing
- ./gradlew :groovy-lsp:test --tests "*CoreParserAdapterTest*nodeAt finds nodes beyond the first line*"
- ./gradlew :groovy-lsp:test --tests "*InlayHintsProviderTest*should show parameter hint when names match*" --tests "*InlayHintsProviderTest*script method calls*"

## Notes
- ./gradlew lintFix failed due to existing detekt violations in parser/core (unrelated to this change).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves reliability of hover and parameter hints.
> 
> - **Hover/AST lookup**: Refines `findNodeAt` to consider point ranges and avoid over-pruning, enabling node resolution beyond the first line in scripts (`CoreParserAdapter`).
> - **Parameter hints**: Always emit parameter name hints for positional args, even when argument names match; still skip closures (`InlayHintsProvider`).
> - *Tests*: Adds/updates unit tests for multi-line node lookup and parameter hint behaviors (including script calls).
> - *Maintenance*: Adds TODO to resolve synthetic JDK parameter names deterministically via source indexing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20671de03b36301f494b8b365aa52cad294ca37b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->