### PR TITLE
refactor(test): improve semantic token test assertions with line-based matching

### DIFF
--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/semantictokens/GroovySemanticTokenProviderTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/semantictokens/GroovySemanticTokenProviderTest.kt
@@ -53,10 +53,10 @@ class GroovySemanticTokenProviderTest {
             while (true) {
                 val col = line.indexOf(identifier, startIndex)
                 if (col < 0) break
-                // Check word boundaries to avoid matching substrings (e.g., "it" in "list")
-                val beforeOk = col == 0 || !line[col - 1].isLetterOrDigit()
+                // Check word boundaries using isJavaIdentifierPart() to handle underscores
+                val beforeOk = col == 0 || !Character.isJavaIdentifierPart(line[col - 1])
                 val afterOk = col + identifier.length >= line.length ||
-                    !line[col + identifier.length].isLetterOrDigit()
+                    !Character.isJavaIdentifierPart(line[col + identifier.length])
                 if (beforeOk && afterOk) {
                     found++
                     if (found == occurrence) {
@@ -71,7 +71,9 @@ class GroovySemanticTokenProviderTest {
 
     /**
      * Finds a token by its expected position and length.
+     * Reserved for exact column matching when #769 (static method position fix) is implemented.
      */
+    @Suppress("unused")
     private fun List<GroovySemanticTokenProvider.SemanticToken>.findByPosition(
         line: Int,
         startChar: Int,


### PR DESCRIPTION
## Summary

Replace ambiguous length-only token matching with line-based matching in `GroovySemanticTokenProviderTest`:

- Add `findPosition()` helper to locate identifiers in source code with word boundary matching
- Add `findByLineAndLength()` for position-aware token matching
- Update all tests to verify tokens appear on expected source lines

## Changes

**Before:** Tests identified tokens only by length, which is ambiguous when multiple tokens have the same length
```kotlin
val myMethodToken = methodTokens.find { it.length == "myMethod".length }
```

**After:** Tests verify tokens on correct source line
```kotlin
val (expectedLine, _) = findPosition(code, "myMethod")!!
val myMethodToken = methodTokens.findByLineAndLength(expectedLine, "myMethod".length)
```

## Note

Exact column matching is deferred to #769 as AST positions may point to declaration start (e.g., `def`) rather than identifier start (e.g., method name).

Closes #772

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts test assertions to be position-aware, reducing ambiguity when multiple identifiers share lengths.
> 
> - Add `findPosition()` to locate identifiers with word-boundary checks in source strings
> - Add `List<SemanticToken>.findByLineAndLength()` and keep `findByPosition()` (reserved) for future exact column checks
> - Update tests to assert METHOD/VARIABLE/etc. tokens on the correct lines (e.g., `myMethod`, `localVar`, `otherMethod`, `it`, `greeting`, chained calls)
> - Improve assertion messages to include expected line numbers
> 
> Path: `groovy-lsp/.../GroovySemanticTokenProviderTest.kt`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b96306bde9a1c9a68104ee8059a275b4908092a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->