### PR TITLE
ci: add E2E test report to GitHub Actions UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -673,6 +673,15 @@ jobs:
             **/build/reports/tests/e2eTest/
           retention-days: 7
 
+      - name: Generate E2E Test Report
+        uses: dorny/test-reporter@e17be7e0078fc00f61965f3b4032f1e1fdc7fcfb # v2.4.0
+        if: success() || failure()
+        with:
+          name: E2E Test Results
+          path: '**/build/test-results/e2eTest/*.xml'
+          reporter: java-junit
+          fail-on-error: false
+
   # Cross-platform smoke tests - verify JAR works on key platforms
   # Lighter weight than release matrix, runs on every main merge for faster feedback
   smoke-test:


### PR DESCRIPTION
## Summary
- Add `dorny/test-reporter` step to display E2E test results in GitHub Checks UI
- Matches existing unit test reporting configuration
- E2E tests already output JUnit XML format via Gradle/JUnit 5

## Test plan
- [ ] Verify E2E tests run and report appears in GitHub Checks
- [ ] Confirm test results show individual scenario breakdowns

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds E2E test result publishing to GitHub Checks.
> 
> - New `dorny/test-reporter` step in `e2e-test` job to render `e2eTest` JUnit XML (`**/build/test-results/e2eTest/*.xml`) in Checks UI
> - Configured with `reporter: java-junit` and `fail-on-error: false` so reporting runs on success or failure
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32c994d09ed73b3a772e1f36c6d1feb642fea745. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD test reporting infrastructure to improve quality assurance processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->