### PR TITLE
fix(sarif): use local variables for delegated property smart casts

### DIFF
--- a/groovy-diagnostics/sarif/src/test/kotlin/com/github/albertocavalcante/diagnostics/sarif/SarifRuleRegistryTest.kt
+++ b/groovy-diagnostics/sarif/src/test/kotlin/com/github/albertocavalcante/diagnostics/sarif/SarifRuleRegistryTest.kt
@@ -64,9 +64,10 @@ class SarifRuleRegistryTest {
         assertNotNull(rule.shortDescription)
         assertNotNull(rule.helpUri)
         assertNotNull(rule.defaultConfiguration)
-        assertNotNull(rule.properties)
-        assertNotNull(rule.properties?.priority)
-        assertNotNull(rule.properties?.category)
+        val properties = rule.properties
+        assertNotNull(properties)
+        assertNotNull(properties.priority)
+        assertNotNull(properties.category)
     }
 
     @Test

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/cli/CheckCommand.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/cli/CheckCommand.kt
@@ -186,11 +186,12 @@ class CheckCommand : CliktCommand(name = "check") {
         // Output SARIF JSON
         val json = writer.toJson(prettyPrint = true)
 
-        if (output != null) {
-            output.writeText(json)
+        val outputFile = output
+        if (outputFile != null) {
+            outputFile.writeText(json)
             if (format == OutputFormat.SARIF) {
                 // Don't pollute SARIF output with extra messages
-                logger.info("SARIF output written to ${output.absolutePath}")
+                logger.info("SARIF output written to ${outputFile.absolutePath}")
             }
         } else {
             println(json)


### PR DESCRIPTION
## Summary

Fix compilation error in CI caused by smart cast limitations on delegated properties.

Kotlin cannot smart cast delegated properties (created with `by option(...)`) after null checks. The fix captures the value in a local variable first, enabling the smart cast to work correctly.

## Changes

- `CheckCommand.kt`: Capture `output` in `outputFile` local variable before null check
- `SarifRuleRegistryTest.kt`: Capture `rule.properties` in local variable before assertions

## Test plan

- [x] `./gradlew :groovy-lsp:compileKotlin` passes
- [x] `./gradlew :groovy-diagnostics:sarif:compileTestKotlin` passes with no warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes Kotlin smart-cast issues by introducing local variables before null checks.
> 
> - In `CheckCommand.kt`, captures `output` into `outputFile` before writing/logging SARIF output
> - In `SarifRuleRegistryTest.kt`, captures `rule.properties` into `properties` before assertions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4df96e53a323b6b4374cb80b70f4f01c8351f27d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->