### PR TITLE
feat(hover): Phase 3 - visual hierarchy and documentation sections (#727)

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/documentation/DocFormatter.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/documentation/DocFormatter.kt
@@ -36,7 +36,8 @@ object DocFormatter {
             }
 
             // Phase 3: Add visual separator before documentation sections if we have content above
-            val hasContentAbove = doc.summary.isNotBlank() || doc.description.isNotBlank()
+            val hasContentAbove =
+                doc.deprecated.isNotBlank() || doc.summary.isNotBlank() || doc.description.isNotBlank()
             val hasDocSections = (includeParams && doc.params.isNotEmpty()) ||
                 (includeReturn && doc.returnDoc.isNotBlank()) ||
                 doc.throws.isNotEmpty() ||
@@ -85,7 +86,11 @@ object DocFormatter {
             // Phase 3: Metadata footer with visual separator
             val hasMetadata = doc.since.isNotBlank() || doc.author.isNotBlank()
             if (hasMetadata) {
-                markdown("---")
+                // Only add separator if there's content above the metadata footer
+                val hasContentAboveFooter = hasContentAbove || hasDocSections
+                if (hasContentAboveFooter) {
+                    markdown("---")
+                }
 
                 val metadataParts = mutableListOf<String>()
                 if (doc.since.isNotBlank()) {

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/documentation/DocFormatterTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/documentation/DocFormatterTest.kt
@@ -360,7 +360,7 @@ class DocFormatterTest {
     }
 
     @Test
-    fun `formatAsMarkdown with only metadata shows footer without leading separator`() {
+    fun `formatAsMarkdown with summary and metadata shows separator before footer`() {
         val doc = Documentation(
             summary = "Simple method.",
             since = "2.0",
@@ -368,8 +368,48 @@ class DocFormatterTest {
 
         val result = DocFormatter.formatAsMarkdown(doc)
 
-        // Should have metadata but check separator placement
+        // Should have metadata with separator since there's content above
         assertTrue(result.contains("*@since 2.0*"))
         assertTrue(result.contains("---"))
+    }
+
+    @Test
+    fun `formatAsMarkdown with only metadata shows footer without leading separator`() {
+        val doc = Documentation(
+            since = "2.0",
+        )
+
+        val result = DocFormatter.formatAsMarkdown(doc)
+
+        // Should have metadata but NO separator since there's no content above
+        assertTrue(result.contains("*@since 2.0*"))
+        assertTrue(!result.contains("---"), "Should NOT have separator when only metadata is present")
+    }
+
+    @Test
+    fun `formatAsMarkdown with only deprecated and params shows separator between sections`() {
+        val doc = Documentation(
+            deprecated = "Use newMethod() instead",
+            params = mapOf("x" to "first param"),
+        )
+
+        val result = DocFormatter.formatAsMarkdown(doc)
+
+        // Should have separator between deprecation and params since deprecation is "content above"
+        assertTrue(result.contains("⚠️ **Deprecated**"))
+        assertTrue(result.contains("#### Parameters"))
+
+        val lines = result.lines()
+        val deprecationIndex = lines.indexOfFirst { it.contains("Deprecated") }
+        val separatorIndex = lines.indexOfFirst { it.trim() == "---" }
+        val paramsIndex = lines.indexOfFirst { it.contains("#### Parameters") }
+
+        assertTrue(deprecationIndex >= 0, "Should have deprecation")
+        assertTrue(separatorIndex >= 0, "Should have separator")
+        assertTrue(paramsIndex >= 0, "Should have params section")
+        assertTrue(
+            deprecationIndex < separatorIndex && separatorIndex < paramsIndex,
+            "Separator should be between deprecation and params",
+        )
     }
 }


### PR DESCRIPTION
## Summary

This PR implements **Phase 3** of the hover redesign (#727), adding visual hierarchy and improved documentation formatting to make hover content more scannable and professional.

### Key Enhancements

#### 1. Deprecation Warnings at Top with Visual Prominence
- Moved deprecation notices to the **top** of hover content
- Uses blockquote format with warning emoji: `> ⚠️ **Deprecated**`
- Ensures deprecated APIs are immediately visible before reading further

#### 2. Section Headers for Better Organization
- Added markdown headers (`####`) for all documentation sections:
  - **Parameters**, **Returns**, **Throws**, **See Also**
- Improves scannability and creates clear visual hierarchy
- Users can quickly jump to relevant sections

#### 3. Smart Parameter Formatting
- **Table format** for methods with 2+ parameters:
  - Includes Name, Type, Description columns
  - Better for complex method signatures with many parameters
- **Inline format** for single parameters:
  - Cleaner, more concise display
  - Uses em dash separator: `**param** — description`

#### 4. Metadata Footer
- Display `@since` and `@author` in italics at bottom
- Separate multiple metadata items with bullet separator (·)
- Add horizontal rule before footer for visual separation
- Keeps metadata visible but not distracting

#### 5. Visual Separators
- Add horizontal rules (`---`) between major sections
- Improves document structure and readability
- Creates clear boundaries between content, documentation, and metadata

### Example Output

**Before (Phase 2):**
```markdown
Calculates the sum of two numbers.

**Parameters:**
- `x`: the first number
- `y`: the second number

**Returns:** the sum

**Deprecated**: Use Calculator.add() instead.
```

**After (Phase 3):**
```markdown
> ⚠️ **Deprecated**: Use Calculator.add() instead.

Calculates the sum of two numbers.

---

#### Parameters
| Name | Type | Description |
| --- | --- | --- |
| `x` |  | the first number |
| `y` |  | the second number |

#### Returns
the sum

---

*@since 1.0* · *@author John Doe*
```

## Testing Approach

Followed **TDD** (Test-Driven Development):

1. ✅ Wrote 11 new comprehensive tests covering all Phase 3 features
2. ✅ Ran tests to verify they failed initially (red)
3. ✅ Implemented the functionality to make tests pass (green)
4. ✅ Updated existing tests to match new format
5. ✅ All 23 DocFormatter tests passing

### Test Coverage

New tests added:
- Deprecation warning at top with visual prominence
- Multiple params use table format with section header
- Single param uses inline format
- Return doc shows section header
- Throws shows section header
- Metadata shows footer with separators
- Visual separators between major sections
- See Also shows section header
- No deprecation warning when not deprecated
- Footer formatting without leading separator

## Quality Checklist

- [x] Tests written FIRST (TDD)
- [x] All new tests pass
- [x] Existing tests updated and pass
- [x] Spotless applied
- [x] No breaking changes
- [x] Follows project conventions

## Related Issues

Closes #727

## Next Steps

Phase 4 (if planned): Integration with signature formatting for complete hover experience

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces Phase 3 hover markdown formatting improvements in `DocFormatter` and expands tests to validate the new structure.
> 
> - Deprecation moved to the top as a blockquote with emoji (`> ⚠️ **Deprecated** ...`)
> - Adds `####` headers for `Parameters`, `Returns`, `Throws`, and `See Also`
> - Smart parameters: table for multiple params, inline with em dash for single param
> - Inserts `---` separators between content, doc sections, and footer
> - Metadata footer renders `@since`/`@author` in italics joined by ` · `
> - Updates existing tests and adds comprehensive new tests to cover all Phase 3 behaviors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02b87c91a2e5f148319ab04e6be7d8615b1ef353. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deprecation warnings displayed prominently at the top of documentation
  * Structured documentation sections with clear headers (Parameters, Returns, Throws, See Also)
  * Parameters formatted as tables for multiple entries or inline for single entries
  * Metadata footer displaying since and author information
  * Enhanced visual separation between documentation sections

* **Tests**
  * Expanded test coverage for new formatting scenarios and edge cases

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->