### PR TITLE
chore(tests): remove unused imports in test files

### DIFF
--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/compilation/DependencyGraphTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/compilation/DependencyGraphTest.kt
@@ -1,7 +1,6 @@
 package com.github.albertocavalcante.groovylsp.compilation
 
 import org.codehaus.groovy.ast.ClassNode
-import org.codehaus.groovy.ast.ImportNode
 import org.codehaus.groovy.ast.ModuleNode
 import java.net.URI
 import kotlin.test.Test

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/compilation/IncrementalCompilerTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/compilation/IncrementalCompilerTest.kt
@@ -12,7 +12,6 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class IncrementalCompilerTest {

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/CrossFileMemberCompletionTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/CrossFileMemberCompletionTest.kt
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.net.URI
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.div
 import kotlin.io.path.writeText


### PR DESCRIPTION
Removes unused imports from DependencyGraphTest, IncrementalCompilerTest, and CrossFileMemberCompletionTest.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cleans up test sources by removing unused imports.
> 
> - Removes `ImportNode` from `DependencyGraphTest.kt`
> - Removes `assertNotNull` from `IncrementalCompilerTest.kt`
> - Removes `java.net.URI` from `CrossFileMemberCompletionTest.kt`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 838f0b1f89096d3081c2a45431c294ee873fdfa9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->