### PR TITLE
build(groovy-build-tool): add bsp-core dependency

### DIFF
--- a/groovy-build-tool/build.gradle.kts
+++ b/groovy-build-tool/build.gradle.kts
@@ -23,6 +23,9 @@ dependencies {
     // JSON parsing for BSP connection files
     implementation(libs.kotlin.serialization.json)
 
+    // BSP core module
+    implementation(project(":bsp:bsp-core"))
+
     // Maven Embedder (for programmatic dependency resolution)
     implementation(libs.maven.embedder)
     implementation(libs.maven.compat)


### PR DESCRIPTION
Adds dependency on bsp-core module to prepare for BSP integration migration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `implementation(project(":bsp:bsp-core"))` to `groovy-build-tool/build.gradle.kts` to include the BSP core module, enabling upcoming BSP integration work.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 824048d4bf673a0e00a9ead91a5680c2a6020298. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->