### PR TITLE
fix(lsp): avoid workspace source fanout in on-demand compile

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/compilation/CompilationOrchestrator.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/compilation/CompilationOrchestrator.kt
@@ -85,11 +85,13 @@ class CompilationOrchestrator(dependencies: CompilationOrchestratorDependencies)
         uri: URI,
         content: String,
         compilePhase: Int = Phases.CANONICALIZATION,
+        workspaceSourcesOverride: List<Path>? = null,
     ): CompilationResult {
         val sourcePath = runCatching { Path.of(uri) }.getOrNull()
 
         // Get file-specific classpath
         val classpath = workspaceManager.getClasspathForFile(uri, content)
+        val workspaceSources = workspaceSourcesOverride ?: workspaceManager.getWorkspaceSources()
 
         // Parse the source code
         val parseResult = workerSessionManager.parse(
@@ -98,7 +100,7 @@ class CompilationOrchestrator(dependencies: CompilationOrchestratorDependencies)
                 content = content,
                 classpath = classpath,
                 sourceRoots = workspaceManager.getSourceRoots(),
-                workspaceSources = workspaceManager.getWorkspaceSources(),
+                workspaceSources = workspaceSources,
                 locatorCandidates = buildLocatorCandidates(uri, sourcePath),
                 compilePhase = compilePhase,
             ),
@@ -199,7 +201,10 @@ class CompilationOrchestrator(dependencies: CompilationOrchestratorDependencies)
                 val content = kotlinx.coroutines.withContext(ioDispatcher) {
                     Files.readString(path)
                 }
-                compile(uri, content)
+                // TODO(#743): Define explicit parse modes and cache authority to avoid cross-source divergence.
+                //   See: https://github.com/albertocavalcante/gvy/issues/743
+                // Skip workspace sources to avoid full-workspace recompiles on on-demand requests.
+                performCompilation(uri, content, workspaceSourcesOverride = emptyList())
             } catch (e: Exception) {
                 logger.error("Failed to compile from disk for $uri: ${e.message}", e)
                 null

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/compilation/CompilationOrchestratorTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/compilation/CompilationOrchestratorTest.kt
@@ -1,0 +1,82 @@
+package com.github.albertocavalcante.groovylsp.compilation
+
+import com.github.albertocavalcante.nativeapi.ParseRequest
+import com.github.albertocavalcante.nativeapi.ParseResult
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class CompilationOrchestratorTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `ensureCompiled on-disk parse does not include workspace sources`() = runBlocking {
+        val targetPath = tempDir.resolve("Target.groovy")
+        Files.writeString(
+            targetPath,
+            """
+            class Target {
+            }
+            """.trimIndent(),
+        )
+        val targetUri = targetPath.toUri()
+
+        val workspaceSource = tempDir.resolve("Workspace.groovy")
+        Files.writeString(
+            workspaceSource,
+            """
+            class Workspace {
+            }
+            """.trimIndent(),
+        )
+
+        val requestSlot = slot<ParseRequest>()
+        val workerSessionManager = mockk<com.github.albertocavalcante.groovylsp.worker.WorkerSessionManager>()
+        val parseResult = ParseResult(
+            ast = null,
+            compilationUnit = mockk(relaxed = true),
+            sourceUnit = mockk(relaxed = true),
+            diagnostics = emptyList(),
+            symbolTable = mockk(relaxed = true),
+            astModel = mockk(relaxed = true),
+            tokenIndex = null,
+        )
+        every { workerSessionManager.parse(capture(requestSlot)) } returns parseResult
+
+        val workspaceManager = mockk<WorkspaceManager>()
+        every { workspaceManager.getClasspathForFile(any(), any()) } returns emptyList()
+        every { workspaceManager.getSourceRoots() } returns listOf(tempDir)
+        every { workspaceManager.getWorkspaceSources() } returns listOf(workspaceSource)
+
+        val orchestrator = CompilationOrchestrator(
+            CompilationOrchestratorDependencies(
+                cacheService = CompilationCacheService(),
+                workerSessionManager = workerSessionManager,
+                workspaceManager = workspaceManager,
+                symbolIndexer = mockk(relaxed = true),
+                parseAccessor = mockk(relaxed = true) {
+                    every { isSuspiciousScript(any(), any()) } returns false
+                },
+                resultMapper = CompilationResultMapper(),
+                ioDispatcher = Dispatchers.Unconfined,
+                errorHandler = CompilationErrorHandler(),
+            ),
+        )
+
+        val result = orchestrator.ensureCompiled(URI.create(targetUri.toString()))
+
+        assertNotNull(result)
+        assertTrue(requestSlot.captured.workspaceSources.isEmpty())
+    }
+}

