### PR TITLE
feat(parser): add ParseMode for isolated on-demand compilation

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/compilation/CompilationOrchestrator.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/compilation/CompilationOrchestrator.kt
@@ -3,6 +3,7 @@ package com.github.albertocavalcante.groovylsp.compilation
 import com.github.albertocavalcante.groovylsp.worker.WorkerSessionManager
 import com.github.albertocavalcante.gvy.semantics.db.GroovySemanticDB
 import com.github.albertocavalcante.gvy.semantics.db.SemanticDocumentBuilder
+import com.github.albertocavalcante.nativeapi.ParseMode
 import com.github.albertocavalcante.nativeapi.ParseRequest
 import com.github.albertocavalcante.nativeapi.ParseResult
 import kotlinx.coroutines.CancellationException
@@ -85,13 +86,14 @@ class CompilationOrchestrator(dependencies: CompilationOrchestratorDependencies)
         uri: URI,
         content: String,
         compilePhase: Int = Phases.CANONICALIZATION,
-        workspaceSourcesOverride: List<Path>? = null,
+        parseMode: ParseMode = ParseMode.WORKSPACE,
     ): CompilationResult {
         val sourcePath = runCatching { Path.of(uri) }.getOrNull()
 
         // Get file-specific classpath
         val classpath = workspaceManager.getClasspathForFile(uri, content)
-        val workspaceSources = workspaceSourcesOverride ?: workspaceManager.getWorkspaceSources()
+        // Workspace sources are still passed but ParseMode controls whether they're used
+        val workspaceSources = workspaceManager.getWorkspaceSources()
 
         // Parse the source code
         val parseResult = workerSessionManager.parse(
@@ -103,6 +105,7 @@ class CompilationOrchestrator(dependencies: CompilationOrchestratorDependencies)
                 workspaceSources = workspaceSources,
                 locatorCandidates = buildLocatorCandidates(uri, sourcePath),
                 compilePhase = compilePhase,
+                parseMode = parseMode,
             ),
         )
 
