### PR TITLE
fix(lsp): resolve Kotlin compiler warnings in test files

### DIFF
--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/services/GroovyGdkProviderTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/services/GroovyGdkProviderTest.kt
@@ -7,6 +7,7 @@ import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import kotlin.test.assertNotNull
 
 /**
  * Unit tests for GroovyGdkProvider.
@@ -65,11 +66,13 @@ class GroovyGdkProviderTest {
 
         // Find 'each' method - in GDK it's: each(List self, Closure closure)
         // After synthesis it should be: each(Closure closure)
-        val eachMethod = methods.find { it.name == "each" && it.parameterTypes.size == 1 }
+        val eachMethod = assertNotNull(
+            methods.find { it.name == "each" && it.parameterTypes.size == 1 },
+            "Should find 'each' method with single parameter",
+        )
 
-        assertThat(eachMethod).isNotNull
-        assertThat(eachMethod?.parameterTypes).hasSize(1)
-        assertThat(eachMethod?.parameterTypes?.get(0)).isEqualTo("Closure")
+        assertThat(eachMethod.parameterTypes).hasSize(1)
+        assertThat(eachMethod.parameterTypes[0]).isEqualTo("Closure")
     }
 
     @Test
@@ -100,10 +103,12 @@ class GroovyGdkProviderTest {
     fun `should include origin class in method info`() {
         val methods = gdkProvider.getMethodsForType("java.util.List")
 
-        val eachMethod = methods.find { it.name == "each" && it.parameterTypes.size == 1 }
+        val eachMethod = assertNotNull(
+            methods.find { it.name == "each" && it.parameterTypes.size == 1 },
+            "Should find 'each' method with single parameter",
+        )
 
-        assertThat(eachMethod).isNotNull
-        assertThat(eachMethod?.originClass).isEqualTo("DefaultGroovyMethods")
+        assertThat(eachMethod.originClass).isEqualTo("DefaultGroovyMethods")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Replace always-true type check with `assertNotNull` in `MethodResolutionStrategyTest`
- Use `assertNotNull` with return value to avoid unnecessary `!!` assertions in `GroovySemanticTokenProviderTest` and `SourceNavigationServiceTest`
- Replace deprecated `parameters` property with `parameterTypes` in `GroovyGdkProviderTest`

## Test plan

- [x] All affected tests pass (`./gradlew :groovy-lsp:test`)
- [x] Build passes with no compiler warnings (`./gradlew :groovy-lsp:compileTestKotlin`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on warning cleanups in test code only.
> 
> - Replace always-true type check with `assertNotNull` in `MethodResolutionStrategyTest`
> - Use `assertNotNull` to capture finds and avoid `!!` in `GroovySemanticTokenProviderTest` and `SourceNavigationServiceTest`
> - Migrate deprecated `parameters` to `parameterTypes` in `GroovyGdkProviderTest` and update signature deduping accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abbd9d4b9f65f7ec91e99188181169ed2ad041d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test assertions with stronger null-safety (use of non-null checks before access).
  * Replaced some direct type/force-unwrapping checks with existence/parameter-type based validations.
  * Simplified retrievals in assertions to improve clarity and robustness.

Note: Internal test improvements only; no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->