### PR TITLE
ci(copilot): install lefthook 2.0.13

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -30,6 +30,10 @@ jobs:
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
           version: 10
+      - name: Install lefthook
+        run: pnpm add -g lefthook@2.0.13
+      - name: Install git hooks
+        run: lefthook install
       - name: Get pnpm store directory
         shell: bash
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"


### PR DESCRIPTION
Matches local dev environment version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **CI workflow update**
> 
> - In `copilot-setup-steps.yml`, add global install of `lefthook@2.0.13` and run `lefthook install` to ensure git hooks are available during Copilot environment setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b0d32c765c10e18da05855800af6ad307413e29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->