@@ -198,13 +201,11 @@ class CompilationOrchestrator(dependencies: CompilationOrchestratorDependencies)
         if (path != null && Files.exists(path) && Files.isRegularFile(path)) {
             logger.debug("Compiling from disk on-demand: $uri")
             return try {
-                val content = kotlinx.coroutines.withContext(ioDispatcher) {
+                val content = withContext(ioDispatcher) {
                     Files.readString(path)
                 }
-                // TODO(#743): Define explicit parse modes and cache authority to avoid cross-source divergence.
-                //   See: https://github.com/albertocavalcante/gvy/issues/743
-                // Skip workspace sources to avoid full-workspace recompiles on on-demand requests.
-                performCompilation(uri, content, workspaceSourcesOverride = emptyList())
+                // Use MINIMAL mode for on-demand navigation requests to avoid workspace-wide recompiles
+                performCompilation(uri, content, parseMode = ParseMode.MINIMAL)
             } catch (e: Exception) {
                 logger.error("Failed to compile from disk for $uri: ${e.message}", e)
                 null

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/compilation/CompilationOrchestratorTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/compilation/CompilationOrchestratorTest.kt
@@ -1,5 +1,6 @@
 package com.github.albertocavalcante.groovylsp.compilation
 
+import com.github.albertocavalcante.nativeapi.ParseMode
 import com.github.albertocavalcante.nativeapi.ParseRequest
 import com.github.albertocavalcante.nativeapi.ParseResult
 import io.mockk.every
@@ -12,8 +13,8 @@ import org.junit.jupiter.api.io.TempDir
 import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 class CompilationOrchestratorTest {
 
@@ -77,6 +78,7 @@ class CompilationOrchestratorTest {
         val result = orchestrator.ensureCompiled(URI.create(targetUri.toString()))
 
         assertNotNull(result)
-        assertTrue(requestSlot.captured.workspaceSources.isEmpty())
+        // ParseMode.MINIMAL ensures workspace sources are skipped during parsing (Issue #743)
+        assertEquals(ParseMode.MINIMAL, requestSlot.captured.parseMode)
     }
 }

--- a/parser/native/src/main/kotlin/com/github/albertocavalcante/groovyparser/GroovyParserFacade.kt
+++ b/parser/native/src/main/kotlin/com/github/albertocavalcante/groovyparser/GroovyParserFacade.kt
@@ -5,6 +5,7 @@ import com.github.albertocavalcante.groovyparser.ast.SymbolTable
 import com.github.albertocavalcante.groovyparser.ast.visitor.RecursiveAstVisitor
 import com.github.albertocavalcante.groovyparser.internal.ParserDiagnosticConverter
 import com.github.albertocavalcante.groovyparser.tokens.GroovyTokenIndex
+import com.github.albertocavalcante.nativeapi.ParseMode
 import com.github.albertocavalcante.nativeapi.ParseRequest
 import com.github.albertocavalcante.nativeapi.ParseResult
 import com.github.albertocavalcante.nativeapi.ParserSeverity
@@ -215,7 +216,7 @@ class GroovyParserFacade(private val parentClassLoader: ClassLoader = ClassLoade
 
         val tokenIndex = GroovyTokenIndex.build(request.content)
 
-        val ast = extractAst(compilationUnit)
+        val ast = extractAst(compilationUnit, request.sourceUnitName)
         val diagnostics =
             ParserDiagnosticConverter.convert(compilationUnit.errorCollector, request.locatorCandidates).toMutableList()
 
@@ -337,6 +338,12 @@ class GroovyParserFacade(private val parentClassLoader: ClassLoader = ClassLoade
     }
 
     private fun addWorkspaceSources(compilationUnit: CompilationUnit, request: ParseRequest) {
+        // In MINIMAL mode, skip workspace sources for fast, isolated parsing (Issue #743)
+        if (request.parseMode == ParseMode.MINIMAL) {
+            logger.trace("Skipping workspace sources in MINIMAL mode for {}", request.uri)
+            return
+        }
+
         request.workspaceSources
             .filter {
                 it.toUri() != request.uri &&
@@ -345,20 +352,39 @@ class GroovyParserFacade(private val parentClassLoader: ClassLoader = ClassLoade
             }
             .forEach { path ->
                 runCatching {
-                    logger.debug("Adding workspace source: $path")
+                    logger.trace("Adding workspace source: $path")
                     compilationUnit.addSource(path.toFile())
                 }.onFailure { throwable ->
-                    logger.debug("Failed adding workspace source {}: {}", path, throwable.message)
+                    logger.trace("Failed adding workspace source {}: {}", path, throwable.message)
                 }
             }
     }
 
-    private fun extractAst(compilationUnit: CompilationUnit): ModuleNode? = try {
+    /**
+     * Extracts the AST module for the requested source file.
+     *
+     * When workspace sources are included, multiple modules may exist in the compilation unit.
+     * This method ensures deterministic selection by matching the requested source's name.
+     *
+     * @param compilationUnit The compiled unit containing all modules
+     * @param sourceUnitName The name of the requested source (from ParseRequest.sourceUnitName)
+     * @return The module matching the requested source, or first module as fallback
+     */
+    private fun extractAst(compilationUnit: CompilationUnit, sourceUnitName: String): ModuleNode? = try {
         val ast = compilationUnit.ast
         if (ast?.modules?.isNotEmpty() == true) {
-            // TODO(#743): Ensure module selection is deterministic for the requested source when workspace sources exist.
-            //   See: https://github.com/albertocavalcante/gvy/issues/743
-            ast.modules.first()
+            // Deterministic module selection: find the module matching the requested source
+            ast.modules.find { module ->
+                module.context?.name == sourceUnitName
+            } ?: run {
+                // Fallback to first module if no match (e.g., if source was parsed with different name)
+                logger.debug(
+                    "Requested source '{}' not found in {} modules, using first",
+                    sourceUnitName,
+                    ast.modules.size,
+                )
+                ast.modules.first()
+            }
         } else {
             logger.debug("No modules available in compilation unit")
             null

--- a/parser/native/src/main/kotlin/com/github/albertocavalcante/nativeapi/ParseRequest.kt
+++ b/parser/native/src/main/kotlin/com/github/albertocavalcante/nativeapi/ParseRequest.kt
@@ -5,6 +5,34 @@ import java.net.URI
 import java.nio.file.Path
 
 /**
+ * Parsing mode controlling workspace source inclusion and caching behavior.
+ *
+ * @see <a href="https://github.com/albertocavalcante/gvy/issues/743">Issue #743</a>
+ */
+enum class ParseMode {
+    /**
+     * Minimal parsing without workspace sources.
+     *
+     * Use for on-demand compilation in navigation operations (go-to-definition, hover)
+     * where cross-file resolution is handled by SemanticDB or symbol index.
+     *
+     * Benefits:
+     * - Fast: no compilation of workspace sources
+     * - Isolated: no interference from other files
+     * - Deterministic: always produces same result for same input
+     */
+    MINIMAL,
+
+    /**
+     * Full workspace parsing with all workspace sources.
+     *
+     * Use for background indexing or full compilation where cross-file
+     * type resolution is required at compile time.
+     */
+    WORKSPACE,
+}
+
+/**
  * Input required to parse a Groovy document.
  */
 data class ParseRequest(
@@ -24,6 +52,14 @@ data class ParseRequest(
      * `SEMANTIC_ANALYSIS` transforms run.
      */
     val compilePhase: Int = Phases.CANONICALIZATION,
+    /**
+     * Parse mode controlling workspace source inclusion.
+     *
+     * Default is [ParseMode.WORKSPACE] for backward compatibility.
+     *
+     * @see ParseMode
+     */
+    val parseMode: ParseMode = ParseMode.WORKSPACE,
 ) {
     val sourceUnitName: String = uri.path ?: uri.toString()
 }

--- a/parser/native/src/test/kotlin/com/github/albertocavalcante/groovyparser/GroovyParserFacadeTest.kt
+++ b/parser/native/src/test/kotlin/com/github/albertocavalcante/groovyparser/GroovyParserFacadeTest.kt
@@ -2,6 +2,7 @@ package com.github.albertocavalcante.groovyparser
 
 import com.github.albertocavalcante.groovyparser.ast.types.Position
 import com.github.albertocavalcante.groovyparser.ast.visitor.RecursiveAstVisitor
+import com.github.albertocavalcante.nativeapi.ParseMode
 import com.github.albertocavalcante.nativeapi.ParseRequest
 import com.github.albertocavalcante.nativeapi.ParserSeverity
 import org.codehaus.groovy.ast.ClassNode
@@ -118,6 +119,79 @@ class GroovyParserFacadeTest {
         assertNotNull(module)
         assertEquals(request.sourceUnitName, module.context?.name)
         assertTrue(module.classes.any { it.nameWithoutPackage == "Zebra" })
+    }
+
+    @Test
+    fun `parse with MINIMAL mode skips workspace sources`() {
+        // Create an extra source that would normally be included in WORKSPACE mode
+        val extraSource = tempDir.resolve("Dependency.groovy").toFile()
+        extraSource.writeText(
+            """
+            class Dependency {
+                String value = "from dependency"
+            }
+            """.trimIndent(),
+        )
+
+        // Code that references the Dependency class
+        val code = """
+            class Consumer {
+                Dependency dep = new Dependency()
+            }
+        """.trimIndent()
+
+        // Parse in MINIMAL mode - workspace sources should be skipped
+        val result = parser.parse(
+            ParseRequest(
+                uri = URI.create("file:///Consumer.groovy"),
+                content = code,
+                workspaceSources = listOf(extraSource.toPath()),
+                parseMode = ParseMode.MINIMAL,
+            ),
+        )
+
+        // Parse succeeds but may have unresolved type error since Dependency is not included
+        assertNotNull(result.ast, "AST should be populated even in MINIMAL mode")
+
+        // Verify only Consumer class is in the AST (Dependency was not added)
+        val userClasses = result.ast!!.classes.filter { !it.name.contains("$") }
+        assertTrue(
+            userClasses.all { it.nameWithoutPackage == "Consumer" },
+            "Only Consumer class should be in AST when workspace sources are skipped",
+        )
+    }
+
+    @Test
+    fun `parse with WORKSPACE mode includes workspace sources`() {
+        // Create an extra source
+        val extraSource = tempDir.resolve("Helper.groovy").toFile()
+        extraSource.writeText(
+            """
+            class Helper {
+                static String help() { "helped" }
+            }
+            """.trimIndent(),
+        )
+
+        val code = """
+            class Main {
+                String result = Helper.help()
+            }
+        """.trimIndent()
+
+        // Parse in WORKSPACE mode (explicit) - workspace sources should be included
+        val result = parser.parse(
+            ParseRequest(
+                uri = URI.create("file:///Main.groovy"),
+                content = code,
+                workspaceSources = listOf(extraSource.toPath()),
+                parseMode = ParseMode.WORKSPACE,
+            ),
+        )
+
+        assertTrue(result.isSuccessful, "Parse should succeed with workspace sources included")
+        assertNotNull(result.ast)
+        assertEquals(0, result.diagnostics.size, "No diagnostics expected when Helper is available")
     }
 
     @Test


### PR DESCRIPTION
## Summary

Introduces `ParseMode` enum to control workspace source inclusion during parsing, addressing workspace-wide fan-out issues during go-to-definition operations.

**Phase 1 of Issue #743** - Foundation for normalized parse modes and cache authority.

## Changes

- Add `ParseMode.MINIMAL` and `ParseMode.WORKSPACE` enum values to `ParseRequest`
- Skip workspace sources in MINIMAL mode for fast, isolated parsing
- Fix non-deterministic module selection by matching `sourceUnitName` against module context
- Reduce log spam by changing "Adding workspace source" from DEBUG to TRACE level
- Update `ensureCompiled()` to use `ParseMode.MINIMAL` for on-demand navigation requests

## Issue #743 Success Criteria Addressed

| Criteria | Status |
|----------|--------|
| Go-to-definition avoids workspace-wide parsing | ✅ MINIMAL mode skips workspace sources |
| No repeated "Adding workspace source" log spam | ✅ Log level reduced to TRACE |
| Deterministic AST module selection per file | ✅ Matches `sourceUnitName` to module |

## Test Plan

- [x] Added tests for `ParseMode.MINIMAL` skipping workspace sources
- [x] Added tests for `ParseMode.WORKSPACE` including workspace sources
- [x] Updated existing test to verify MINIMAL mode in `ensureCompiled()`
- [x] Existing deterministic module selection test continues to pass
- [x] All 1542 groovy-lsp tests pass (1 skipped, 43 skipped by design)
- [x] All parser tests pass

Fixes #743 (Phase 1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a controllable parse mode and tightens AST selection to reduce workspace fan-out during navigation.
> 
> - Adds `ParseMode` enum to `ParseRequest` with `MINIMAL` (no workspace sources) and `WORKSPACE` defaults
> - `GroovyParserFacade` now:
>   - Skips `workspaceSources` when `parseMode` is `MINIMAL`
>   - Selects AST module deterministically by `sourceUnitName`
>   - Lowers "Adding workspace source" logs from DEBUG to TRACE
> - `CompilationOrchestrator` passes `parseMode` to parsing and uses `ParseMode.MINIMAL` for on-demand disk compiles in `ensureCompiled()`
> - Tests: new coverage for MINIMAL vs WORKSPACE behavior and updated orchestrator test to assert `parseMode`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d4e4445871f60d575d76951b5675c17c501fa38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced parse mode support (MINIMAL and WORKSPACE) to control workspace source handling during compilation, enabling lightweight on-demand parsing with reduced overhead.

* **Tests**
  * Added test coverage verifying parse mode behavior across different compilation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->