### PR TITLE
fix(test): handle ProgramResult in MainTest captureOutput

### DIFF
--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/MainTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/MainTest.kt
@@ -1,13 +1,20 @@
 package com.github.albertocavalcante.groovylsp
 
+import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.parse
 import com.github.albertocavalcante.groovylsp.cli.GlsCommand
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.PrintStream
+
+/**
+ * Result of a CLI command execution, capturing both output and exit code.
+ */
+private data class CommandResult(val output: String, val exitCode: Int)
 
 class MainTest {
 
@@ -21,10 +28,11 @@ class MainTest {
 
     @Test
     fun `test version command outputs version string`() {
-        val output = captureOutput {
+        val result = captureOutput {
             runWithContext("version")
         }
-        assertTrue(output.contains("gls") && output.contains("version"))
+        assertEquals(0, result.exitCode, "version command should succeed")
+        assertTrue(result.output.contains("gls") && result.output.contains("version"))
     }
 
     @Test
@@ -44,12 +52,13 @@ class MainTest {
         val tempFile = File(tempDir, "Test.groovy")
         tempFile.writeText("class Test { void foo() { println 'bar' } }")
 
-        val output = captureOutput {
+        val result = captureOutput {
             runWithContext("format", tempFile.absolutePath)
         }
 
+        assertEquals(0, result.exitCode, "format command should succeed")
         // The formatter should produce some output (the formatted file content)
-        assertTrue(output.isNotEmpty(), "Expected formatted output, got empty string")
+        assertTrue(result.output.isNotEmpty(), "Expected formatted output, got empty string")
     }
 
     @Test
@@ -57,12 +66,13 @@ class MainTest {
         val tempFile = File(tempDir, "Test.groovy")
         tempFile.writeText("class Test { void foo() { println 'bar' } }")
 
-        val output = captureOutput {
+        val result = captureOutput {
             runWithContext("check", tempFile.absolutePath)
         }
 
+        assertEquals(0, result.exitCode, "check command should succeed for valid file")
         // Valid file should produce "OK" output
-        assertTrue(output.contains("OK") || output.contains(tempFile.name))
+        assertTrue(result.output.contains("OK") || result.output.contains(tempFile.name))
     }
 
     @Test
@@ -70,14 +80,15 @@ class MainTest {
         val errorFile = File(tempDir, "Error.groovy")
         errorFile.writeText("class Error { void foo() { println 'bar' ") // Missing closing braces
 
-        val output = captureOutput {
+        val result = captureOutput {
             runWithContext("check", errorFile.absolutePath)
         }
 
+        assertEquals(1, result.exitCode, "check command should exit with code 1 for errors")
         // The check command should output the error file path or an ERROR severity
         assertTrue(
-            output.contains(errorFile.name) || output.contains("ERROR"),
-            "Expected error file name or ERROR in output, got: $output",
+            result.output.contains(errorFile.name) || result.output.contains("ERROR"),
+            "Expected error file name or ERROR in output, got: ${result.output}",
         )
     }
 
@@ -86,41 +97,47 @@ class MainTest {
         val errorFile = File(tempDir, "Error.groovy")
         errorFile.writeText("class Error { void foo() { println 'bar' ") // Missing closing braces
 
-        val output = captureOutput {
+        val result = captureOutput {
             // --no-color is a global option, must precise before subcommand
             runWithContext("--no-color", "check", errorFile.absolutePath)
         }
 
+        assertEquals(1, result.exitCode, "check command should exit with code 1 for errors")
         // Output should contain "[ERROR]" (plain text)
-        assertTrue(output.contains("[ERROR]"), "Expected plain [ERROR] tag, got: $output")
+        assertTrue(result.output.contains("[ERROR]"), "Expected plain [ERROR] tag, got: ${result.output}")
 
         // Output should NOT contain ANSI escape codes
         val ansiEscape = "\u001B"
-        assertTrue(!output.contains(ansiEscape), "Output should not contain ANSI codes, got: $output")
+        assertTrue(!result.output.contains(ansiEscape), "Output should not contain ANSI codes, got: ${result.output}")
     }
 
     @Test
     fun `test execute command runs groovy version`() {
-        val output = captureOutput {
+        val result = captureOutput {
             runWithContext("execute", "groovy.version")
         }
 
+        assertEquals(0, result.exitCode, "execute command should succeed")
         // Should output something containing version info
-        assertTrue(output.isNotEmpty())
+        assertTrue(result.output.isNotEmpty())
     }
 
     /**
      * Captures stdout output during the execution of a block.
+     * Returns both output and exit code so tests can assert on command success/failure.
      */
-    private fun captureOutput(block: () -> Unit): String {
+    private fun captureOutput(block: () -> Unit): CommandResult {
         val originalOut = System.out
         val baos = ByteArrayOutputStream()
         System.setOut(PrintStream(baos))
+        var exitCode = 0
         try {
             block()
+        } catch (e: ProgramResult) {
+            exitCode = e.statusCode
         } finally {
             System.setOut(originalOut)
         }
-        return baos.toString()
+        return CommandResult(baos.toString(), exitCode)
     }
 }


### PR DESCRIPTION
## Summary

Fix test failures in `MainTest` caused by unhandled `ProgramResult` exceptions.

## Problem

CLI commands use `ProgramResult` to signal exit codes. The `check` command throws `ProgramResult(1)` when errors are found (correct behavior), but the test's `captureOutput` helper wasn't catching this exception, causing tests to fail even though output was correctly captured.

## Solution

Updated `captureOutput` to catch `ProgramResult` exceptions, allowing tests to verify CLI output even when commands exit with non-zero codes.

## Test plan

- [x] All 7 `MainTest` tests pass locally
- [x] `test check command reports errors` - now passes
- [x] `test check respects no-color flag` - now passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves CLI test robustness by capturing exit codes and outputs, fixing failures when commands use `ProgramResult`.
> 
> - Add `CommandResult` and update `captureOutput` to catch `ProgramResult` and return `exitCode` plus captured `output`
> - Update tests for `version`, `format`, `check`, and `execute` to assert on `exitCode` and key output; ensure `--no-color` `check` output has `[ERROR]` without ANSI codes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8bb5b46e08e80219f96eb3b47ca05c87ad5fbb0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for CLI behavior by validating exit codes and captured output for success and error scenarios.
  * Added verification that the "no-color" option produces output without ANSI color codes.
  * Changes are test-only and do not affect user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->