### PR TITLE
fix(jenkins): remove redundant identical conditional branches

### DIFF
--- a/groovy-jenkins/src/main/kotlin/com/github/albertocavalcante/groovyjenkins/JenkinsPluginManager.kt
+++ b/groovy-jenkins/src/main/kotlin/com/github/albertocavalcante/groovyjenkins/JenkinsPluginManager.kt
@@ -86,15 +86,9 @@ class JenkinsPluginManager(
      */
     suspend fun registerStaticMetadata(metadata: BundledJenkinsMetadata) {
         staticMetadataMutex.withLock {
-            // Merge with existing if any, or just set it
-            if (staticMetadataCache == null) {
-                staticMetadataCache = metadata
-            } else {
-                // Simplistic merge: overwrite (since we expect one main file)
-                // Or we could implement deep merging logic here if needed.
-                // For now, let's treat it as "last writer wins" or just replacement.
-                staticMetadataCache = metadata
-            }
+            // Simplistic merge: overwrite (since we expect one main file)
+            // Or we could implement deep merging logic here if needed via MetadataMerger.
+            staticMetadataCache = metadata
         }
         logger.debug("Registered static Jenkins metadata with {} steps", metadata.steps.size)
     }


### PR DESCRIPTION
Addresses SonarCloud MAJOR code smell where both branches of an if/else were identical.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines static metadata handling with no functional changes.
> 
> - Simplifies `registerStaticMetadata` by removing the redundant conditional and directly setting `staticMetadataCache`
> - Updates inline comments to mention possible future merging via `MetadataMerger`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89568c9bd96f9414422280956cbeea5011561a37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated static metadata caching logic to consistently overwrite with provided values rather than merging, ensuring reliable metadata registration behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->