### PR TITLE
docs(agent): enforce idiomacy scan in /lint workflow

### DIFF
--- a/.agent/workflows/lint.md
+++ b/.agent/workflows/lint.md
@@ -1,22 +1,39 @@
 ---
-description: Deterministic assessment of repo quality (read-only): run the right gates, stop on first failure, produce a short report.
+description: Deterministic repo quality gate. Default auto-fix loop; optional read-only check mode.
 ---
 
-# /lint — Assess repo quality (read-only)
+# /lint — Assess repo quality
+
+Modes:
+
+- `/lint` (default): auto-fix loop (runs gates and invokes `/lintfix` until green or blocked)
+- `/lint check` (alias: `/lint readonly`): read-only check (runs gates once, stops on first failure, no fixes)
+
+User intent override:
+
+- If the user says **"fix all"**, treat it as `/lint` default mode and run end-to-end without asking for follow-up.
 
 Run quality gates and produce a structured report.
 
+Default behavior is to continuously fix lint issues via `/lintfix` until gates are green (or you are blocked).
+
 This workflow is intentionally strict: it is designed to prevent LLMs (and humans) from guessing, drifting scope, or
-“fixing while assessing”.
+fixing multiple things at once.
 
 ## Agent contract (non-negotiable)
 
-- MUST stop on the first failing gate and hand off to `/lintfix`.
-- MUST NOT modify code in `/lint`.
+- MUST honor the selected mode:
+  - Default: run gates deterministically and fix failures via `/lintfix` until green (or until blocked).
+  - `check`/`readonly`: run gates deterministically and stop on first failure (no fixes).
+- MUST treat explicit user instruction **"fix all"** as permission to continue the loop end-to-end:
+  - Do NOT ask "proceed?" between iterations.
+  - Only stop when all required gates are green AND the Step 4 idiomacy scan is completed.
+- MUST fix **one failure at a time** (first failing gate) and re-run the same gate to verify (default mode).
 - MUST NOT invent commands. If a command or script is unclear, fetch it from the repo files (see “Lazy fetch”).
-- MUST record the failure contract: `{command, first failing task/script, file(s), rule/message}`.
-- MUST behave like a Kotlin linter persona (“style officer”) on the **changed code only**: flag non-idiomatic patterns
-  and risky constructs even if tools pass.
+- MUST record the failure contract on each iteration: `{command, first failing task/script, file(s), rule/message}`.
+- MUST behave like a Kotlin linter persona (“style officer”) on the **changed code only**:
+  - Step 4 idiomacy scan is REQUIRED (it is not optional and not satisfied by Detekt output alone).
+  - Flag non-idiomatic patterns and risky constructs even if tools pass.
 
 ## Lazy fetch (avoid stale copy/paste, save tokens)
 
@@ -36,15 +53,39 @@ pwd && git worktree list   # MUST be in a worktree, not main
 ## Step 1 — Determine scope
 
 ```bash
+# Prefer PR/branch diff (committed changes) when available.
 git diff --name-only origin/main...HEAD
+
+# If you're not committed yet (or origin/main...HEAD is empty), fall back to working tree scope:
+# - staged changes
+git diff --name-only --cached
+# - unstaged changes
+git diff --name-only
+# - untracked files
+git ls-files --others --exclude-standard
 ```
+
+Scope selection rules:
+
+- If `origin/main...HEAD` is non-empty → Scope = committed diff
+- Else → Scope = union of (staged + unstaged + untracked)
 
 | Path pattern      | Toolchain | Required gate                                                                                                         |
 | ----------------- | --------- | --------------------------------------------------------------------------------------------------------------------- |
 | `editors/code/**` | pnpm      | `cd editors/code && pnpm install --frozen-lockfile && pnpm run check-types && pnpm run lint && pnpm run format:check` |
 | anything else     | Gradle    | `make lint`                                                                                                           |
 
-## Step 2 — Run gates (stop on first failure)
+## Step 2 — Run gates (auto-fix loop)
+
+Run the required gates. If a gate fails, invoke `/lintfix` and then re-run the same gate. Repeat until all required
+gates are green or you are blocked.
+
+In default mode (including when the user says "fix all"), do not pause for confirmation between iterations.
+
+Hard limit: max 10 fix iterations per `/lint` run. If exceeded, STOP and report the last failure contract.
+
+If mode is `check`/`readonly`: run the same gates, but do NOT invoke `/lintfix`; STOP on the first failing gate and
+produce the report.
 
 ### 2.1 Gradle
 
