### PR TITLE
ci(copilot): add gradle caching

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -45,6 +45,8 @@ jobs:
         with:
           distribution: temurin
           java-version: "17"
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
       - name: Install extension dependencies
         run: pnpm install --frozen-lockfile
         working-directory: editors/code


### PR DESCRIPTION
Uses gradle-build-action to cache dependencies and wrapper.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces Gradle caching to speed up Copilot environment setup.
> 
> - Adds `Setup Gradle` step using `gradle/actions/setup-gradle@v5` in `copilot-setup-steps.yml` to cache Gradle wrapper and dependencies
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f730e13e5cf9de2edb5c888fa022c553f5bef16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->