### PR TITLE
feat(semantics): Phase 6 - Either-based error handling foundation

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/SignatureHelpProvider.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/SignatureHelpProvider.kt
@@ -13,6 +13,7 @@ import com.github.albertocavalcante.groovyparser.ast.isDynamic
 import com.github.albertocavalcante.groovyparser.ast.safePosition
 import com.github.albertocavalcante.gvy.semantics.PrimitiveKind
 import com.github.albertocavalcante.gvy.semantics.SemanticType
+import com.github.albertocavalcante.gvy.semantics.SemanticTypeFormatter
 import groovy.lang.Script
 import org.codehaus.groovy.ast.ASTNode
 import org.codehaus.groovy.ast.ClassHelper
@@ -275,40 +276,9 @@ class SignatureHelpProvider(
 
     /**
      * Format SemanticType to fully qualified name for classpath lookups.
+     * Delegates to SemanticTypeFormatter for consistent formatting.
      */
-    private fun formatSemanticTypeToFqn(type: SemanticType): String = when (type) {
-        is SemanticType.Known -> type.fqn
-        is SemanticType.Primitive -> when (type.kind) {
-            PrimitiveKind.INT -> "int"
-            PrimitiveKind.LONG -> "long"
-            PrimitiveKind.DOUBLE -> "double"
-            PrimitiveKind.FLOAT -> "float"
-            PrimitiveKind.BOOLEAN -> "boolean"
-            PrimitiveKind.BYTE -> "byte"
-            PrimitiveKind.CHAR -> "char"
-            PrimitiveKind.SHORT -> "short"
-            PrimitiveKind.VOID -> "void"
-        }
-
-        is SemanticType.Dynamic -> "java.lang.Object"
-        is SemanticType.Unknown -> "java.lang.Object"
-        is SemanticType.Null -> "java.lang.Object"
-        is SemanticType.Union -> {
-            // Return first known type, or Object as fallback
-            type.types.firstNotNullOfOrNull {
-                when (it) {
-                    is SemanticType.Known -> it.fqn
-                    else -> null
-                }
-            } ?: "java.lang.Object"
-        }
-
-        is SemanticType.Array -> {
-            val componentFqn = formatSemanticTypeToFqn(type.componentType)
-            // Array types in reflection use format like "java.lang.String[]"
-            "$componentFqn[]"
-        }
-    }
+    private fun formatSemanticTypeToFqn(type: SemanticType): String = SemanticTypeFormatter.formatToFqn(type)
 
     private fun resolveImplicitThisReceiverType(methodCall: MethodCallExpression, astVisitor: GroovyAstModel): String {
         var current: ASTNode? = methodCall

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/CompletionProvider.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/CompletionProvider.kt
@@ -12,6 +12,7 @@ import com.github.albertocavalcante.groovylsp.types.SemanticTypeResolver
 import com.github.albertocavalcante.groovyparser.ast.GroovyAstModel
 import com.github.albertocavalcante.groovyparser.tokens.GroovyTokenIndex
 import com.github.albertocavalcante.groovyspock.SpockDetector
+import com.github.albertocavalcante.gvy.semantics.SemanticTypeFormatter
 import com.github.albertocavalcante.gvy.semantics.native.ClassSymbol
 import com.github.albertocavalcante.gvy.semantics.native.FieldSymbol
 import com.github.albertocavalcante.gvy.semantics.native.ImportSymbol
@@ -394,30 +395,13 @@ object CompletionProvider {
 
     /**
      * Formats a SemanticType into a human-readable string for display.
+     * Delegates to SemanticTypeFormatter for consistent formatting.
      *
      * @param type The semantic type to format
      * @return A formatted type string
      */
-    private fun formatType(type: com.github.albertocavalcante.gvy.semantics.SemanticType): String = when (type) {
-        is com.github.albertocavalcante.gvy.semantics.SemanticType.Known -> {
-            val baseName = type.fqn.substringAfterLast('.')
-            if (type.typeArgs.isEmpty()) {
-                baseName
-            } else {
-                val params = type.typeArgs.joinToString(", ") { formatType(it) }
-                "$baseName<$params>"
-            }
-        }
-        is com.github.albertocavalcante.gvy.semantics.SemanticType.Primitive -> type.kind.name.lowercase()
-        is com.github.albertocavalcante.gvy.semantics.SemanticType.Array -> "${formatType(type.componentType)}[]"
-        is com.github.albertocavalcante.gvy.semantics.SemanticType.Unknown -> "def"
-        is com.github.albertocavalcante.gvy.semantics.SemanticType.Dynamic -> "def"
-        is com.github.albertocavalcante.gvy.semantics.SemanticType.Union -> {
-            // For union types, just show the first type
-            type.types.firstOrNull()?.let { formatType(it) } ?: "def"
-        }
-        is com.github.albertocavalcante.gvy.semantics.SemanticType.Null -> "null"
-    }
+    private fun formatType(type: com.github.albertocavalcante.gvy.semantics.SemanticType): String =
+        SemanticTypeFormatter.formatForCompletion(type)
 
     /**
      * Parses a method signature into parameter strings for display.

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/types/SemanticTypeResolver.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/types/SemanticTypeResolver.kt
@@ -1,14 +1,19 @@
 package com.github.albertocavalcante.groovylsp.types
 
+import arrow.core.Either
 import com.github.albertocavalcante.groovyparser.resolution.TypeSolver
 import com.github.albertocavalcante.gvy.semantics.PrimitiveKind
 import com.github.albertocavalcante.gvy.semantics.SemanticType
+import com.github.albertocavalcante.gvy.semantics.SemanticTypeFormatter
+import com.github.albertocavalcante.gvy.semantics.calculator.TypeInferenceError
+import com.github.albertocavalcante.gvy.semantics.calculator.TypeResult
 import com.github.albertocavalcante.gvy.semantics.native.GroovySemantics
 import com.github.albertocavalcante.gvy.semantics.native.NativeCalculators
 import org.codehaus.groovy.ast.ASTNode
 import org.codehaus.groovy.ast.ClassHelper
 import org.codehaus.groovy.ast.ClassNode
 import org.codehaus.groovy.ast.ModuleNode
+import org.slf4j.LoggerFactory
 
 /**
  * Bridge between GroovySemantics and LSP providers.
@@ -18,18 +23,59 @@ import org.codehaus.groovy.ast.ModuleNode
 class SemanticTypeResolver(private val typeSolver: TypeSolver) {
     val semantics = GroovySemantics(typeSolver, NativeCalculators.createRegistry())
 
+    companion object {
+        private val logger = LoggerFactory.getLogger(SemanticTypeResolver::class.java)
+    }
+
     /**
      * Resolve the type of an AST node using GroovySemantics.
      * Uses the module-aware API for proper multi-document support.
+     *
+     * This is a legacy method that returns SemanticType directly.
+     * For new code that needs error handling, prefer resolveTypeResult().
+     *
+     * @param node The AST node to resolve type for
+     * @param moduleNode The module context (optional)
+     * @return The resolved SemanticType, or Unknown if resolution fails
      */
     fun resolveType(node: ASTNode, moduleNode: ModuleNode?): SemanticType = if (moduleNode != null) {
-        // Use the new module-aware API for multi-document safety
-        semantics.resolveType(node, moduleNode)
+        // Delegate to new Either-based API and fold the result
+        resolveTypeResult(node, moduleNode).fold(
+            ifLeft = { error ->
+                logger.debug("Type resolution failed, returning Unknown: {}", error.reason)
+                SemanticType.Unknown(error.reason)
+            },
+            ifRight = { type -> type },
+        )
     } else {
         // Fallback for cases where module is not available
-        @Suppress("DEPRECATION")
-        semantics.resolveType(node)
+        resolveTypeResult(node).fold(
+            ifLeft = { error ->
+                logger.debug("Type resolution failed, returning Unknown: {}", error.reason)
+                SemanticType.Unknown(error.reason)
+            },
+            ifRight = { type -> type },
+        )
     }
+
+    /**
+     * Resolve the type of an AST node, returning Either for error handling.
+     * This method enables callers to get detailed error information.
+     *
+     * @param node The AST node to resolve type for
+     * @return Either a TypeInferenceError (left) or the resolved SemanticType (right)
+     */
+    fun resolveTypeResult(node: ASTNode): TypeResult = semantics.resolveTypeResult(node)
+
+    /**
+     * Resolve the type of an AST node with explicit module, returning Either for error handling.
+     * This is the preferred method for multi-document support with detailed error handling.
+     *
+     * @param node The AST node to resolve type for
+     * @param module The module context for resolution
+     * @return Either a TypeInferenceError (left) or the resolved SemanticType (right)
+     */
+    fun resolveTypeResult(node: ASTNode, module: ModuleNode): TypeResult = semantics.resolveTypeResult(node, module)
 
     /**
      * Convert a ClassNode directly to a SemanticType.
@@ -82,19 +128,9 @@ class SemanticTypeResolver(private val typeSolver: TypeSolver) {
 
     /**
      * Format SemanticType for display in hover, inlay hints, etc.
+     * Delegates to SemanticTypeFormatter for consistent formatting across all providers.
      */
-    fun formatSemanticType(type: SemanticType): String = when (type) {
-        is SemanticType.Known -> type.fqn.substringAfterLast('.')
-        is SemanticType.Primitive -> type.kind.name.lowercase()
-        is SemanticType.Dynamic -> type.hint ?: "def"
-        is SemanticType.Unknown -> "unresolved"
-        is SemanticType.Union -> {
-            val formatted = type.types.map { formatSemanticType(it) }.sorted()
-            formatted.joinToString(" | ")
-        }
-        is SemanticType.Null -> "null"
-        is SemanticType.Array -> "${formatSemanticType(type.componentType)}[]"
-    }
+    fun formatSemanticType(type: SemanticType): String = SemanticTypeFormatter.format(type)
 
     private fun getPrimitiveClassNode(kind: PrimitiveKind): ClassNode = when (kind) {
         PrimitiveKind.VOID -> ClassHelper.VOID_TYPE

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/types/SemanticTypeResolver.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/types/SemanticTypeResolver.kt
@@ -1,6 +1,7 @@
 package com.github.albertocavalcante.groovylsp.types
 
 import arrow.core.Either
+import arrow.core.getOrElse
 import com.github.albertocavalcante.groovyparser.resolution.TypeSolver
 import com.github.albertocavalcante.gvy.semantics.PrimitiveKind
 import com.github.albertocavalcante.gvy.semantics.SemanticType
@@ -38,24 +39,15 @@ class SemanticTypeResolver(private val typeSolver: TypeSolver) {
      * @param moduleNode The module context (optional)
      * @return The resolved SemanticType, or Unknown if resolution fails
      */
-    fun resolveType(node: ASTNode, moduleNode: ModuleNode?): SemanticType = if (moduleNode != null) {
-        // Delegate to new Either-based API and fold the result
-        resolveTypeResult(node, moduleNode).fold(
-            ifLeft = { error ->
-                logger.debug("Type resolution failed, returning Unknown: {}", error.reason)
-                SemanticType.Unknown(error.reason)
-            },
-            ifRight = { type -> type },
-        )
-    } else {
-        // Fallback for cases where module is not available
-        resolveTypeResult(node).fold(
-            ifLeft = { error ->
-                logger.debug("Type resolution failed, returning Unknown: {}", error.reason)
-                SemanticType.Unknown(error.reason)
-            },
-            ifRight = { type -> type },
-        )
+    fun resolveType(node: ASTNode, moduleNode: ModuleNode?): SemanticType = (
+        if (moduleNode != null) {
+            resolveTypeResult(node, moduleNode)
+        } else {
+            resolveTypeResult(node)
+        }
+        ).getOrElse { error ->
+        logger.debug("Type resolution failed, returning Unknown: {}", error.reason)
+        SemanticType.Unknown(error.reason)
     }
 
     /**

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/types/SemanticTypeResolverTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/types/SemanticTypeResolverTest.kt
@@ -153,7 +153,7 @@ class SemanticTypeResolverTest {
         val type = SemanticType.Unknown("test reason")
         val formatted = resolver.formatSemanticType(type)
 
-        assertThat(formatted).isEqualTo("unresolved")
+        assertThat(formatted).isEqualTo("def") // Groovy's dynamic type keyword
     }
 
     @Test

--- a/semantics/core/build.gradle.kts
+++ b/semantics/core/build.gradle.kts
@@ -7,6 +7,12 @@ tasks.jar {
 }
 
 dependencies {
+    // Functional Programming - Arrow-kt core types (Either, Option, etc.)
+    api(libs.arrow.core)
+
+    // Common functional utilities (DomainError, etc.)
+    implementation(project(":groovy-common"))
+
     // Groovy AST for SemanticDocumentBuilder
     implementation(libs.groovy.core)
 

--- a/semantics/core/src/main/kotlin/com/github/albertocavalcante/gvy/semantics/SemanticTypeFormatter.kt
+++ b/semantics/core/src/main/kotlin/com/github/albertocavalcante/gvy/semantics/SemanticTypeFormatter.kt
@@ -1,0 +1,132 @@
+package com.github.albertocavalcante.gvy.semantics
+
+/**
+ * Centralized formatter for SemanticType instances.
+ * Consolidates type formatting logic previously duplicated across
+ * SemanticTypeResolver, CompletionProvider, InlayHintsProvider, HoverContentGenerator,
+ * and SignatureHelpProvider.
+ */
+object SemanticTypeFormatter {
+
+    /**
+     * Format a SemanticType for display with configurable options.
+     *
+     * @param type The semantic type to format
+     * @param options Formatting options (default: simple name, with generics)
+     * @return A formatted type string
+     */
+    fun format(type: SemanticType, options: FormatOptions = FormatOptions.DEFAULT): String = when (type) {
+        is SemanticType.Known -> formatKnownType(type, options)
+        is SemanticType.Primitive -> formatPrimitiveType(type.kind)
+        is SemanticType.Dynamic -> formatDynamicType(type)
+        is SemanticType.Unknown -> "unresolved"
+        is SemanticType.Union -> formatUnionType(type, options)
+        is SemanticType.Null -> "null"
+        is SemanticType.Array -> formatArrayType(type, options)
+    }
+
+    /**
+     * Format a SemanticType for completion items.
+     * Uses simple names with generics for readability.
+     *
+     * @param type The semantic type to format
+     * @return A formatted type string suitable for completion items
+     */
+    fun formatForCompletion(type: SemanticType): String = format(
+        type,
+        FormatOptions(includePackage = false, includeGenerics = true),
+    )
+
+    /**
+     * Format a SemanticType for hover information.
+     * Uses simple names with generics for readability.
+     *
+     * @param type The semantic type to format
+     * @return A formatted type string suitable for hover display
+     */
+    fun formatForHover(type: SemanticType): String = format(
+        type,
+        FormatOptions(includePackage = false, includeGenerics = true),
+    )
+
+    /**
+     * Format a SemanticType to fully qualified name for classpath lookups.
+     * Returns the FQN for Known types, primitive names for primitives,
+     * and "java.lang.Object" for dynamic/unknown types.
+     *
+     * @param type The semantic type to format
+     * @return A fully qualified name suitable for reflection/classpath operations
+     */
+    fun formatToFqn(type: SemanticType): String = when (type) {
+        is SemanticType.Known -> type.fqn
+        is SemanticType.Primitive -> formatPrimitiveType(type.kind)
+        is SemanticType.Dynamic -> "java.lang.Object"
+        is SemanticType.Unknown -> "java.lang.Object"
+        is SemanticType.Null -> "java.lang.Object"
+        is SemanticType.Union -> {
+            // Return first known type, or Object as fallback
+            type.types.firstNotNullOfOrNull {
+                when (it) {
+                    is SemanticType.Known -> it.fqn
+                    else -> null
+                }
+            } ?: "java.lang.Object"
+        }
+        is SemanticType.Array -> {
+            val componentFqn = formatToFqn(type.componentType)
+            "$componentFqn[]"
+        }
+    }
+
+    private fun formatKnownType(type: SemanticType.Known, options: FormatOptions): String {
+        val baseName = if (options.includePackage) {
+            type.fqn
+        } else {
+            type.fqn.substringAfterLast('.')
+        }
+
+        return if (options.includeGenerics && type.typeArgs.isNotEmpty()) {
+            val formattedArgs = type.typeArgs.joinToString(", ") { format(it, options) }
+            "$baseName<$formattedArgs>"
+        } else {
+            baseName
+        }
+    }
+
+    private fun formatPrimitiveType(kind: PrimitiveKind): String = kind.name.lowercase()
+
+    private fun formatDynamicType(type: SemanticType.Dynamic): String = type.hint ?: "def"
+
+    private fun formatUnionType(type: SemanticType.Union, options: FormatOptions): String {
+        val formatted = type.types.map { format(it, options) }.sorted()
+        return formatted.joinToString(" | ")
+    }
+
+    private fun formatArrayType(type: SemanticType.Array, options: FormatOptions): String =
+        "${format(type.componentType, options)}[]"
+}
+
+/**
+ * Formatting options for SemanticType display.
+ *
+ * @property includePackage If true, use fully qualified names; if false, use simple names
+ * @property includeGenerics If true, include generic type parameters; if false, omit them
+ */
+data class FormatOptions(val includePackage: Boolean = false, val includeGenerics: Boolean = true) {
+    companion object {
+        /**
+         * Default formatting options: simple names with generics.
+         */
+        val DEFAULT = FormatOptions(includePackage = false, includeGenerics = true)
+
+        /**
+         * Fully qualified formatting: FQNs with generics.
+         */
+        val FULLY_QUALIFIED = FormatOptions(includePackage = true, includeGenerics = true)
+
+        /**
+         * Simple formatting: simple names without generics.
+         */
+        val SIMPLE = FormatOptions(includePackage = false, includeGenerics = false)
+    }
+}

--- a/semantics/core/src/main/kotlin/com/github/albertocavalcante/gvy/semantics/SemanticTypeFormatter.kt
+++ b/semantics/core/src/main/kotlin/com/github/albertocavalcante/gvy/semantics/SemanticTypeFormatter.kt
@@ -19,7 +19,7 @@ object SemanticTypeFormatter {
         is SemanticType.Known -> formatKnownType(type, options)
         is SemanticType.Primitive -> formatPrimitiveType(type.kind)
         is SemanticType.Dynamic -> formatDynamicType(type)
-        is SemanticType.Unknown -> "unresolved"
+        is SemanticType.Unknown -> "def" // Groovy's dynamic type keyword
         is SemanticType.Union -> formatUnionType(type, options)
         is SemanticType.Null -> "null"
         is SemanticType.Array -> formatArrayType(type, options)

--- a/semantics/core/src/main/kotlin/com/github/albertocavalcante/gvy/semantics/calculator/TypeCalculator.kt
+++ b/semantics/core/src/main/kotlin/com/github/albertocavalcante/gvy/semantics/calculator/TypeCalculator.kt
@@ -1,5 +1,7 @@
 package com.github.albertocavalcante.gvy.semantics.calculator
 
+import arrow.core.left
+import arrow.core.right
 import com.github.albertocavalcante.gvy.semantics.SemanticType
 import kotlin.reflect.KClass
 
@@ -35,4 +37,17 @@ interface TypeCalculator<T : Any> {
      * @return The calculated type, or null if this calculator cannot handle it
      */
     fun calculate(node: T, context: TypeContext): SemanticType?
+
+    /**
+     * Calculate the type of the given node, returning an Either for explicit error handling.
+     *
+     * Default implementation bridges to [calculate] for backward compatibility.
+     * Override this method to provide explicit error types.
+     *
+     * @param node The AST node to calculate type for
+     * @param context Resolution context (scope, type solver, etc.)
+     * @return Either an error or the calculated type
+     */
+    fun calculateResult(node: T, context: TypeContext): TypeResult = calculate(node, context)?.right()
+        ?: TypeInferenceError.UnsupportedNode(node::class.simpleName ?: "unknown").left()
 }

--- a/semantics/core/src/main/kotlin/com/github/albertocavalcante/gvy/semantics/calculator/TypeCalculatorRegistry.kt
+++ b/semantics/core/src/main/kotlin/com/github/albertocavalcante/gvy/semantics/calculator/TypeCalculatorRegistry.kt
@@ -1,6 +1,11 @@
 package com.github.albertocavalcante.gvy.semantics.calculator
 
+import arrow.core.fold
+import arrow.core.getOrElse
+import arrow.core.left
+import arrow.core.right
 import com.github.albertocavalcante.gvy.semantics.SemanticType
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
 
 /**
@@ -11,6 +16,41 @@ import kotlin.reflect.KClass
  */
 class TypeCalculatorRegistry private constructor(private val calculators: Map<KClass<*>, List<TypeCalculator<*>>>) {
 
+    private val calculatorCache = ConcurrentHashMap<KClass<*>, List<TypeCalculator<*>>>()
+
+    /**
+     * Calculate the type of a node, returning Either for explicit error handling.
+     *
+     * Tries each applicable calculator in priority order until one succeeds.
+     *
+     * @param node The AST node to calculate type for
+     * @param context Resolution context
+     * @return Either an error or the calculated type
+     */
+    fun calculateResult(node: Any, context: TypeContext): TypeResult {
+        val nodeClass = node::class
+        val applicableCalculators = findApplicableCalculators(nodeClass)
+
+        if (applicableCalculators.isEmpty()) {
+            return TypeInferenceError.NoCalculatorFound(nodeClass.simpleName ?: "unknown").left()
+        }
+
+        var lastError: TypeInferenceError = TypeInferenceError.NoCalculatorFound(nodeClass.simpleName ?: "unknown")
+
+        for (calc in applicableCalculators) {
+            @Suppress("UNCHECKED_CAST")
+            val calculator = calc as TypeCalculator<Any>
+            val result = calculator.calculateResult(node, context)
+
+            result.fold(
+                ifLeft = { lastError = it },
+                ifRight = { return it.right() },
+            )
+        }
+
+        return lastError.left()
+    }
+
     /**
      * Calculate the type of a node.
      * Tries calculators in priority order until one succeeds.
@@ -19,34 +59,21 @@ class TypeCalculatorRegistry private constructor(private val calculators: Map<KC
      * @param context The type context
      * @return The calculated type, or [SemanticType.Unknown] if no calculator could handle it
      */
-    fun calculate(node: Any, context: TypeContext): SemanticType {
-        val nodeClass = node::class
+    fun calculate(node: Any, context: TypeContext): SemanticType = calculateResult(node, context).getOrElse { error ->
+        SemanticType.Unknown(error.reason)
+    }
 
-        // Find calculators for this node type (including superclasses)
-        val applicableCalculators = findApplicableCalculators(nodeClass)
+    private fun findApplicableCalculators(nodeClass: KClass<*>): List<TypeCalculator<*>> =
+        calculatorCache.getOrPut(nodeClass) {
+            // Check exact match first
+            calculators[nodeClass]?.let { return@getOrPut it }
 
-        val result = applicableCalculators.firstNotNullOfOrNull {
-            @Suppress("UNCHECKED_CAST")
-            val calc = it as TypeCalculator<Any>
-            calc.calculate(node, context)
+            // Check superclasses and interfaces
+            calculators.entries
+                .filter { (key, _) -> key.java.isAssignableFrom(nodeClass.java) }
+                .flatMap { it.value }
+                .sortedByDescending { it.priority }
         }
-
-        return result ?: SemanticType.Unknown("No calculator found for ${nodeClass.simpleName}")
-    }
-
-    private fun findApplicableCalculators(nodeClass: KClass<*>): List<TypeCalculator<*>> {
-        // Check exact match first
-        calculators[nodeClass]?.let { return it }
-
-        // TODO(#639): Cache resolved calculator lists per runtime node class.
-        //   See: https://github.com/albertocavalcante/gvy/issues/639
-
-        // Check superclasses and interfaces
-        return calculators.entries
-            .filter { (key, _) -> key.java.isAssignableFrom(nodeClass.java) }
-            .flatMap { it.value }
-            .sortedByDescending { it.priority }
-    }
 
     /**
      * Builder for creating a registry.

--- a/semantics/core/src/main/kotlin/com/github/albertocavalcante/gvy/semantics/calculator/TypeContext.kt
+++ b/semantics/core/src/main/kotlin/com/github/albertocavalcante/gvy/semantics/calculator/TypeContext.kt
@@ -1,5 +1,7 @@
 package com.github.albertocavalcante.gvy.semantics.calculator
 
+import arrow.core.left
+import arrow.core.right
 import com.github.albertocavalcante.gvy.semantics.SemanticType
 
 /**
@@ -61,4 +63,59 @@ interface TypeContext {
      * Affects how strictly types are resolved.
      */
     val isStaticCompilation: Boolean
+
+    /**
+     * Resolve a type by FQN, returning Either for explicit error handling.
+     *
+     * Default implementation bridges to [resolveType].
+     */
+    fun resolveTypeResult(fqn: String): TypeResult = resolveType(fqn).let { type ->
+        if (type is SemanticType.Unknown) {
+            TypeInferenceError.TypeNotResolved(fqn, type.reason).left()
+        } else {
+            type.right()
+        }
+    }
+
+    /**
+     * Calculate type of a node, returning Either for explicit error handling.
+     *
+     * Default implementation bridges to [calculateType].
+     */
+    fun calculateTypeResult(node: Any): TypeResult = calculateType(node).let { type ->
+        if (type is SemanticType.Unknown) {
+            TypeInferenceError.UnsupportedNode(node::class.simpleName ?: "unknown").left()
+        } else {
+            type.right()
+        }
+    }
+
+    /**
+     * Look up a symbol by name, returning Either for explicit error handling.
+     *
+     * Default implementation bridges to [lookupSymbol].
+     */
+    fun lookupSymbolResult(name: String): TypeResult = lookupSymbol(name)?.right()
+        ?: TypeInferenceError.SymbolNotFound(name).left()
+
+    /**
+     * Get method return type, returning Either for explicit error handling.
+     *
+     * Default implementation bridges to [getMethodReturnType].
+     */
+    fun getMethodReturnTypeResult(
+        receiverType: SemanticType,
+        methodName: String,
+        argumentTypes: List<SemanticType>,
+    ): TypeResult = getMethodReturnType(receiverType, methodName, argumentTypes)?.right()
+        ?: TypeInferenceError.MethodNotFound(receiverType, methodName, argumentTypes).left()
+
+    /**
+     * Get field type, returning Either for explicit error handling.
+     *
+     * Default implementation bridges to [getFieldType].
+     */
+    fun getFieldTypeResult(receiverType: SemanticType, fieldName: String): TypeResult =
+        getFieldType(receiverType, fieldName)?.right()
+            ?: TypeInferenceError.FieldNotFound(receiverType, fieldName).left()
 }

--- a/semantics/core/src/main/kotlin/com/github/albertocavalcante/gvy/semantics/calculator/TypeInferenceError.kt
+++ b/semantics/core/src/main/kotlin/com/github/albertocavalcante/gvy/semantics/calculator/TypeInferenceError.kt
@@ -1,0 +1,273 @@
+package com.github.albertocavalcante.gvy.semantics.calculator
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import com.github.albertocavalcante.groovycommon.functional.DomainError
+import com.github.albertocavalcante.gvy.semantics.SemanticType
+
+/**
+ * Errors that can occur during type inference.
+ *
+ * This sealed interface provides a type-safe way to represent all possible
+ * failure modes in the type calculation system. By using a sealed hierarchy,
+ * we enable exhaustive when() matching and make error handling explicit.
+ *
+ * ## Design rationale
+ *
+ * - **Sealed interface**: Allows exhaustive when() matching
+ * - **Data classes**: Each error carries specific context
+ * - **Railway-oriented programming**: Works with Arrow Either for composable error handling
+ * - **Domain-specific**: Errors are semantic, not technical (e.g., "SymbolNotFound" vs "NullPointerException")
+ *
+ * ## Usage example
+ *
+ * ```kotlin
+ * fun resolveType(symbolName: String): TypeResult =
+ *     symbolTable[symbolName]
+ *         .ensureFound { SymbolNotFound(symbolName) }
+ *
+ * resolveType("myVar").fold(
+ *     ifLeft = { error -> logger.warn("Type error: ${error.reason}") },
+ *     ifRight = { type -> useType(type) }
+ * )
+ * ```
+ */
+sealed interface TypeInferenceError {
+
+    /**
+     * Human-readable description of why the type inference failed.
+     */
+    val reason: String
+
+    /**
+     * Symbol was not found in the current scope or parent scopes.
+     *
+     * This typically occurs when referencing an undefined variable, class, or import.
+     *
+     * @property symbolName The name of the symbol that couldn't be resolved
+     */
+    data class SymbolNotFound(val symbolName: String) : TypeInferenceError {
+        override val reason: String
+            get() = "Symbol not found: $symbolName"
+    }
+
+    /**
+     * Method call could not be resolved on the receiver type.
+     *
+     * This occurs when:
+     * - The method name doesn't exist on the receiver
+     * - The method exists but the argument types don't match any overload
+     * - The method exists but is not accessible (private, protected, etc.)
+     *
+     * @property receiverType The type of the object the method was called on
+     * @property methodName The name of the method that couldn't be found
+     * @property argumentTypes The types of the arguments passed to the method
+     */
+    data class MethodNotFound(
+        val receiverType: SemanticType,
+        val methodName: String,
+        val argumentTypes: List<SemanticType>,
+    ) : TypeInferenceError {
+        override val reason: String
+            get() = "Method not found: $receiverType.$methodName(${argumentTypes.joinToString(", ")})"
+    }
+
+    /**
+     * Field/property access could not be resolved on the receiver type.
+     *
+     * This occurs when:
+     * - The field name doesn't exist on the receiver
+     * - The field exists but is not accessible (private, protected, etc.)
+     *
+     * @property receiverType The type of the object the field was accessed on
+     * @property fieldName The name of the field that couldn't be found
+     */
+    data class FieldNotFound(val receiverType: SemanticType, val fieldName: String) : TypeInferenceError {
+        override val reason: String
+            get() = "Field not found: $receiverType.$fieldName"
+    }
+
+    /**
+     * A type reference (by FQN) could not be resolved.
+     *
+     * This typically occurs when:
+     * - The class doesn't exist or is not on the classpath
+     * - The import is missing or incorrect
+     * - There's a typo in the type name
+     *
+     * @property fqn The fully qualified name that couldn't be resolved
+     * @property cause Optional additional context about why resolution failed
+     */
+    data class TypeNotResolved(val fqn: String, val cause: String? = null) : TypeInferenceError {
+        override val reason: String
+            get() = if (cause != null) {
+                "Type not resolved: $fqn (cause: $cause)"
+            } else {
+                "Type not resolved: $fqn"
+            }
+    }
+
+    /**
+     * The AST node type is not supported by any calculator.
+     *
+     * This typically indicates:
+     * - A new Groovy/Java syntax that isn't handled yet
+     * - A malformed or unexpected AST structure
+     * - A calculator is missing for this node type
+     *
+     * @property nodeType The class name of the unsupported AST node
+     */
+    data class UnsupportedNode(val nodeType: String) : TypeInferenceError {
+        override val reason: String
+            get() = "Unsupported node type: $nodeType"
+    }
+
+    /**
+     * No calculator was found that can handle this node type.
+     *
+     * Similar to [UnsupportedNode], but specifically indicates that the
+     * calculator registry returned no matches. This can help distinguish
+     * between "calculator exists but returned null" vs "no calculator at all".
+     *
+     * @property nodeType The class name of the node with no calculator
+     */
+    data class NoCalculatorFound(val nodeType: String) : TypeInferenceError {
+        override val reason: String
+            get() = "No calculator found for node type: $nodeType"
+    }
+
+    /**
+     * The receiver type of a member access could not be resolved.
+     *
+     * This occurs when trying to access a method or field on an expression
+     * whose type couldn't be determined (e.g., `unknownVar.someMethod()`).
+     *
+     * @property hint Optional context about what was being accessed
+     */
+    data class ReceiverTypeUnresolved(val hint: String? = null) : TypeInferenceError {
+        override val reason: String
+            get() = if (hint != null) {
+                "Receiver type unresolved: $hint"
+            } else {
+                "Receiver type unresolved"
+            }
+    }
+
+    /**
+     * An internal error occurred during type inference.
+     *
+     * This represents unexpected failures that shouldn't happen in normal operation,
+     * such as:
+     * - Reflection failures
+     * - Unexpected null values
+     * - Logic errors in calculators
+     *
+     * @property reason Human-readable description of the internal error
+     * @property cause The underlying exception, if any
+     */
+    data class InternalError(override val reason: String, val cause: Throwable? = null) : TypeInferenceError
+}
+
+/**
+ * Type alias for type inference results using Railway-Oriented Programming.
+ *
+ * This represents the result of a type calculation operation:
+ * - **Left**: A [TypeInferenceError] describing what went wrong
+ * - **Right**: A successfully calculated [SemanticType]
+ *
+ * ## Why Either?
+ *
+ * 1. **Explicit error handling**: Callers must handle errors at compile time
+ * 2. **Composable**: Chain operations with `map`, `flatMap`, `fold`
+ * 3. **No exceptions**: Errors are values, not control flow
+ * 4. **Testable**: Easy to assert on Left/Right without try-catch
+ *
+ * ## Example usage
+ *
+ * ```kotlin
+ * fun calculateType(node: ASTNode): TypeResult =
+ *     resolveReceiver(node)
+ *         .flatMap { receiver -> resolveMethod(receiver, node.methodName) }
+ *         .map { method -> method.returnType }
+ * ```
+ */
+typealias TypeResult = Either<TypeInferenceError, SemanticType>
+
+/**
+ * Convert this [TypeInferenceError] to a general [DomainError].
+ *
+ * This allows type inference errors to be propagated through layers
+ * that use the general [DomainError] type (e.g., LSP handlers).
+ *
+ * @return A [DomainError] with source set to "TypeInference"
+ */
+fun TypeInferenceError.toDomainError(): DomainError = DomainError(
+    reason = this.reason,
+    source = "TypeInference",
+    cause = (this as? TypeInferenceError.InternalError)?.cause,
+)
+
+/**
+ * Wrap this [SemanticType] in a successful [TypeResult].
+ *
+ * Convenience method for creating Right values.
+ *
+ * ```kotlin
+ * val result: TypeResult = TypeConstants.STRING.asRight()
+ * ```
+ */
+fun SemanticType.asRight(): TypeResult = this.right()
+
+/**
+ * Wrap this [TypeInferenceError] in a failed [TypeResult].
+ *
+ * Convenience method for creating Left values.
+ *
+ * ```kotlin
+ * val result: TypeResult = SymbolNotFound("myVar").asLeft()
+ * ```
+ */
+fun TypeInferenceError.asLeft(): TypeResult = this.left()
+
+/**
+ * Ensure a nullable value is non-null, or return an error.
+ *
+ * This is useful for converting nullable results into Either:
+ *
+ * ```kotlin
+ * fun resolveSymbol(name: String): TypeResult =
+ *     symbolTable[name].ensureFound { SymbolNotFound(name) }
+ * ```
+ *
+ * @param error Lazy error provider, called only if this value is null
+ * @return Either.Right(value) if non-null, or Either.Left(error) if null
+ */
+fun <T : Any> T?.ensureFound(error: () -> TypeInferenceError): Either<TypeInferenceError, T> =
+    this?.right() ?: error().left()
+
+/**
+ * Catch exceptions and convert them to [TypeInferenceError.InternalError].
+ *
+ * This is useful for wrapping risky operations (reflection, I/O) that
+ * might throw unexpected exceptions:
+ *
+ * ```kotlin
+ * fun reflectiveCall(obj: Any): TypeResult = catchingTypeError {
+ *     val result = obj.javaClass.getMethod("getValue").invoke(obj)
+ *     inferTypeOf(result)
+ * }
+ * ```
+ *
+ * @param block The operation that might throw
+ * @return Either.Right(result) if successful, or Either.Left(InternalError) if an exception occurred
+ */
+inline fun <T> catchingTypeError(block: () -> T): Either<TypeInferenceError, T> = runCatching { block() }.fold(
+    onSuccess = { it.right() },
+    onFailure = { ex ->
+        TypeInferenceError.InternalError(
+            reason = ex.message ?: "Unknown error: ${ex.javaClass.simpleName}",
+            cause = ex,
+        ).left()
+    },
+)

--- a/semantics/native/src/main/kotlin/com/github/albertocavalcante/gvy/semantics/native/GroovySemantics.kt
+++ b/semantics/native/src/main/kotlin/com/github/albertocavalcante/gvy/semantics/native/GroovySemantics.kt
@@ -1,9 +1,12 @@
 package com.github.albertocavalcante.gvy.semantics.native
 
+import arrow.core.left
 import com.github.albertocavalcante.groovyparser.resolution.TypeSolver
 import com.github.albertocavalcante.gvy.semantics.SemanticType
 import com.github.albertocavalcante.gvy.semantics.TypeLub
 import com.github.albertocavalcante.gvy.semantics.calculator.TypeCalculatorRegistry
+import com.github.albertocavalcante.gvy.semantics.calculator.TypeInferenceError
+import com.github.albertocavalcante.gvy.semantics.calculator.TypeResult
 import org.codehaus.groovy.ast.ASTNode
 import org.codehaus.groovy.ast.ModuleNode
 import org.codehaus.groovy.ast.expr.DeclarationExpression
@@ -32,11 +35,15 @@ class GroovySemantics(
     // Thread-safe cache of contexts per module
     private val contextCache = ConcurrentHashMap<ModuleNode, NativeTypeContext>()
 
+    // Current module for single-parameter API compatibility
+    private var currentModule: ModuleNode? = null
+
     /**
      * Inject semantics into a parsed module.
      * After injection, semantic operations are available.
      */
     fun inject(module: ModuleNode) {
+        currentModule = module
         if (!contextCache.containsKey(module)) {
             val scope = buildRootScope(module)
             val context = NativeTypeContext(
@@ -137,6 +144,30 @@ class GroovySemantics(
         ReplaceWith("resolveType(expression, module)"),
     )
     fun resolveType(expression: Expression): SemanticType = resolveType(expression as ASTNode)
+
+    /**
+     * Resolve the type of an AST node, returning Either for explicit error handling.
+     *
+     * @param node The AST node to resolve type for
+     * @return Either a TypeInferenceError or the resolved SemanticType
+     */
+    fun resolveTypeResult(node: ASTNode): TypeResult {
+        val module = currentModule
+            ?: return TypeInferenceError.InternalError("No module injected").left()
+
+        val context = contextCache[module]
+            ?: return TypeInferenceError.InternalError("Module not in context cache").left()
+
+        return calculatorRegistry.calculateResult(node, context)
+    }
+
+    /**
+     * Resolve the type of an AST node with explicit module, returning Either.
+     */
+    fun resolveTypeResult(node: ASTNode, module: ModuleNode): TypeResult {
+        inject(module)
+        return resolveTypeResult(node)
+    }
 
     /**
      * Check if a type is assignable to another.

--- a/semantics/native/src/main/kotlin/com/github/albertocavalcante/gvy/semantics/native/NativeTypeContext.kt
+++ b/semantics/native/src/main/kotlin/com/github/albertocavalcante/gvy/semantics/native/NativeTypeContext.kt
@@ -205,14 +205,16 @@ class NativeTypeContext(
     ): TypeResult = when (receiverType) {
         is SemanticType.Known -> {
             // Strategy 1: Native AST (same module) - fast path
-            nativeFinder(receiverType.fqn)
-                ?.let { converter(it).right() }
-                // Strategy 2: Workspace Index (cross-file)
-                ?: workspaceMemberLookup?.let { workspace -> workspaceDirect(workspace, receiverType.fqn) }?.right()
-                // Strategy 3: Check inherited members
-                ?: workspaceMemberLookup?.let { workspace -> workspaceInherited(workspace, receiverType.fqn) }?.right()
-                // Finally return error
-                ?: errorFactory(receiverType).left()
+            nativeFinder(receiverType.fqn)?.let { return converter(it).right() }
+
+            // Strategy 2 & 3: Workspace Index (cross-file)
+            workspaceMemberLookup?.let { workspace ->
+                workspaceDirect(workspace, receiverType.fqn)?.let { return it.right() }
+                workspaceInherited(workspace, receiverType.fqn)?.let { return it.right() }
+            }
+
+            // Not found, return error
+            errorFactory(receiverType).left()
         }
         else -> errorFactory(receiverType).left()
     }

--- a/semantics/native/src/main/kotlin/com/github/albertocavalcante/gvy/semantics/native/NativeTypeContext.kt
+++ b/semantics/native/src/main/kotlin/com/github/albertocavalcante/gvy/semantics/native/NativeTypeContext.kt
@@ -1,10 +1,14 @@
 package com.github.albertocavalcante.gvy.semantics.native
 
+import arrow.core.left
+import arrow.core.right
 import com.github.albertocavalcante.groovyparser.resolution.TypeSolver
 import com.github.albertocavalcante.gvy.semantics.SemanticType
 import com.github.albertocavalcante.gvy.semantics.TypeConstants
 import com.github.albertocavalcante.gvy.semantics.calculator.TypeCalculatorRegistry
 import com.github.albertocavalcante.gvy.semantics.calculator.TypeContext
+import com.github.albertocavalcante.gvy.semantics.calculator.TypeInferenceError
+import com.github.albertocavalcante.gvy.semantics.calculator.TypeResult
 import com.github.albertocavalcante.gvy.semantics.workspace.MemberLookup
 import org.codehaus.groovy.ast.ClassHelper
 import org.codehaus.groovy.ast.ClassNode
@@ -54,39 +58,23 @@ class NativeTypeContext(
         receiverType: SemanticType,
         methodName: String,
         argumentTypes: List<SemanticType>,
-    ): SemanticType? = when (receiverType) {
-        is SemanticType.Known -> {
-            // Strategy 1: Native AST (same module) - fast path
-            val method = findMethodInModule(receiverType.fqn, methodName, argumentTypes)
-            if (method != null) {
-                return fromClassNode(method.returnType)
-            }
-
-            // Strategy 2: Workspace Index (cross-file)
-            workspaceMemberLookup?.let { workspace ->
-                val memberInfo = workspace.findMethod(receiverType.fqn, methodName, argumentTypes.size)
-                if (memberInfo != null) {
-                    return memberInfo.type ?: SemanticType.Unknown("Method return type not indexed for $methodName")
+    ): SemanticType? = resolveFromHierarchyNullable(
+        receiverType = receiverType,
+        nativeFinder = { fqn -> findMethodInModule(fqn, methodName, argumentTypes) },
+        workspaceDirect = { workspace, fqn ->
+            workspace.findMethod(fqn, methodName, argumentTypes.size)?.type
+        },
+        workspaceInherited = { workspace, fqn ->
+            workspace.getAllMembers(fqn, includeInherited = true)
+                .find {
+                    it.name == methodName &&
+                        it.kind == com.github.albertocavalcante.gvy.semantics.db.SymbolKind.METHOD
                 }
-
-                // Check inherited members if direct lookup fails
-                val allMembers = workspace.getAllMembers(receiverType.fqn, includeInherited = true)
-                val inheritedMethod = allMembers.find {
-                    it.name == methodName && it.kind == com.github.albertocavalcante.gvy.semantics.db.SymbolKind.METHOD
-                }
-                if (inheritedMethod != null) {
-                    return inheritedMethod.type
-                        ?: SemanticType.Unknown("Inherited method return type not indexed for $methodName")
-                }
-            }
-
-            // Strategy 3: TypeSolver (classpath) - future enhancement
-            // For now, return Unknown if not found in same module or workspace
-            SemanticType.Unknown("Method $methodName not found on ${receiverType.fqn}")
-        }
-
-        else -> null // Dynamic, Null, Primitive, Array, Union types don't have methods
-    }
+                ?.type
+        },
+        converter = { fromClassNode(it.returnType) },
+        notFoundMessage = { "Method $methodName not found on $it" },
+    )
 
     /**
      * Find a method in the current module by class, method name, and argument count.
@@ -106,42 +94,28 @@ class NativeTypeContext(
         }
 
     override fun getFieldType(receiverType: SemanticType, fieldName: String): SemanticType? = when (receiverType) {
-        is SemanticType.Known -> {
-            // Strategy 1: Native AST (same module) - fast path
-            val field = findFieldInModule(receiverType.fqn, fieldName)
-            if (field != null) {
-                return fromClassNode(field.type)
-            }
-
-            // Strategy 2: Workspace Index (cross-file)
-            workspaceMemberLookup?.let { workspace ->
-                val memberInfo = workspace.findField(receiverType.fqn, fieldName)
-                if (memberInfo != null) {
-                    return memberInfo.type ?: SemanticType.Unknown("Field type not indexed for $fieldName")
-                }
-
-                // Check inherited members if direct lookup fails
-                val allMembers = workspace.getAllMembers(receiverType.fqn, includeInherited = true)
-                val inheritedField = allMembers.find {
-                    it.name == fieldName && it.kind == com.github.albertocavalcante.gvy.semantics.db.SymbolKind.FIELD
-                }
-                if (inheritedField != null) {
-                    return inheritedField.type
-                        ?: SemanticType.Unknown("Inherited field type not indexed for $fieldName")
-                }
-            }
-
-            // Strategy 3: TypeSolver (classpath) - future enhancement
-            // For now, return Unknown if not found in same module or workspace
-            SemanticType.Unknown("Field $fieldName not found on ${receiverType.fqn}")
-        }
-
         is SemanticType.Array -> {
             // Special handling: arrays have 'length' property
             if (fieldName == "length") TypeConstants.INT else null
         }
 
-        else -> null // Dynamic, Null, Primitive, Union types don't have fields
+        else -> resolveFromHierarchyNullable(
+            receiverType = receiverType,
+            nativeFinder = { fqn -> findFieldInModule(fqn, fieldName) },
+            workspaceDirect = { workspace, fqn ->
+                workspace.findField(fqn, fieldName)?.type
+            },
+            workspaceInherited = { workspace, fqn ->
+                workspace.getAllMembers(fqn, includeInherited = true)
+                    .find {
+                        it.name == fieldName &&
+                            it.kind == com.github.albertocavalcante.gvy.semantics.db.SymbolKind.FIELD
+                    }
+                    ?.type
+            },
+            converter = { fromClassNode(it.type) },
+            notFoundMessage = { "Field $fieldName not found on $it" },
+        )
     }
 
     /**
@@ -152,6 +126,165 @@ class NativeTypeContext(
         ?.find { it.name == classFqn }
         ?.fields
         ?.find { it.name == fieldName }
+
+    /**
+     * Generic member resolution helper for nullable return.
+     * Implements the three-tier resolution strategy:
+     * 1. Native AST (same module) - fast path
+     * 2. Workspace direct lookup (cross-file)
+     * 3. Workspace inherited lookup (cross-file with inheritance)
+     *
+     * @param T The native AST node type (MethodNode, FieldNode, etc.)
+     * @param receiverType The type to resolve members from
+     * @param nativeFinder Function to find member in native AST by FQN
+     * @param workspaceDirect Function to find member directly in workspace by FQN
+     * @param workspaceInherited Function to find inherited member in workspace by FQN
+     * @param converter Function to convert native AST node to SemanticType
+     * @param notFoundMessage Function to generate error message when not found
+     * @return SemanticType if found, null if receiver type doesn't support member lookup
+     */
+    private inline fun <T> resolveFromHierarchyNullable(
+        receiverType: SemanticType,
+        nativeFinder: (String) -> T?,
+        workspaceDirect: (MemberLookup, String) -> SemanticType?,
+        workspaceInherited: (MemberLookup, String) -> SemanticType?,
+        converter: (T) -> SemanticType,
+        notFoundMessage: (String) -> String,
+    ): SemanticType? = when (receiverType) {
+        is SemanticType.Known -> {
+            // Strategy 1: Native AST (same module) - fast path
+            val nativeMember = nativeFinder(receiverType.fqn)
+            if (nativeMember != null) {
+                return converter(nativeMember)
+            }
+
+            // Strategy 2: Workspace Index (cross-file)
+            workspaceMemberLookup?.let { workspace ->
+                val directMember = workspaceDirect(workspace, receiverType.fqn)
+                if (directMember != null) {
+                    return directMember
+                }
+
+                // Strategy 3: Check inherited members if direct lookup fails
+                val inheritedMember = workspaceInherited(workspace, receiverType.fqn)
+                if (inheritedMember != null) {
+                    return inheritedMember
+                }
+            }
+
+            // Not found in any strategy
+            SemanticType.Unknown(notFoundMessage(receiverType.fqn))
+        }
+
+        else -> null // Dynamic, Null, Primitive, Union types don't support member lookup
+    }
+
+    /**
+     * Generic member resolution helper for Either return (TypeResult).
+     * Implements the three-tier resolution strategy:
+     * 1. Native AST (same module) - fast path
+     * 2. Workspace direct lookup (cross-file)
+     * 3. Workspace inherited lookup (cross-file with inheritance)
+     *
+     * @param T The native AST node type (MethodNode, FieldNode, etc.)
+     * @param receiverType The type to resolve members from
+     * @param nativeFinder Function to find member in native AST by FQN
+     * @param workspaceDirect Function to find member directly in workspace by FQN
+     * @param workspaceInherited Function to find inherited member in workspace by FQN
+     * @param converter Function to convert native AST node to SemanticType
+     * @param errorFactory Function to create TypeInferenceError when not found
+     * @return Either TypeInferenceError or SemanticType
+     */
+    private inline fun <T> resolveFromHierarchyResult(
+        receiverType: SemanticType,
+        nativeFinder: (String) -> T?,
+        workspaceDirect: (MemberLookup, String) -> SemanticType?,
+        workspaceInherited: (MemberLookup, String) -> SemanticType?,
+        converter: (T) -> SemanticType,
+        errorFactory: (SemanticType) -> TypeInferenceError,
+    ): TypeResult = when (receiverType) {
+        is SemanticType.Known -> {
+            // Strategy 1: Native AST (same module) - fast path
+            nativeFinder(receiverType.fqn)
+                ?.let { converter(it).right() }
+                // Strategy 2: Workspace Index (cross-file)
+                ?: workspaceMemberLookup?.let { workspace -> workspaceDirect(workspace, receiverType.fqn) }?.right()
+                // Strategy 3: Check inherited members
+                ?: workspaceMemberLookup?.let { workspace -> workspaceInherited(workspace, receiverType.fqn) }?.right()
+                // Finally return error
+                ?: errorFactory(receiverType).left()
+        }
+        else -> errorFactory(receiverType).left()
+    }
+
+    // Either-returning methods for explicit error handling
+
+    override fun resolveTypeResult(fqn: String): TypeResult = runCatching {
+        val ref = typeSolver.tryToSolveType(fqn)
+        if (ref.isSolved) {
+            SemanticType.Known(fqn).right()
+        } else {
+            TypeInferenceError.TypeNotResolved(fqn, "Type not found").left()
+        }
+    }.getOrElse { e ->
+        TypeInferenceError.TypeNotResolved(fqn, "Error resolving: ${e.message}").left()
+    }
+
+    override fun calculateTypeResult(node: Any): TypeResult = calculatorRegistry.calculateResult(node, this)
+
+    override fun lookupSymbolResult(name: String): TypeResult = scope.lookupVariable(name)?.right()
+        ?: TypeInferenceError.SymbolNotFound(name).left()
+
+    override fun getMethodReturnTypeResult(
+        receiverType: SemanticType,
+        methodName: String,
+        argumentTypes: List<SemanticType>,
+    ): TypeResult = resolveFromHierarchyResult(
+        receiverType = receiverType,
+        nativeFinder = { fqn -> findMethodInModule(fqn, methodName, argumentTypes) },
+        workspaceDirect = { workspace, fqn ->
+            workspace.findMethod(fqn, methodName, argumentTypes.size)?.type
+        },
+        workspaceInherited = { workspace, fqn ->
+            workspace.getAllMembers(fqn, includeInherited = true)
+                .find {
+                    it.name == methodName &&
+                        it.kind == com.github.albertocavalcante.gvy.semantics.db.SymbolKind.METHOD
+                }
+                ?.type
+        },
+        converter = { fromClassNode(it.returnType) },
+        errorFactory = { TypeInferenceError.MethodNotFound(it, methodName, argumentTypes) },
+    )
+
+    override fun getFieldTypeResult(receiverType: SemanticType, fieldName: String): TypeResult = when (receiverType) {
+        is SemanticType.Array -> {
+            // Special handling: arrays have 'length' property
+            if (fieldName == "length") {
+                TypeConstants.INT.right()
+            } else {
+                TypeInferenceError.FieldNotFound(receiverType, fieldName).left()
+            }
+        }
+
+        else -> resolveFromHierarchyResult(
+            receiverType = receiverType,
+            nativeFinder = { fqn -> findFieldInModule(fqn, fieldName) },
+            workspaceDirect = { workspace, fqn ->
+                workspace.findField(fqn, fieldName)?.type
+            },
+            workspaceInherited = { workspace, fqn ->
+                workspace.getAllMembers(fqn, includeInherited = true)
+                    .find {
+                        it.name == fieldName &&
+                            it.kind == com.github.albertocavalcante.gvy.semantics.db.SymbolKind.FIELD
+                    }
+                    ?.type
+            },
+            converter = { fromClassNode(it.type) },
+            errorFactory = { TypeInferenceError.FieldNotFound(it, fieldName) },
+        )
+    }
 
     companion object {
         /**


### PR DESCRIPTION
## Summary

Implements functional error handling patterns using Arrow KT's Either type, providing explicit type inference errors instead of nullable returns. This advances Phase 6 of the semantics layer initiative.

**Key changes:**
- TypeInferenceError sealed hierarchy with 8 error types (SymbolNotFound, MethodNotFound, etc.)
- TypeResult typealias: `Either<TypeInferenceError, SemanticType>`
- Calculator registry caching for performance (#639)
- DRY resolution helpers eliminating ~100 lines of duplicate code
- SemanticTypeFormatter consolidating ~67 lines of duplicate formatting code
- All Either-returning `*Result` methods with backward-compatible defaults

## Test plan

- [x] semantics:core tests (147 passing)
- [x] semantics-native tests (53 passing)
- [x] groovy-lsp tests (all passing)
- [x] spotless formatting verified

## References

- Plan: `.plan/phase-6-functional-patterns.md`
- Calculator migration (deferred): #683
- Caching improvement: #639
- Issue: #622

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Establishes a functional error-handling foundation and consolidates type formatting.
> 
> - Adds `TypeInferenceError` sealed hierarchy and `TypeResult = Either<Error, SemanticType>`; propagates `*Result` APIs through `TypeCalculator`, `TypeCalculatorRegistry` (with calculator caching), `NativeTypeContext`, and `GroovySemantics`
> - Introduces `SemanticTypeFormatter` and replaces ad-hoc formatters in `SignatureHelpProvider`, `CompletionProvider`, and `SemanticTypeResolver` (including FQN and completion/hover formats)
> - Refactors member/type resolution in `NativeTypeContext` with shared helpers; preserves nullable APIs while adding Either-returning variants
> - Updates tests (e.g., Unknown formats to `def`) and adds Arrow/common deps in `semantics/core` build
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4545b3fd219045fbb44f975423d0823227a66b3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->