@@ -52,7 +93,7 @@ git diff --name-only origin/main...HEAD
 make lint
 ```
 
-FAIL → record: `{command=make lint, task, file, rule}`. STOP and run `/lintfix`.
+FAIL → record: `{command=make lint, task, file, rule}` → run `/lintfix` → re-run `make lint`.
 
 ### 2.2 Extension (skip if no `editors/code/**` in scope)
 
@@ -60,7 +101,7 @@ FAIL → record: `{command=make lint, task, file, rule}`. STOP and run `/lintfix
 cd editors/code && pnpm install --frozen-lockfile && pnpm run check-types && pnpm run lint && pnpm run format:check
 ```
 
-FAIL → record: `{command=<pnpm script>, file, message}`. STOP and run `/lintfix`.
+FAIL → record: `{command=<pnpm script>, file, message}` → run `/lintfix` → re-run the failing command.
 
 ### 2.3 Build (only for refactors / multi-module)
 
@@ -68,10 +109,16 @@ FAIL → record: `{command=<pnpm script>, file, message}`. STOP and run `/lintfi
 make build
 ```
 
-## Step 3 — Baseline check
+## Step 3 — Baseline check (after gates are green)
 
 ```bash
 find . -name "detekt-baseline.xml" 2>/dev/null
+
+# If you're linting committed changes (origin/main...HEAD scope):
+git diff --stat origin/main...HEAD -- '**/detekt-baseline.xml'
+
+# If you're linting working tree changes (fallback scope):
+git diff --stat --cached -- '**/detekt-baseline.xml'
 git diff --stat -- '**/detekt-baseline.xml'
 ```
 
@@ -84,9 +131,17 @@ This step is where the LLM acts as an additional linter.
 
 Rules:
 
-- ONLY review files in `git diff --name-only origin/main...HEAD`.
+- ONLY review files in the **Scope** from Step 1.
 - Be strict about Kotlin idioms and risk patterns.
 - Do NOT propose “nice-to-have” refactors; only log issues that are actionable and related to the change surface.
+
+Policy:
+
+- If you find clear correctness or maintainability risks in the change surface, you MAY fix them immediately (small,
+  verified diffs) even if tools pass.
+- If you find subjective/style improvements, log them under “Smells” and proceed.
+- If user intent is **"fix all"**, you MUST fix actionable idiomacy issues in scope (correctness/maintainability/risk),
+  and then re-run the relevant gate(s) (at minimum `make lint`). Only purely subjective items may be logged.
 
 For each changed `.kt` file, answer YES/NO:
 
@@ -103,26 +158,32 @@ For each changed `.kt` file, answer YES/NO:
      it reduces complexity.
 5. Unnecessary mutability (`var`, mutable collections) where `val` + transformations suffice?
 6. Overuse of nesting (`let`/`also` chains) instead of early returns or `when` expressions?
+7. Prefer declarative DSLs over mutable builder patterns – use Kotlin DSLs for configuration where possible.
 
 ### C) Null-safety + contracts
 
-7. New `!!` without a strong invariant?
+8. New `!!` without a strong invariant?
    - Prefer `requireNotNull(...)`, `checkNotNull(...)`, safe calls, or explicit domain types.
-8. Nullable types widened without necessity (turning non-null into nullable)?
+9. Nullable types widened without necessity (turning non-null into nullable)?
 
 ### D) Error handling (idiomatic + safe)
 
-9. Broad `catch (Exception)` without context/logging or without rethrowing?
-10. `try/catch` used where `runCatching { }` + `.onFailure { }` / `.getOrElse { }` would make intent clearer? - Use
+10. Broad `catch (Exception)` without context/logging or without rethrowing?
+11. `try/catch` used where `runCatching { }` + `.onFailure { }` / `.getOrElse { }` would make intent clearer? - Use
     `runCatching` when you’re intentionally converting exceptions into a value/result flow. - Keep `try/catch` when you
     must handle specific exceptions differently or need precise control flow.
 
 ### E) Behavioral risk + tests
 
-11. Behavior changed but tests unchanged?
-12. Performance cliff added (new repeated parsing, accidental O(N^2), unnecessary allocations in hot paths)?
+12. Behavior changed but tests unchanged?
+13. Performance cliff added (new repeated parsing, accidental O(N^2), unnecessary allocations in hot paths)?
 
 Any YES → write a 1-line note under “Smells” and point to `/lintfix` (or create a deferred issue).
+
+Important: do NOT stop at Detekt-only findings.
+
+- If tools are green but the Step 4 scan finds actionable issues, treat them as the next work item and fix them
+  (verified by re-running `make lint`, and `make test` when behavior might have changed).
 
 #### Few-shot (how to flag issues deterministically)
 
@@ -171,10 +232,11 @@ Produce exactly:
 
 ```
 ## Lint Report