--- a/parser/native/src/main/kotlin/com/github/albertocavalcante/groovyparser/GroovyParserFacade.kt
+++ b/parser/native/src/main/kotlin/com/github/albertocavalcante/groovyparser/GroovyParserFacade.kt
@@ -356,6 +356,8 @@ class GroovyParserFacade(private val parentClassLoader: ClassLoader = ClassLoade
     private fun extractAst(compilationUnit: CompilationUnit): ModuleNode? = try {
         val ast = compilationUnit.ast
         if (ast?.modules?.isNotEmpty() == true) {
+            // TODO(#743): Ensure module selection is deterministic for the requested source when workspace sources exist.
+            //   See: https://github.com/albertocavalcante/gvy/issues/743
             ast.modules.first()
         } else {
             logger.debug("No modules available in compilation unit")

--- a/parser/native/src/test/kotlin/com/github/albertocavalcante/groovyparser/GroovyParserFacadeTest.kt
+++ b/parser/native/src/test/kotlin/com/github/albertocavalcante/groovyparser/GroovyParserFacadeTest.kt
@@ -93,6 +93,34 @@ class GroovyParserFacadeTest {
     }
 
     @Test
+    fun `parse returns ast for requested source when workspace sources are present`() {
+        val extraSource = tempDir.resolve("Aardvark.groovy").toFile()
+        extraSource.writeText(
+            """
+            class Aardvark {
+            }
+            """.trimIndent(),
+        )
+
+        val request = ParseRequest(
+            uri = URI.create("file:///Zebra.groovy"),
+            content = """
+                class Zebra {
+                }
+            """.trimIndent(),
+            workspaceSources = listOf(extraSource.toPath()),
+        )
+
+        val result = parser.parse(request)
+
+        assertTrue(result.isSuccessful)
+        val module = result.ast
+        assertNotNull(module)
+        assertEquals(request.sourceUnitName, module.context?.name)
+        assertTrue(module.classes.any { it.nameWithoutPackage == "Zebra" })
+    }
+
+    @Test
     fun `parse populates recursive ast model by default`() {
         val code = """
             class Sample {


### PR DESCRIPTION
## Summary
- Avoid workspace source fanout when compiling on-demand from disk in `ensureCompiled`
- Add tests for minimal on-demand parse behavior
- Add parser test to keep requested source as AST anchor when workspace sources are present
- Add TODOs linked to #743 for deeper parse-mode architecture work

## Testing
- `./gradlew :parser:native:test --tests "*GroovyParserFacadeTest*parse returns ast for requested source when workspace sources are present"`
- `./gradlew :groovy-lsp:test --tests "*CompilationOrchestratorTest*ensureCompiled on-disk parse does not include workspace sources"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents full-workspace recompiles when compiling on-demand from disk and ensures AST selection favors the requested file.
> 
> - Add `workspaceSourcesOverride` to `performCompilation` and use `emptyList()` in `ensureCompiled` on-disk path to exclude `workspaceSources`
> - Tests: `CompilationOrchestratorTest` asserts on-disk parse omits `workspaceSources`; `GroovyParserFacadeTest` verifies AST corresponds to requested source when workspace sources exist
> - Minor: add TODOs linked to `#743` in `ensureCompiled` and `extractAst` for future parse-mode/AST selection work
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 518a939451736e63a5262bb18a52d2d7a0caaa22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * On-disk compilation now correctly excludes workspace sources, preventing potential cross-source conflicts during on-demand recompilations.

* **Tests**
  * Added test coverage for on-disk compilation behavior with workspace sources.
  * Added test coverage for AST parsing with multiple source files present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->