### PR TITLE
fix(diagnostics): propagate cancellations and guard spock paths

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/diagnostics/ParserDiagnosticProvider.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/diagnostics/ParserDiagnosticProvider.kt
@@ -1,6 +1,7 @@
 package com.github.albertocavalcante.groovylsp.providers.diagnostics
 
 import com.github.albertocavalcante.groovylsp.compilation.GroovyCompilationService
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import org.eclipse.lsp4j.Diagnostic
@@ -42,6 +43,8 @@ class ParserDiagnosticProvider(private val compilationService: GroovyCompilation
             diagnostics.forEach { diagnostic ->
                 emit(diagnostic)
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             logger.error("Failed to provide parser diagnostics for $uri", e)
             // Don't re-throw - allow other providers to continue

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/diagnostics/rules/builtin/SpockTestStructureRule.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/diagnostics/rules/builtin/SpockTestStructureRule.kt
@@ -35,7 +35,8 @@ class SpockTestStructureRule : AbstractDiagnosticRule() {
 
     override suspend fun analyzeImpl(uri: URI, content: String, context: RuleContext): List<Diagnostic> {
         // Only analyze Spock test files
-        if (!uri.path.contains("Spec.groovy") && !uri.path.contains("Test.groovy")) {
+        val path = uri.path ?: return emptyList()
+        if (!path.contains("Spec.groovy") && !path.contains("Test.groovy")) {
             return emptyList()
         }
 

--- a/tests/e2e/resources/scenarios/diagnostics-jenkins-custom-rules.yaml
+++ b/tests/e2e/resources/scenarios/diagnostics-jenkins-custom-rules.yaml
@@ -60,15 +60,17 @@ steps:
           expect:
             type: NONE_CONTAINS
             value: 'Information'
-        # Should detect at least 2 incomplete stages
-        - jsonPath: $.diagnostics[?(@.message =~ /.*steps.*/i)].length()
+        # Should detect incomplete Build and Deploy stages
+        - jsonPath: $.diagnostics[?(@.message =~ /.*Build.*steps.*/i)]
           expect:
-            type: GTE
-            value: 2
+            type: NOT_EMPTY
+        - jsonPath: $.diagnostics[?(@.message =~ /.*Deploy.*steps.*/i)]
+          expect:
+            type: NOT_EMPTY
         # Build stage diagnostic should be on line 3 (0-indexed)
-        - jsonPath: $.diagnostics[0].range.start.line
+        - jsonPath: $.diagnostics[?(@.message =~ /.*Build.*steps.*/i)].range.start.line
           expect:
-            type: EQUALS
+            type: CONTAINS
             value: 3
   - changeDocument:
       path: Jenkinsfile


### PR DESCRIPTION
# Description

- Propagate cancellation exceptions in parser diagnostics and cover with tests.
- Skip Spock rule analysis when the URI has no path, with a direct analyzeImpl test.
- Stabilize Jenkins diagnostics E2E assertions by checking expected stage messages.

# Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

# Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

# Verification

- ./gradlew :groovy-lsp:test --tests "*ParserDiagnosticProviderTest"
- ./gradlew :groovy-lsp:test --tests "*SpockTestStructureRuleTest"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Parser diagnostics:** `ParserDiagnosticProvider` now rethrows `CancellationException` instead of swallowing it; added unit tests for cancellation and exception handling.
> - **Spock rule guard:** `SpockTestStructureRule` skips analysis when `uri.path` is null before checking `Spec.groovy`/`Test.groovy`; tests include direct `analyzeImpl` invocation.
> - **E2E stability:** Jenkins diagnostics scenario updated to assert incomplete Build/Deploy stages explicitly and relax line check to `CONTAINS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ed04ae512dcd426bcb5197f871585d9678a8392. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->