-- Scope: [file list | PR | repo]
+- Scope: [committed(origin/main...HEAD) | working-tree(staged/unstaged/untracked)], [file list | PR | repo]
 - Gradle: PASS | FAIL {task, file, rule}
 - Extension: PASS | FAIL | SKIPPED
 - Baseline: UNCHANGED | REDUCED | GREW
+- Idiomatic: PASS | FAIL | N/A (no Kotlin in scope)
 - Smells: none | [list]
 - Next: [single action]
 ```

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ lint:
 
 format:
 	./gradlew lintFix $(GRADLE_ARGS)
+	dprint fmt
 
 # Auto-fix specific issues
 fix-imports:


### PR DESCRIPTION
# Description

Updates the `/lint` and `/lintfix` workflow documentation to enforce mandatory idiomacy scanning beyond Detekt checks. When a user says "fix all", the agent now runs end-to-end without asking for confirmation between iterations, and must complete both tool validation (Detekt/Spotless) and an explicit Kotlin idiomacy assessment before stopping.

# Key Changes

- **Autonomous "fix all" mode**: No more "proceed?" prompts between iterations
- **Mandatory idiomacy scan**: Step 4 smell scan is now REQUIRED, not optional
- **Explicit report field**: Added `Idiomatic: PASS | FAIL | N/A` to Lint Report output
- **Actionable smell fixes**: `/lintfix` can now be invoked to fix idiomacy issues even when Detekt passes
- **Makefile enhancement**: Added `dprint fmt` to `make format` for markdown formatting

# Motivation

Agents were previously stopping after Detekt was green, missing non-idiomatic patterns like:
- Duplicated reflection logic with broad/swallowed exceptions
- Java-style loops where Kotlin stdlib is clearer
- Unnecessary mutability

This change ensures code quality goes beyond tool compliance to enforce true Kotlin idioms.

# Type of Change

- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring

# Checklist

- [x] Documentation follows the repo style
- [x] Changes are backward compatible (adds requirements, doesn't break existing usage)
- [x] All quality gates pass (`make lint` and `make test`)

# Verification

- Tested `make format` now runs both `./gradlew lintFix` and `dprint fmt` successfully
- Workflow docs pass markdown linting
- No detekt baseline changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Elevates repo quality workflows with stricter gates, autonomous loops, and explicit idiomacy checks.
> 
> - **`/lint`**: Default auto-fix loop that invokes `/lintfix` until green (max 10 iterations); new `check/readonly` mode; honors user "fix all" to run end-to-end without prompts; refined scope selection; re-run same gate after each fix; mandatory Step 4 idiomacy scan; expanded failure contract; enhanced baseline check; updated report adds `Idiomatic: PASS | FAIL | N/A`.
> - **`/lintfix`**: Clarifies tight inner-loop contract (first failure only, verify, return); allows fixing actionable idiomacy/smell issues even when tools pass; adds verification matrix entry for idiomacy; keeps baseline discipline and verify loop.
> - **Makefile**: `make format` now also runs `dprint fmt` for markdown formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a45b27dba258e629d7891a5eab9a186fd663d327. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated lint workflow to support two modes: auto-fix loop (default) and read-only check mode.
  * Enhanced lintfix workflow with stricter rules and verification requirements.
  * Clarified iteration limits and gate re-run semantics for lint operations.

* **Chores**
  * Added formatting step to the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->