### PR TITLE
fix(ci): correct working directory in extension nightly workflow

### DIFF
--- a/.github/workflows/extension-nightly.yml
+++ b/.github/workflows/extension-nightly.yml
@@ -25,6 +25,11 @@ on:
         type: boolean
         default: false
 
+# NOTE: Working directory is applied per-step (not globally) because early steps
+# like "Validate ref input" and "Determine checkout ref" execute BEFORE checkout
+# and must run from the repository root. Steps after checkout use explicit
+# working-directory: editors/code to maintain the correct context.
+
 jobs:
   nightly:
     timeout-minutes: 30


### PR DESCRIPTION
## Problem

The Extension Nightly workflow was failing with:
```
##[error]An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/gvy/gvy/editors/code'. No such file or directory
```

The workflow had a global `defaults.run.working-directory: editors/code` setting at the top level, which applied to **all steps** in the job. This caused the "Validate ref input" and "Determine checkout ref" steps (which run **before** checkout) to try executing in the `editors/code` directory that didn't exist yet.

## Solution

Removed the global `defaults.run.working-directory` setting and instead added explicit `working-directory: editors/code` to each step that actually needs it (all steps that run **after** the checkout step).

This ensures:
1. Pre-checkout steps (validate ref, determine checkout ref) run in the repository root (default)
2. Post-checkout steps that need `editors/code` explicitly set it

This approach matches how the working `extension.yml` workflow handles multiple jobs with the same directory requirements.

## Changes

- Removed lines 28-30: global `defaults.run.working-directory`
- Added `working-directory: editors/code` to 7 steps that need it:
  - Get pnpm store directory
  - Compute Groovy LSP cache key
  - Install dependencies
  - Compute nightly version
  - Build extension
  - Run tests
  - Package VSIX

## Verification

The workflow structure now mirrors the working `extension.yml` workflow pattern, where the checkout happens first without any working directory constraints, and subsequent steps explicitly declare their working directory needs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts workflow execution context to avoid pre-checkout failures and ensure post-checkout steps run in the extension directory.
> 
> - Removes global `defaults.run.working-directory` and documents per-step approach
> - Adds `working-directory: editors/code` to key post-checkout steps (pnpm store path, Groovy LSP cache key, install, versioning, build, tests, packaging)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea516e62d0153ea905468bc0e2fc7d167702bafa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized build workflow configuration to streamline step organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->