### PR TITLE
feat(lsp): add MethodCallExpression handling to GroovySemanticTokenProvider

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/semantictokens/GroovySemanticTokenProvider.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/semantictokens/GroovySemanticTokenProvider.kt
@@ -149,8 +149,8 @@ object GroovySemanticTokenProvider {
             logger.error("Index out of bounds while generating semantic tokens for {}: {}", uri, e.message, e)
         } catch (e: IllegalStateException) {
             logger.error("Illegal state while generating semantic tokens for {}: {}", uri, e.message, e)
-        } catch (@Suppress("TooGenericExceptionCaught") e: RuntimeException) {
-            // Catch remaining runtime exceptions to prevent LSP crashes
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            // Catch remaining exceptions to prevent LSP crashes
             logger.error(
                 "Unexpected error generating semantic tokens for {}: {} - {}",
                 uri,

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/semantictokens/GroovySemanticTokenProviderTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/semantictokens/GroovySemanticTokenProviderTest.kt
@@ -415,8 +415,9 @@ class GroovySemanticTokenProviderTest {
         val enumMemberTokens = tokens.filter {
             it.tokenType == GroovySemanticTokenProvider.TokenTypes.ENUM_MEMBER
         }
-        assertTrue(
-            enumMemberTokens.size >= 3,
+        assertEquals(
+            3,
+            enumMemberTokens.size,
             "Should have ENUM_MEMBER tokens for enum constants, got ${enumMemberTokens.size}",
         )
     }
@@ -656,11 +657,10 @@ class GroovySemanticTokenProviderTest {
 
         // Should have METHOD tokens for both declaration and call
         val methodTokens = tokens.filter {
-            it.tokenType == GroovySemanticTokenProvider.TokenTypes.METHOD ||
-                it.tokenType == GroovySemanticTokenProvider.TokenTypes.FUNCTION
+            it.tokenType == GroovySemanticTokenProvider.TokenTypes.METHOD
         }
 
-        // We should have 3 METHOD/FUNCTION tokens:
+        // We should have 3 METHOD tokens:
         // 1. caller declaration
         // 2. process() call
         // 3. process declaration
@@ -684,10 +684,9 @@ class GroovySemanticTokenProviderTest {
 
         val tokens = GroovySemanticTokenProvider.getSemanticTokens(astModel, uri)
 
-        // Should have METHOD/FUNCTION tokens for both method calls
+        // Should have METHOD tokens for both method calls
         val methodTokens = tokens.filter {
-            it.tokenType == GroovySemanticTokenProvider.TokenTypes.METHOD ||
-                it.tokenType == GroovySemanticTokenProvider.TokenTypes.FUNCTION
+            it.tokenType == GroovySemanticTokenProvider.TokenTypes.METHOD
         }
 
         val toUpperCaseToken = methodTokens.find { it.length == "toUpperCase".length }
@@ -715,10 +714,9 @@ class GroovySemanticTokenProviderTest {
 
         val tokens = GroovySemanticTokenProvider.getSemanticTokens(astModel, uri)
 
-        // Should have METHOD/FUNCTION token for add()
+        // Should have METHOD token for add()
         val methodTokens = tokens.filter {
-            it.tokenType == GroovySemanticTokenProvider.TokenTypes.METHOD ||
-                it.tokenType == GroovySemanticTokenProvider.TokenTypes.FUNCTION
+            it.tokenType == GroovySemanticTokenProvider.TokenTypes.METHOD
         }
 
         val addToken = methodTokens.find { it.length == "add".length }
@@ -741,10 +739,9 @@ class GroovySemanticTokenProviderTest {
 
         val tokens = GroovySemanticTokenProvider.getSemanticTokens(astModel, uri)
 
-        // Should have METHOD/FUNCTION tokens for helper (declaration and call)
+        // Should have METHOD tokens for helper (declaration and call)
         val methodTokens = tokens.filter {
-            it.tokenType == GroovySemanticTokenProvider.TokenTypes.METHOD ||
-                it.tokenType == GroovySemanticTokenProvider.TokenTypes.FUNCTION
+            it.tokenType == GroovySemanticTokenProvider.TokenTypes.METHOD
         }
 
         val helperTokens = methodTokens.filter { it.length == "helper".length }
@@ -789,10 +786,9 @@ class GroovySemanticTokenProviderTest {
 
         val tokens = GroovySemanticTokenProvider.getSemanticTokens(astModel, uri)
 
-        // Should have METHOD/FUNCTION token for 'each' method call
+        // Should have METHOD token for 'each' method call
         val methodTokens = tokens.filter {
-            it.tokenType == GroovySemanticTokenProvider.TokenTypes.METHOD ||
-                it.tokenType == GroovySemanticTokenProvider.TokenTypes.FUNCTION
+            it.tokenType == GroovySemanticTokenProvider.TokenTypes.METHOD
         }
 
         val eachToken = methodTokens.find { it.length == "each".length }


### PR DESCRIPTION
## Summary

Adds semantic token support for method calls, enabling IDE highlighting
of method invocations in Groovy code.

- Handle `MethodCallExpression` for instance method calls (e.g., `obj.method()`, `method()`)
- Handle `StaticMethodCallExpression` for static method calls (e.g., `ClassName.staticMethod()`)
- Add TDD tests covering method call tokenization scenarios

## Dependencies

This PR depends on #765 (feat: integrate GroovySemanticTokenProvider) which introduces the base provider.

## Test plan

- [x] TDD tests for method call tokenization
- [x] Tests for chained method calls
- [x] Tests for static method calls
- [x] Tests for method calls with closure arguments
- [x] All existing semantic token tests pass

Closes #762

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables semantic highlighting of method invocations in Groovy code.
> 
> - Tokenize `MethodCallExpression` and `StaticMethodCallExpression` as `METHOD` (static calls marked with `STATIC`)
> - Integrated new handlers into AST traversal; added `visitMethodCallExpression` and `visitStaticMethodCallExpression`
> - Broadened error handling to catch `Exception` to prevent LSP crashes
> - Tests: updated method declaration test to include calls; added cases for chained calls, object calls, static calls, constructor call (non-crash), and closure-arg calls; tightened enum member assertion to exact count
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c962576b2c22191a072f7db1ad73b517fe70dced. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->