### PR TITLE
refactor(lsp): decouple Groovy vs Jenkins mode across providers

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/config/GroovyMode.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/config/GroovyMode.kt
@@ -1,0 +1,30 @@
+package com.github.albertocavalcante.groovylsp.config
+
+/**
+ * Defines the language mode for Groovy LSP features.
+ *
+ * Controls which features are available:
+ * - GROOVY: Pure Groovy without framework-specific features
+ * - JENKINS: Jenkins Pipeline mode with steps, declarative blocks, CPS awareness
+ * - AUTO: Auto-detect based on file patterns and workspace structure (default)
+ */
+enum class GroovyMode {
+    /** Pure Groovy mode - no framework-specific features */
+    GROOVY,
+
+    /** Jenkins Pipeline mode - steps, declarative, CPS awareness */
+    JENKINS,
+
+    /** Auto-detect based on file patterns and workspace (default) */
+    AUTO,
+    ;
+
+    companion object {
+        fun fromString(value: String?): GroovyMode = when (value?.lowercase()) {
+            "groovy" -> GROOVY
+            "jenkins" -> JENKINS
+            "auto" -> AUTO
+            else -> AUTO
+        }
+    }
+}

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/config/ModeResolver.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/config/ModeResolver.kt
@@ -1,0 +1,65 @@
+package com.github.albertocavalcante.groovylsp.config
+
+import com.github.albertocavalcante.groovylsp.project.JenkinsCapabilities
+import java.net.URI
+
+/**
+ * Resolves the effective language mode for a given file.
+ *
+ * Mode resolution priority:
+ * 1. Explicit configuration (groovyMode != AUTO)
+ * 2. Auto-detection based on JenkinsCapabilities
+ *
+ * @property configuredMode The mode configured by the user (default: AUTO)
+ * @property jenkinsCapabilities Optional Jenkins capabilities for auto-detection
+ */
+class ModeResolver(
+    private val configuredMode: GroovyMode = GroovyMode.AUTO,
+    private val jenkinsCapabilities: JenkinsCapabilities? = null,
+) {
+    /**
+     * Resolve the effective mode for a given file URI.
+     *
+     * @param uri The file URI to resolve mode for
+     * @return The effective GroovyMode for this file
+     */
+    fun resolveMode(uri: URI): GroovyMode = when (configuredMode) {
+        GroovyMode.GROOVY -> GroovyMode.GROOVY
+        GroovyMode.JENKINS -> GroovyMode.JENKINS
+        GroovyMode.AUTO -> autoDetectMode(uri)
+    }
+
+    /**
+     * Check if Jenkins mode is enabled for a given file.
+     * Convenience method for conditional Jenkins feature enabling.
+     *
+     * @param uri The file URI to check
+     * @return true if Jenkins features should be enabled for this file
+     */
+    fun isJenkinsModeEnabled(uri: URI): Boolean = resolveMode(uri) == GroovyMode.JENKINS
+
+    /**
+     * Check if Groovy-only mode is explicitly set.
+     * When true, no Jenkins features should be provided.
+     *
+     * @return true if pure Groovy mode is configured
+     */
+    fun isGroovyOnlyMode(): Boolean = configuredMode == GroovyMode.GROOVY
+
+    private fun autoDetectMode(uri: URI): GroovyMode = if (jenkinsCapabilities?.isJenkinsFile(uri) == true) {
+        GroovyMode.JENKINS
+    } else {
+        GroovyMode.GROOVY
+    }
+
+    companion object {
+        /**
+         * Create a ModeResolver from ServerConfiguration.
+         */
+        fun fromConfig(config: ServerConfiguration, jenkinsCapabilities: JenkinsCapabilities?): ModeResolver =
+            ModeResolver(
+                configuredMode = config.groovyMode,
+                jenkinsCapabilities = jenkinsCapabilities,
+            )
+    }
+}

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/config/ServerConfiguration.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/config/ServerConfiguration.kt
@@ -53,6 +53,9 @@ data class ServerConfiguration(
     // Gradle Build Strategy - controls how Gradle projects resolve dependencies
     // See: https://devblogs.microsoft.com/java/new-build-server-for-gradle/
     val gradleBuildStrategy: GradleBuildStrategy = GradleBuildStrategy.AUTO,
+
+    // Language mode - controls which framework-specific features are enabled
+    val groovyMode: GroovyMode = GroovyMode.AUTO,
 ) {
 
     enum class CompilationMode {
@@ -154,6 +157,9 @@ data class ServerConfiguration(
                     gradleBuildStrategy = GradleBuildStrategy.fromString(
                         map["groovy.gradle.buildStrategy"] as? String,
                     ),
+
+                    // Language mode
+                    groovyMode = GroovyMode.fromString(map["groovy.mode"] as? String),
                 )
             } catch (e: Exception) {
                 logger.warn(e) { "Error parsing configuration, using defaults" }
@@ -179,7 +185,8 @@ data class ServerConfiguration(
             val logLevelString = rawValue as? String
             // Log at INFO level so this is ALWAYS visible before level is changed
             logger.info {
-                "Parsing logLevel from initOptions: raw='$rawValue', type=${rawValue?.javaClass?.simpleName ?: "null"}, parsed=$logLevelString"
+                val rawType = rawValue?.javaClass?.simpleName ?: "null"
+                "Parsing logLevel from initOptions: raw='$rawValue', type=$rawType, parsed=$logLevelString"
             }
             val parsed = LogLevel.fromString(logLevelString)
             logger.info { "LogLevel parsed as: ${parsed.name}" }

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/CompletionProvider.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/CompletionProvider.kt
@@ -5,10 +5,16 @@ import com.github.albertocavalcante.groovyjenkins.metadata.MergedGlobalVariable
 import com.github.albertocavalcante.groovyjenkins.metadata.MergedJenkinsMetadata
 import com.github.albertocavalcante.groovyjenkins.metadata.declarative.DeclarativePipelineSchema
 import com.github.albertocavalcante.groovylsp.compilation.GroovyCompilationService
+import com.github.albertocavalcante.groovylsp.config.GroovyMode
+import com.github.albertocavalcante.groovylsp.config.ModeResolver
 import com.github.albertocavalcante.groovylsp.dsl.completion.CompletionsBuilder
-import com.github.albertocavalcante.groovylsp.dsl.completion.GroovyCompletions
 import com.github.albertocavalcante.groovylsp.dsl.completion.completions
 import com.github.albertocavalcante.groovylsp.indexing.WorkspaceSymbolIndex
+import com.github.albertocavalcante.groovylsp.providers.completion.strategy.CompletionStrategy
+import com.github.albertocavalcante.groovylsp.providers.completion.strategy.CompletionStrategyContext
+import com.github.albertocavalcante.groovylsp.providers.completion.strategy.GroovyCompletionStrategy
+import com.github.albertocavalcante.groovylsp.providers.completion.strategy.JenkinsBlockContext
+import com.github.albertocavalcante.groovylsp.providers.completion.strategy.JenkinsCompletionStrategy
 import com.github.albertocavalcante.groovylsp.types.SemanticTypeResolver
 import com.github.albertocavalcante.groovyparser.ast.GroovyAstModel
 import com.github.albertocavalcante.groovyparser.ast.symbols.Symbol
@@ -17,16 +23,11 @@ import com.github.albertocavalcante.groovyspock.SpockDetector
 import com.github.albertocavalcante.gvy.semantics.SemanticType
 import com.github.albertocavalcante.gvy.semantics.SemanticTypeFormatter
 import com.github.albertocavalcante.gvy.semantics.db.SymbolKind
-import com.github.albertocavalcante.gvy.semantics.native.ClassSymbol
 import com.github.albertocavalcante.gvy.semantics.native.DeclarationWalker
-import com.github.albertocavalcante.gvy.semantics.native.FieldSymbol
-import com.github.albertocavalcante.gvy.semantics.native.ImportSymbol
-import com.github.albertocavalcante.gvy.semantics.native.MethodSymbol
-import com.github.albertocavalcante.gvy.semantics.native.SymbolCompletionContext
 import com.github.albertocavalcante.gvy.semantics.native.SymbolExtractor
-import com.github.albertocavalcante.gvy.semantics.native.VariableSymbol
 import com.github.albertocavalcante.gvy.semantics.workspace.MemberInfo
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.runBlocking
 import org.codehaus.groovy.ast.ASTNode
 import org.codehaus.groovy.ast.ModuleNode
 import org.codehaus.groovy.ast.stmt.BlockStatement
@@ -73,7 +74,9 @@ object CompletionProvider {
     /**
      * Get basic Groovy language completion items using DSL.
      */
-    fun getBasicCompletions(): List<CompletionItem> = GroovyCompletions.basic()
+    fun getBasicCompletions(): List<CompletionItem> = completions {
+        com.github.albertocavalcante.groovylsp.dsl.completion.GroovyCompletions.basic().forEach(::add)
+    }
 
     /**
      * Get contextual completions based on AST analysis.
@@ -194,7 +197,7 @@ object CompletionProvider {
         }
         return completions {
             addKeywords()
-            GroovyCompletions.basic().forEach(::add)
+            com.github.albertocavalcante.groovylsp.dsl.completion.GroovyCompletions.basic().forEach(::add)
         }
     }
 
@@ -219,15 +222,25 @@ object CompletionProvider {
 
     private fun buildCompletionsList(ctx: CompletionContext, isSpockSpec: Boolean): List<CompletionItem> {
         ctx.moduleNode?.let { ctx.semanticResolver.semantics.inject(it) }
+
+        // Extract symbol context
         val symbolContext = SymbolExtractor.extractCompletionSymbols(
             ctx.ast,
             ctx.line,
             ctx.character,
             ctx.semanticResolver.semantics,
         )
-        val isJenkinsFile =
-            ctx.compilationService.workspaceManager.getJenkinsCapabilities()?.isJenkinsFile(ctx.uri) ?: false
 
+        // Get Jenkins capabilities and create mode resolver
+        val jenkinsCapabilities = ctx.compilationService.workspaceManager.getJenkinsCapabilities()
+        val modeResolver = ModeResolver(
+            configuredMode = GroovyMode.AUTO, // TODO: Get from ServerConfiguration once available
+            jenkinsCapabilities = jenkinsCapabilities,
+        )
+        val mode = modeResolver.resolveMode(ctx.uri)
+        val isJenkinsFile = jenkinsCapabilities?.isJenkinsFile(ctx.uri) ?: false
+
+        // Handle import completions (early return)
         val importContext = CompletionContextDetector.detectImportCompletionContext(
             content = ctx.content,
             line = ctx.line,
@@ -238,6 +251,7 @@ object CompletionProvider {
             return completions { addImportCompletions(importContext, ctx.compilationService) }
         }
 
+        // Detect completion context
         val nodeAtCursor = CompletionContextDetector.findNodeAtOrBefore(
             ctx.astModel,
             ctx.uri,
@@ -254,68 +268,65 @@ object CompletionProvider {
                 ctx.moduleNode,
             )
 
-        val jenkinsContext = resolveJenkinsContext(ctx, isJenkinsFile)
-        val metadata = jenkinsContext.metadata
+        // Build strategy context
+        val jenkinsMetadata = if (isJenkinsFile) jenkinsCapabilities?.getAllMetadata() else null
+        val jenkinsBlockContext = buildJenkinsBlockContext(ctx, isJenkinsFile)
+
+        val strategyContext = CompletionStrategyContext(
+            baseContext = ctx,
+            symbolContext = symbolContext,
+            nodeAtCursor = nodeAtCursor,
+            contextType = completionContext,
+            mode = mode,
+            isJenkinsFile = isJenkinsFile,
+            jenkinsMetadata = jenkinsMetadata,
+            jenkinsBlockContext = jenkinsBlockContext,
+        )
 
         return completions {
+            // Spock block labels (keep existing logic)
             addSpockBlockLabelsIfApplicable(ctx, completionContext, isSpockSpec)
 
-            // For member access context (e.g., "p."), only add member completions
-            // Skip local symbols, keywords, etc. as they are not relevant for member completion
+            // Handle member access context (special case - keep existing)
             if (completionContext is ContextType.MemberAccess) {
-                handleMemberAccessContext(completionContext, ctx, metadata)
+                handleMemberAccessContext(completionContext, ctx, jenkinsMetadata)
                 return@completions
             }
 
-            addLocalSymbolsIfApplicable(symbolContext, jenkinsContext.isStrictDeclarative)
+            // Use strategies for general completions
+            val strategies = buildStrategies(mode)
+            val strategyItems = runBlocking {
+                CompletionStrategy.aggregate(strategies).complete(strategyContext).fold(
+                    ifLeft = { emptyList() },
+                    ifRight = { it },
+                )
+            }
+            strategyItems.forEach(::add)
 
-            addJenkinsCompletionsIfApplicable(
-                jenkinsContext = jenkinsContext,
-                ctx = ctx,
-                nodeAtCursor = nodeAtCursor,
-            )
-
-            if (handleContextualCompletions(completionContext, ctx, metadata)) {
+            // Handle contextual completions (TypeParameter - keep existing)
+            if (handleContextualCompletions(completionContext, ctx, jenkinsMetadata)) {
                 return@completions
             }
         }
     }
 
-    private data class JenkinsContext(
-        val metadata: MergedJenkinsMetadata?,
-        val blockCategories: Set<DeclarativePipelineSchema.CompletionCategory>?,
-        val innerInstructions: Set<String>?,
-        val isStrictDeclarative: Boolean,
-    )
+    private fun buildStrategies(mode: GroovyMode): List<CompletionStrategy> = when (mode) {
+        GroovyMode.GROOVY -> listOf(GroovyCompletionStrategy())
+        GroovyMode.JENKINS -> listOf(JenkinsCompletionStrategy(), GroovyCompletionStrategy())
+        GroovyMode.AUTO -> listOf(JenkinsCompletionStrategy(), GroovyCompletionStrategy())
+    }
 
-    private fun resolveJenkinsContext(ctx: CompletionContext, isJenkinsFile: Boolean): JenkinsContext {
-        if (!isJenkinsFile) {
-            return JenkinsContext(
-                metadata = null,
-                blockCategories = null,
-                innerInstructions = null,
-                isStrictDeclarative = false,
-            )
-        }
+    private fun buildJenkinsBlockContext(ctx: CompletionContext, isJenkinsFile: Boolean): JenkinsBlockContext? {
+        if (!isJenkinsFile) return null
 
-        // Use text-based context detection (more robust during editing) instead of AST traversal.
-        val detected = JenkinsContextDetector.detectFromDocument(
-            ctx.content.lines(),
-            ctx.line,
-            ctx.character,
-        )
-        val metadata = ctx.compilationService.workspaceManager.getJenkinsCapabilities()?.getAllMetadata()
-
+        val detected = JenkinsContextDetector.detectFromDocument(ctx.content.lines(), ctx.line, ctx.character)
         val currentBlock = detected.currentBlock
-        val blockCategories = currentBlock?.let(DeclarativePipelineSchema::getCompletionCategories)
-        val innerInstructions = currentBlock?.let(DeclarativePipelineSchema::getInnerInstructions)
-        val isStrictDeclarative =
-            detected.isDeclarativePipeline &&
-                currentBlock != null &&
-                currentBlock != "script"
+        val blockCategories = currentBlock?.let(DeclarativePipelineSchema::getCompletionCategories) ?: emptySet()
+        val innerInstructions = currentBlock?.let(DeclarativePipelineSchema::getInnerInstructions) ?: emptySet()
+        val isStrictDeclarative = detected.isDeclarativePipeline && currentBlock != null && currentBlock != "script"
 
-        return JenkinsContext(
-            metadata = metadata,
+        return JenkinsBlockContext(
+            currentBlock = currentBlock,
             blockCategories = blockCategories,
             innerInstructions = innerInstructions,
             isStrictDeclarative = isStrictDeclarative,
@@ -326,81 +337,6 @@ object CompletionProvider {
     //   Several extension functions below don't use `this` but are defined as extensions for
     //   DSL consistency. Consider suppressing warnings or refactoring.
     //   See: https://github.com/albertocavalcante/gvy/issues/864
-
-    private fun CompletionsBuilder.addLocalSymbolsIfApplicable(
-        context: SymbolCompletionContext,
-        isStrictDeclarative: Boolean,
-    ) {
-        if (isStrictDeclarative) {
-            return
-        }
-
-        addClasses(context.classes)
-        addMethods(context.methods)
-        addFields(context.fields)
-        addVariables(context.variables)
-        addImports(context.imports)
-        addKeywords()
-
-        // Add basic Groovy snippet completions (println, print, etc.)
-        GroovyCompletions.basic().forEach(::add)
-    }
-
-    private fun CompletionsBuilder.addJenkinsCompletionsIfApplicable(
-        jenkinsContext: JenkinsContext,
-        ctx: CompletionContext,
-        nodeAtCursor: ASTNode?,
-    ) {
-        val metadata = jenkinsContext.metadata ?: return
-
-        with(JenkinsCompletionProvider) {
-            // Suggest parameter map keys so we can complete named parameters
-            addJenkinsMapKeyCompletions(ctx, nodeAtCursor, ctx.astModel, metadata)
-
-            // Lenient step allowance: allow steps if not in a strict declarative block,
-            // or if the block explicitly allows steps.
-            val allowSteps =
-                !jenkinsContext.isStrictDeclarative ||
-                    jenkinsContext.blockCategories
-                        ?.contains(DeclarativePipelineSchema.CompletionCategory.STEP) == true
-
-            if (allowSteps) {
-                // TODO(#657): Refactor to use a determined JenkinsCompletionStrategy.
-                addJenkinsStepCompletions(metadata)
-            }
-
-            addJenkinsGlobalVariables(metadata, ctx.compilationService.workspaceManager.getJenkinsCapabilities())
-
-            // Only add block-level completions when cursor is at block level (not inside method call args)
-            val cursorContext = detectCursorPositionContext(nodeAtCursor, ctx.astModel)
-            val isBlockLevel = cursorContext is CursorPositionContext.BlockLevel
-
-            jenkinsContext.blockCategories?.let { categories ->
-                if (categories.contains(DeclarativePipelineSchema.CompletionCategory.AGENT_TYPE) && isBlockLevel) {
-                    addJenkinsAgentTypeCompletions()
-                }
-                if (categories.contains(DeclarativePipelineSchema.CompletionCategory.DECLARATIVE_OPTION) &&
-                    isBlockLevel
-                ) {
-                    addJenkinsDeclarativeOptions(metadata)
-                }
-                if (categories.contains(DeclarativePipelineSchema.CompletionCategory.POST_CONDITION) && isBlockLevel) {
-                    addJenkinsPostConditionCompletions()
-                }
-            }
-        }
-
-        // Add inner instructions (sub-blocks) from schema
-        jenkinsContext.innerInstructions?.forEach { instruction ->
-            completion {
-                label(instruction)
-                kind(CompletionItemKind.Keyword)
-                detail("Declarative directive")
-                insertText("$instruction {")
-                sortText("0-directive-$instruction")
-            }
-        }
-    }
 
     @Suppress("UnusedParameter", "FunctionParameterNaming") // TODO: Use _metadata for Jenkins-specific completions
     private fun CompletionsBuilder.handleContextualCompletions(
@@ -951,65 +887,6 @@ object CompletionProvider {
          */
         data class MemberAccess(val qualifierType: String, val qualifierName: String? = null) : ContextType
         data class TypeParameter(val prefix: String) : ContextType
-    }
-
-    private fun CompletionsBuilder.addClasses(classes: List<ClassSymbol>) {
-        classes.forEach { classSymbol ->
-            clazz(
-                name = classSymbol.name,
-                packageName = classSymbol.packageName,
-                doc = "Class: ${classSymbol.name}",
-            )
-        }
-    }
-
-    private fun CompletionsBuilder.addMethods(methods: List<MethodSymbol>) {
-        methods.forEach { methodSymbol ->
-            val paramSignatures = methodSymbol.parameters.map { "${it.type} ${it.name}" }
-            method(
-                name = methodSymbol.name,
-                returnType = methodSymbol.returnType,
-                parameters = paramSignatures,
-                doc = "Method: ${methodSymbol.name}",
-            )
-        }
-    }
-
-    private fun CompletionsBuilder.addFields(fields: List<FieldSymbol>) {
-        fields.forEach { fieldSymbol ->
-            field(
-                name = fieldSymbol.name,
-                type = fieldSymbol.type,
-                doc = "Field: ${fieldSymbol.type} ${fieldSymbol.name}",
-            )
-        }
-    }
-
-    private fun CompletionsBuilder.addVariables(variables: List<VariableSymbol>) {
-        variables.forEach { varSymbol ->
-            val kind = varSymbol.kind.name.lowercase().replace('_', ' ').replaceFirstChar { it.uppercase() }
-            val docString = "$kind: ${varSymbol.type} ${varSymbol.name}"
-            variable(
-                name = varSymbol.name,
-                type = varSymbol.type,
-                doc = docString,
-            )
-        }
-    }
-
-    private fun CompletionsBuilder.addImports(imports: List<ImportSymbol>) {
-        imports.forEach { importSymbol ->
-            if (!importSymbol.isStarImport) {
-                val name = importSymbol.className
-                    ?: importSymbol.packageName.substringAfterLast('.')
-
-                clazz(
-                    name = name,
-                    packageName = importSymbol.packageName,
-                    doc = "Imported: ${importSymbol.packageName}.$name",
-                )
-            }
-        }
     }
 
     /**

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/strategy/CompletionStrategy.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/strategy/CompletionStrategy.kt
@@ -1,0 +1,99 @@
+package com.github.albertocavalcante.groovylsp.providers.completion.strategy
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import com.github.albertocavalcante.groovycommon.functional.DomainError
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
+import org.eclipse.lsp4j.CompletionItem
+
+/**
+ * Type alias for completion-specific errors.
+ * Uses DomainError from groovy-common for consistent error handling.
+ */
+typealias CompletionError = DomainError
+
+/** Type alias for completion results using Arrow Either */
+typealias CompletionResult = Either<CompletionError, List<CompletionItem>>
+
+/**
+ * Strategy interface for mode-specific completion providers.
+ *
+ * Each implementation is responsible for ONE specific completion approach:
+ * - [JenkinsCompletionStrategy]: Jenkins steps, global variables, declarative
+ * - [GroovyCompletionStrategy]: Core Groovy symbols, keywords, snippets
+ *
+ * Returns [Either.Left] with [CompletionError] if strategy doesn't apply,
+ * or [Either.Right] with completion items on success.
+ *
+ * ## Example Usage
+ * ```kotlin
+ * val strategies = listOf(
+ *     JenkinsCompletionStrategy(jenkinsCapabilities),
+ *     GroovyCompletionStrategy(),
+ * )
+ * val aggregated = CompletionStrategy.aggregate(strategies)
+ * val items = aggregated.complete(context).getOrElse { emptyList() }
+ * ```
+ */
+internal fun interface CompletionStrategy {
+    /**
+     * Attempt to provide completions for the given context.
+     *
+     * @param context The completion context with AST, position, and mode info
+     * @return Either.Right(items) if completions provided, Either.Left(error) if not applicable
+     */
+    suspend fun complete(context: CompletionStrategyContext): CompletionResult
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
+
+        /**
+         * Compose multiple strategies, collecting all successful completions.
+         *
+         * Unlike definition resolution (short-circuit on first success),
+         * completion aggregates results from all applicable strategies.
+         *
+         * @param strategies Strategies to aggregate
+         * @return A composite strategy that collects all completions
+         */
+        @Suppress("TooGenericExceptionCaught")
+        fun aggregate(strategies: List<CompletionStrategy>): CompletionStrategy = CompletionStrategy { context ->
+            val allItems = mutableListOf<CompletionItem>()
+
+            for (strategy in strategies) {
+                val result = try {
+                    strategy.complete(context)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Error) {
+                    throw e
+                } catch (e: Exception) {
+                    logger.debug(e) {
+                        "Completion strategy ${strategy::class.simpleName ?: "unknown"} threw unexpectedly"
+                    }
+                    notApplicable(strategy::class.simpleName ?: "unknown")
+                }
+
+                result.fold(
+                    ifLeft = { /* skip non-applicable strategies */ },
+                    ifRight = { items -> allItems.addAll(items) },
+                )
+            }
+
+            allItems.right()
+        }
+
+        /** Convenience: strategy doesn't apply to this context */
+        fun notApplicable(strategy: String = "unknown"): CompletionResult =
+            CompletionError("Strategy not applicable", strategy).left()
+
+        /** Convenience: wrap successful completions */
+        fun found(items: List<CompletionItem>): CompletionResult = items.right()
+
+        /** Convenience: wrap an error */
+        fun error(reason: String, strategy: String = "unknown"): CompletionResult =
+            CompletionError(reason, strategy).left()
+    }
+}

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/strategy/CompletionStrategyContext.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/strategy/CompletionStrategyContext.kt
@@ -1,0 +1,47 @@
+package com.github.albertocavalcante.groovylsp.providers.completion.strategy
+
+import com.github.albertocavalcante.groovyjenkins.metadata.MergedJenkinsMetadata
+import com.github.albertocavalcante.groovyjenkins.metadata.declarative.DeclarativePipelineSchema
+import com.github.albertocavalcante.groovylsp.config.GroovyMode
+import com.github.albertocavalcante.groovylsp.providers.completion.CompletionContext
+import com.github.albertocavalcante.groovylsp.providers.completion.CompletionProvider.ContextType
+import com.github.albertocavalcante.gvy.semantics.native.SymbolCompletionContext
+import org.codehaus.groovy.ast.ASTNode
+
+/**
+ * Context for completion strategies containing all data needed for completions.
+ *
+ * @property baseContext The underlying CompletionContext with AST, position, etc.
+ * @property symbolContext Extracted symbols (classes, methods, fields, variables)
+ * @property nodeAtCursor The AST node at the cursor position
+ * @property contextType Detected completion context type (MemberAccess, TypeParameter, etc.)
+ * @property mode The effective language mode for this file
+ * @property isJenkinsFile Whether this is detected as a Jenkins file
+ * @property jenkinsMetadata Jenkins metadata (steps, global vars) if available
+ * @property jenkinsBlockContext Jenkins declarative block context if applicable
+ */
+internal data class CompletionStrategyContext(
+    val baseContext: CompletionContext,
+    val symbolContext: SymbolCompletionContext,
+    val nodeAtCursor: ASTNode?,
+    val contextType: ContextType?,
+    val mode: GroovyMode,
+    val isJenkinsFile: Boolean,
+    val jenkinsMetadata: MergedJenkinsMetadata? = null,
+    val jenkinsBlockContext: JenkinsBlockContext? = null,
+)
+
+/**
+ * Jenkins declarative pipeline block context.
+ *
+ * @property currentBlock The current declarative block name (e.g., "steps", "post", "options")
+ * @property blockCategories Completion categories allowed in this block
+ * @property innerInstructions Sub-directives allowed in this block
+ * @property isStrictDeclarative Whether we're in strict declarative mode (no arbitrary Groovy)
+ */
+internal data class JenkinsBlockContext(
+    val currentBlock: String?,
+    val blockCategories: Set<DeclarativePipelineSchema.CompletionCategory>,
+    val innerInstructions: Set<String>,
+    val isStrictDeclarative: Boolean,
+)

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/strategy/GroovyCompletionStrategy.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/strategy/GroovyCompletionStrategy.kt
@@ -1,0 +1,140 @@
+package com.github.albertocavalcante.groovylsp.providers.completion.strategy
+
+import com.github.albertocavalcante.groovylsp.dsl.completion.CompletionsBuilder
+import com.github.albertocavalcante.groovylsp.dsl.completion.GroovyCompletions
+import com.github.albertocavalcante.groovylsp.dsl.completion.completions
+import com.github.albertocavalcante.gvy.semantics.native.ClassSymbol
+import com.github.albertocavalcante.gvy.semantics.native.FieldSymbol
+import com.github.albertocavalcante.gvy.semantics.native.ImportSymbol
+import com.github.albertocavalcante.gvy.semantics.native.MethodSymbol
+import com.github.albertocavalcante.gvy.semantics.native.VariableSymbol
+import org.eclipse.lsp4j.CompletionItem
+
+/**
+ * Completion strategy for core Groovy language features.
+ *
+ * Provides completions for:
+ * - Local symbols (classes, methods, fields, variables from symbol context)
+ * - Groovy keywords (def, class, if, for, etc.)
+ * - Basic Groovy snippets (println, print)
+ *
+ * This strategy is always active regardless of mode, providing
+ * baseline Groovy language support.
+ */
+internal class GroovyCompletionStrategy : CompletionStrategy {
+
+    override suspend fun complete(context: CompletionStrategyContext): CompletionResult {
+        // Skip local symbols in strict declarative Jenkins mode
+        // (only declarative directives allowed)
+        val skipLocalSymbols = context.jenkinsBlockContext?.isStrictDeclarative == true
+
+        val items = buildGroovyCompletions(context, skipLocalSymbols)
+        return CompletionStrategy.found(items)
+    }
+
+    private fun buildGroovyCompletions(
+        context: CompletionStrategyContext,
+        skipLocalSymbols: Boolean,
+    ): List<CompletionItem> = completions {
+        if (!skipLocalSymbols) {
+            addClasses(context.symbolContext.classes)
+            addMethods(context.symbolContext.methods)
+            addFields(context.symbolContext.fields)
+            addVariables(context.symbolContext.variables)
+            addImports(context.symbolContext.imports)
+            addKeywords()
+            // Only add basic snippets when not in strict declarative mode
+            GroovyCompletions.basic().forEach(::add)
+        }
+    }
+
+    private fun CompletionsBuilder.addClasses(classes: List<ClassSymbol>) {
+        classes.forEach { classSymbol ->
+            clazz(
+                name = classSymbol.name,
+                packageName = classSymbol.packageName,
+                doc = "Class: ${classSymbol.name}",
+            )
+        }
+    }
+
+    private fun CompletionsBuilder.addMethods(methods: List<MethodSymbol>) {
+        methods.forEach { methodSymbol ->
+            val paramSignatures = methodSymbol.parameters.map { "${it.type} ${it.name}" }
+            method(
+                name = methodSymbol.name,
+                returnType = methodSymbol.returnType,
+                parameters = paramSignatures,
+                doc = "Method: ${methodSymbol.name}",
+            )
+        }
+    }
+
+    private fun CompletionsBuilder.addFields(fields: List<FieldSymbol>) {
+        fields.forEach { fieldSymbol ->
+            field(
+                name = fieldSymbol.name,
+                type = fieldSymbol.type,
+                doc = "Field: ${fieldSymbol.type} ${fieldSymbol.name}",
+            )
+        }
+    }
+
+    private fun CompletionsBuilder.addVariables(variables: List<VariableSymbol>) {
+        variables.forEach { varSymbol ->
+            val kind = varSymbol.kind.name.lowercase().replace('_', ' ').replaceFirstChar { it.uppercase() }
+            val docString = "$kind: ${varSymbol.type} ${varSymbol.name}"
+            variable(
+                name = varSymbol.name,
+                type = varSymbol.type,
+                doc = docString,
+            )
+        }
+    }
+
+    private fun CompletionsBuilder.addImports(imports: List<ImportSymbol>) {
+        imports.forEach { importSymbol ->
+            if (!importSymbol.isStarImport) {
+                val name = importSymbol.className
+                    ?: importSymbol.packageName.substringAfterLast('.')
+
+                clazz(
+                    name = name,
+                    packageName = importSymbol.packageName,
+                    doc = "Imported: ${importSymbol.packageName}.$name",
+                )
+            }
+        }
+    }
+
+    /**
+     * Keywords that have snippet versions in GroovyCompletions.basic().
+     * These are excluded from addKeywords() to prevent duplicate completions (#857).
+     */
+    private val snippetKeywords = setOf("def", "class", "interface", "enum", "if", "for", "while")
+
+    private fun CompletionsBuilder.addKeywords() {
+        val allKeywords = listOf(
+            // Types
+            "def", "void", "int", "boolean", "char", "byte",
+            "short", "long", "float", "double", "String", "Object",
+            // Control flow
+            "if", "else", "for", "while", "do", "switch", "case", "default",
+            "break", "continue", "return", "try", "catch", "finally", "throw",
+            // Structure
+            "class", "interface", "trait", "enum", "package", "import",
+            // Modifiers
+            "public", "protected", "private", "static", "final", "abstract",
+            "synchronized", "transient", "volatile", "native",
+            // Values/Other
+            "true", "false", "null", "this", "super", "new", "in", "as", "assert",
+        )
+        // Filter out keywords that have snippet versions in GroovyCompletions.basic()
+        allKeywords.filterNot { it in snippetKeywords }.forEach { k ->
+            keyword(
+                keyword = k,
+                doc = "Keyword/Type: $k",
+            )
+        }
+    }
+}

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/strategy/JenkinsCompletionStrategy.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/strategy/JenkinsCompletionStrategy.kt
@@ -1,0 +1,117 @@
+package com.github.albertocavalcante.groovylsp.providers.completion.strategy
+
+import com.github.albertocavalcante.groovyjenkins.metadata.MergedJenkinsMetadata
+import com.github.albertocavalcante.groovyjenkins.metadata.declarative.DeclarativePipelineSchema
+import com.github.albertocavalcante.groovylsp.config.GroovyMode
+import com.github.albertocavalcante.groovylsp.dsl.completion.completions
+import com.github.albertocavalcante.groovylsp.providers.completion.CursorPositionContext
+import com.github.albertocavalcante.groovylsp.providers.completion.JenkinsCompletionProvider
+import com.github.albertocavalcante.groovylsp.providers.completion.detectCursorPositionContext
+import org.eclipse.lsp4j.CompletionItem
+import org.eclipse.lsp4j.CompletionItemKind
+
+/**
+ * Completion strategy for Jenkins Pipeline mode.
+ *
+ * Provides completions for:
+ * - Jenkins steps (echo, sh, readFile, etc.)
+ * - Global variables (env, params, currentBuild)
+ * - Declarative options (timeout, retry)
+ * - Post conditions (always, success, failure)
+ * - Agent types (any, none, docker)
+ * - Declarative directives (stages, steps, etc.)
+ *
+ * This strategy only activates when:
+ * 1. Mode is explicitly JENKINS, OR
+ * 2. Mode is AUTO and file is detected as Jenkins file
+ */
+internal class JenkinsCompletionStrategy : CompletionStrategy {
+
+    override suspend fun complete(context: CompletionStrategyContext): CompletionResult {
+        // Return early if not Jenkins mode
+        if (context.mode == GroovyMode.GROOVY) {
+            return CompletionStrategy.notApplicable("JenkinsCompletion")
+        }
+        if (context.mode == GroovyMode.AUTO && !context.isJenkinsFile) {
+            return CompletionStrategy.notApplicable("JenkinsCompletion")
+        }
+
+        val metadata = context.jenkinsMetadata
+            ?: return CompletionStrategy.notApplicable("JenkinsCompletion")
+
+        val items = buildJenkinsCompletions(context, metadata)
+        return CompletionStrategy.found(items)
+    }
+
+    private fun buildJenkinsCompletions(
+        context: CompletionStrategyContext,
+        metadata: MergedJenkinsMetadata,
+    ): List<CompletionItem> {
+        val blockContext = context.jenkinsBlockContext
+
+        return completions {
+            with(JenkinsCompletionProvider) {
+                // Suggest parameter map keys for method calls
+                addJenkinsMapKeyCompletions(
+                    ctx = context.baseContext,
+                    nodeAtCursor = context.nodeAtCursor,
+                    astModel = context.baseContext.astModel,
+                    metadata = metadata,
+                )
+
+                // Add Jenkins step completions if allowed by block context
+                val allowSteps = blockContext == null ||
+                    !blockContext.isStrictDeclarative ||
+                    blockContext.blockCategories.contains(DeclarativePipelineSchema.CompletionCategory.STEP)
+
+                if (allowSteps) {
+                    addJenkinsStepCompletions(metadata)
+                }
+
+                // Add Jenkins global variables
+                addJenkinsGlobalVariables(
+                    metadata = metadata,
+                    jenkinsCapabilities = context.baseContext.compilationService
+                        .workspaceManager.getJenkinsCapabilities(),
+                )
+
+                // Only add block-level completions when cursor is at block level (not inside method call args)
+                val cursorContext = detectCursorPositionContext(
+                    context.nodeAtCursor,
+                    context.baseContext.astModel,
+                )
+                val isBlockLevel = cursorContext is CursorPositionContext.BlockLevel
+
+                // Add block-specific completions based on declarative context
+                blockContext?.blockCategories?.let { categories ->
+                    if (categories.contains(DeclarativePipelineSchema.CompletionCategory.AGENT_TYPE) &&
+                        isBlockLevel
+                    ) {
+                        addJenkinsAgentTypeCompletions()
+                    }
+                    if (categories.contains(DeclarativePipelineSchema.CompletionCategory.DECLARATIVE_OPTION) &&
+                        isBlockLevel
+                    ) {
+                        addJenkinsDeclarativeOptions(metadata)
+                    }
+                    if (categories.contains(DeclarativePipelineSchema.CompletionCategory.POST_CONDITION) &&
+                        isBlockLevel
+                    ) {
+                        addJenkinsPostConditionCompletions()
+                    }
+                }
+
+                // Add inner instructions (sub-blocks) from schema
+                blockContext?.innerInstructions?.forEach { instruction ->
+                    completion {
+                        label(instruction)
+                        kind(CompletionItemKind.Keyword)
+                        detail("Declarative directive")
+                        insertText("$instruction {")
+                        sortText("0-directive-$instruction")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/hover/HoverProvider.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/hover/HoverProvider.kt
@@ -1,6 +1,8 @@
 package com.github.albertocavalcante.groovylsp.providers.hover
 
 import com.github.albertocavalcante.groovylsp.compilation.GroovyCompilationService
+import com.github.albertocavalcante.groovylsp.config.GroovyMode
+import com.github.albertocavalcante.groovylsp.config.ModeResolver
 import com.github.albertocavalcante.groovylsp.converters.toGroovyPosition
 import com.github.albertocavalcante.groovylsp.documentation.DocFormatter
 import com.github.albertocavalcante.groovylsp.documentation.Documentation
@@ -10,9 +12,6 @@ import com.github.albertocavalcante.groovylsp.errors.InvalidPositionException
 import com.github.albertocavalcante.groovylsp.errors.NodeNotFoundAtPositionException
 import com.github.albertocavalcante.groovylsp.errors.SymbolResolutionException
 import com.github.albertocavalcante.groovylsp.errors.invalidPosition
-import com.github.albertocavalcante.groovylsp.markdown.dsl.markdown
-import com.github.albertocavalcante.groovylsp.project.JenkinsCapabilities
-import com.github.albertocavalcante.groovylsp.providers.completion.JenkinsStepCompletionProvider
 import com.github.albertocavalcante.groovylsp.providers.hover.strategies.ClassDeclarationHoverStrategy
 import com.github.albertocavalcante.groovylsp.providers.hover.strategies.ClosureHoverStrategy
 import com.github.albertocavalcante.groovylsp.providers.hover.strategies.ConstructorCallHoverStrategy
@@ -20,6 +19,7 @@ import com.github.albertocavalcante.groovylsp.providers.hover.strategies.Declara
 import com.github.albertocavalcante.groovylsp.providers.hover.strategies.FieldDeclarationHoverStrategy
 import com.github.albertocavalcante.groovylsp.providers.hover.strategies.GenericHoverStrategy
 import com.github.albertocavalcante.groovylsp.providers.hover.strategies.ImportHoverStrategy
+import com.github.albertocavalcante.groovylsp.providers.hover.strategies.JenkinsStepHoverStrategy
 import com.github.albertocavalcante.groovylsp.providers.hover.strategies.LiteralHoverStrategy
 import com.github.albertocavalcante.groovylsp.providers.hover.strategies.MethodCallHoverStrategy
 import com.github.albertocavalcante.groovylsp.providers.hover.strategies.MethodDeclarationHoverStrategy
@@ -45,7 +45,6 @@ import org.eclipse.lsp4j.Hover
 import org.eclipse.lsp4j.MarkupContent
 import org.eclipse.lsp4j.MarkupKind
 import org.eclipse.lsp4j.Position
-import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 import java.io.IOException
 import java.net.URI
@@ -69,21 +68,36 @@ class HoverProvider(
     private val documentationProvider = DocumentationProvider
         .getInstance(documentProvider)
 
+    // Create mode resolver lazily
+    // Note: Uses AUTO mode since we don't have direct access to ServerConfiguration from compilation service
+    // AUTO mode will auto-detect based on JenkinsCapabilities, which is the desired behavior
+    private val modeResolver: ModeResolver by lazy {
+        ModeResolver(
+            configuredMode = GroovyMode.AUTO,
+            jenkinsCapabilities = compilationService.workspaceManager.getJenkinsCapabilities(),
+        )
+    }
+
     // Strategies for handling different node types (order matters - more specific first)
-    private val strategies: List<HoverStrategy> = listOf(
-        MethodDeclarationHoverStrategy(),
-        ClassDeclarationHoverStrategy(),
-        FieldDeclarationHoverStrategy(),
-        ImportHoverStrategy(),
-        DeclarationExpressionHoverStrategy(),
-        VariableExpressionHoverStrategy(),
-        MethodCallHoverStrategy(),
-        ConstructorCallHoverStrategy(), // Phase 4: Constructor calls
-        PropertyExpressionHoverStrategy(), // Phase 4: Property access (object.property)
-        ClosureHoverStrategy(), // Phase 4: Closure expressions
-        LiteralHoverStrategy(), // Phase 4: Literals (strings, numbers, lists, maps)
-        GenericHoverStrategy(), // Fallback - must be last
-    )
+    private val strategies: List<HoverStrategy> by lazy {
+        val jenkinsCapabilities = compilationService.workspaceManager.getJenkinsCapabilities()
+        listOfNotNull(
+            // Jenkins step hover has high priority for method calls in Jenkins files
+            jenkinsCapabilities?.let { JenkinsStepHoverStrategy(it, modeResolver) },
+            MethodDeclarationHoverStrategy(),
+            ClassDeclarationHoverStrategy(),
+            FieldDeclarationHoverStrategy(),
+            ImportHoverStrategy(),
+            DeclarationExpressionHoverStrategy(),
+            VariableExpressionHoverStrategy(),
+            MethodCallHoverStrategy(),
+            ConstructorCallHoverStrategy(), // Phase 4: Constructor calls
+            PropertyExpressionHoverStrategy(), // Phase 4: Property access (object.property)
+            ClosureHoverStrategy(), // Phase 4: Closure expressions
+            LiteralHoverStrategy(), // Phase 4: Literals (strings, numbers, lists, maps)
+            GenericHoverStrategy(), // Fallback - must be last
+        )
+    }
 
     /**
      * Provide hover information for the symbol at the given position.
@@ -286,9 +300,6 @@ class HoverProvider(
      * Create hover content using the strategy pattern with documentation enhancement.
      */
     private suspend fun createHoverContent(node: ASTNode, documentUri: URI): Hover? {
-        // Check if this is a Jenkins step and we have metadata for it
-        tryCreateJenkinsStepHover(node, documentUri)?.let { return it }
-
         val module = compilationService.getAst(documentUri) as? ModuleNode
         val context = HoverContext(
             moduleNode = module,
@@ -337,120 +348,6 @@ class HoverProvider(
 
         // Enhance hover with documentation
         return enhanceHoverWithDocumentation(baseHover, doc)
-    }
-
-    /**
-     * Try to create a hover for a Jenkins step from bundled metadata.
-     * Also checks for vars/ global variables with .txt documentation.
-     */
-    private fun tryCreateJenkinsStepHover(node: ASTNode, documentUri: URI): Hover? {
-        // Only check for Jenkins files
-        val jenkinsCapabilities = compilationService.workspaceManager.getJenkinsCapabilities()
-        if (jenkinsCapabilities?.isJenkinsFile(documentUri) != true) {
-            return null
-        }
-
-        // Only for method calls
-        if (node !is MethodCallExpression) {
-            return null
-        }
-
-        val stepName = node.methodAsString ?: return null
-
-        // First, check if this is a vars/ global variable call
-        val varsHover = tryCreateVarsGlobalVariableHover(stepName, node, jenkinsCapabilities)
-        if (varsHover != null) {
-            return varsHover
-        }
-        val metadata = jenkinsCapabilities.getAllMetadata() ?: return null
-        val stepMetadata = JenkinsStepCompletionProvider.getStepMetadata(stepName, metadata) ?: return null
-
-        // Build rich hover content for Jenkins step
-        val markdownContent = markdown {
-            h2("Jenkins Step: `$stepName`")
-
-            stepMetadata.documentation?.let { doc ->
-                text(doc)
-            }
-
-            stepMetadata.plugin?.let { plugin ->
-                text("**Plugin:** $plugin")
-            }
-
-            // Use namedParams instead of parameters for MergedStepMetadata
-            if (stepMetadata.namedParams.isNotEmpty()) {
-                h3("Parameters")
-                list(
-                    stepMetadata.namedParams.map { (name, param) ->
-                        val required = if (param.required) " *(required)*" else ""
-                        val defaultVal = param.defaultValue?.let { " (default: `$it`)" } ?: ""
-                        val base = "**`$name`**: `${param.type}`$required$defaultVal"
-                        param.description?.let { desc -> "$base\n  - $desc" } ?: base
-                    },
-                )
-            }
-        }
-
-        val markupContent = MarkupContent().apply {
-            kind = MarkupKind.MARKDOWN
-            value = markdownContent
-        }
-
-        // Build hover range from the method call expression
-        // LSP end is EXCLUSIVE, Groovy lastColumnNumber is 1-based INCLUSIVE
-        // 1-based inclusive column N equals 0-based exclusive column N (no subtraction needed for end)
-        val hoverRange = Range(
-            Position(node.lineNumber - 1, node.columnNumber - 1),
-            Position(node.lastLineNumber - 1, node.lastColumnNumber),
-        )
-
-        return Hover().apply {
-            contents = Either.forRight(markupContent)
-            range = hoverRange
-        }
-    }
-
-    /**
-     * Try to create a hover for a vars/ global variable call.
-     * Shows the documentation from the companion .txt file if available.
-     */
-    private fun tryCreateVarsGlobalVariableHover(
-        varName: String,
-        node: MethodCallExpression,
-        jenkinsCapabilities: JenkinsCapabilities,
-    ): Hover? {
-        val globalVariables = jenkinsCapabilities.getGlobalVariables()
-        val globalVar = globalVariables.find { it.name == varName } ?: return null
-
-        // Build hover content
-        val markdownContent = markdown {
-            h2("Jenkins Shared Library: `$varName`")
-
-            if (globalVar.documentation.isNotEmpty()) {
-                text(globalVar.documentation)
-            } else {
-                text(italic("No documentation available. Add a `vars/$varName.txt` file to provide documentation."))
-            }
-
-            text("**Source:** `${globalVar.path.fileName}`")
-        }
-
-        val markupContent = MarkupContent().apply {
-            kind = MarkupKind.MARKDOWN
-            value = markdownContent
-        }
-
-        // LSP end is EXCLUSIVE, Groovy lastColumnNumber is 1-based INCLUSIVE
-        // 1-based inclusive column N equals 0-based exclusive column N (no subtraction needed for end)
-        val hoverRange = Range(
-            Position(node.lineNumber - 1, node.columnNumber - 1),
-            Position(node.lastLineNumber - 1, node.lastColumnNumber),
-        )
-
-        return Hover().apply {
-            contents = Either.forRight(markupContent)
-            range = hoverRange
-        }
     }
 
     /**

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/hover/strategies/JenkinsStepHoverStrategy.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/hover/strategies/JenkinsStepHoverStrategy.kt
@@ -1,0 +1,144 @@
+package com.github.albertocavalcante.groovylsp.providers.hover.strategies
+
+import com.github.albertocavalcante.groovylsp.config.ModeResolver
+import com.github.albertocavalcante.groovylsp.markdown.dsl.markdown
+import com.github.albertocavalcante.groovylsp.project.JenkinsCapabilities
+import com.github.albertocavalcante.groovylsp.providers.completion.JenkinsStepCompletionProvider
+import com.github.albertocavalcante.groovylsp.providers.hover.HoverContext
+import com.github.albertocavalcante.groovylsp.providers.hover.HoverStrategy
+import org.codehaus.groovy.ast.ASTNode
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.eclipse.lsp4j.Hover
+import org.eclipse.lsp4j.MarkupContent
+import org.eclipse.lsp4j.MarkupKind
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.jsonrpc.messages.Either
+
+/**
+ * Hover strategy for Jenkins Pipeline steps and global variables.
+ *
+ * Provides rich hover documentation for:
+ * - Jenkins steps (echo, sh, readFile) with parameter info from metadata
+ * - vars/ global variables from shared libraries with .txt documentation
+ *
+ * This strategy is only active when Jenkins mode is enabled for the file.
+ */
+class JenkinsStepHoverStrategy(
+    private val jenkinsCapabilities: JenkinsCapabilities?,
+    private val modeResolver: ModeResolver,
+) : HoverStrategy {
+
+    override fun canHandle(node: ASTNode): Boolean {
+        if (node !is MethodCallExpression) return false
+        return jenkinsCapabilities != null
+    }
+
+    override fun generateHover(node: ASTNode, context: HoverContext): Hover? {
+        if (node !is MethodCallExpression) return null
+
+        // Check if Jenkins mode is enabled for this file
+        if (!modeResolver.isJenkinsModeEnabled(context.documentUri)) {
+            return null
+        }
+
+        val stepName = node.methodAsString ?: return null
+
+        // Try vars/ global variable hover first
+        tryCreateVarsGlobalVariableHover(stepName, node)?.let { return it }
+
+        // Then try step metadata hover
+        return tryCreateStepMetadataHover(stepName, node)
+    }
+
+    /**
+     * Try to create a hover for a vars/ global variable call.
+     * Shows the documentation from the companion .txt file if available.
+     */
+    private fun tryCreateVarsGlobalVariableHover(varName: String, node: MethodCallExpression): Hover? {
+        val globalVariables = jenkinsCapabilities?.getGlobalVariables() ?: return null
+        val globalVar = globalVariables.find { it.name == varName } ?: return null
+
+        // Build hover content
+        val markdownContent = markdown {
+            h2("Jenkins Shared Library: `$varName`")
+
+            if (globalVar.documentation.isNotEmpty()) {
+                text(globalVar.documentation)
+            } else {
+                text(italic("No documentation available. Add a `vars/$varName.txt` file to provide documentation."))
+            }
+
+            text("**Source:** `${globalVar.path.fileName}`")
+        }
+
+        val markupContent = MarkupContent().apply {
+            kind = MarkupKind.MARKDOWN
+            value = markdownContent
+        }
+
+        // LSP end is EXCLUSIVE, Groovy lastColumnNumber is 1-based INCLUSIVE
+        // 1-based inclusive column N equals 0-based exclusive column N (no subtraction needed for end)
+        val hoverRange = Range(
+            Position(node.lineNumber - 1, node.columnNumber - 1),
+            Position(node.lastLineNumber - 1, node.lastColumnNumber),
+        )
+
+        return Hover().apply {
+            contents = Either.forRight(markupContent)
+            range = hoverRange
+        }
+    }
+
+    /**
+     * Try to create a hover for a Jenkins step from bundled metadata.
+     */
+    private fun tryCreateStepMetadataHover(stepName: String, node: MethodCallExpression): Hover? {
+        val metadata = jenkinsCapabilities?.getAllMetadata() ?: return null
+        val stepMetadata = JenkinsStepCompletionProvider.getStepMetadata(stepName, metadata) ?: return null
+
+        // Build rich hover content for Jenkins step
+        val markdownContent = markdown {
+            h2("Jenkins Step: `$stepName`")
+
+            stepMetadata.documentation?.let { doc ->
+                text(doc)
+            }
+
+            stepMetadata.plugin?.let { plugin ->
+                text("**Plugin:** $plugin")
+            }
+
+            // Use namedParams instead of parameters for MergedStepMetadata
+            if (stepMetadata.namedParams.isNotEmpty()) {
+                h3("Parameters")
+                list(
+                    stepMetadata.namedParams.map { (name, param) ->
+                        val required = if (param.required) " *(required)*" else ""
+                        val defaultVal = param.defaultValue?.let { " (default: `$it`)" } ?: ""
+                        val base = "**`$name`**: `${param.type}`$required$defaultVal"
+                        param.description?.let { desc -> "$base\n  - $desc" } ?: base
+                    },
+                )
+            }
+        }
+
+        val markupContent = MarkupContent().apply {
+            kind = MarkupKind.MARKDOWN
+            value = markdownContent
+        }
+
+        // Build hover range from the method call expression
+        // LSP end is EXCLUSIVE, Groovy lastColumnNumber is 1-based INCLUSIVE
+        // 1-based inclusive column N equals 0-based exclusive column N (no subtraction needed for end)
+        val hoverRange = Range(
+            Position(node.lineNumber - 1, node.columnNumber - 1),
+            Position(node.lastLineNumber - 1, node.lastColumnNumber),
+        )
+
+        return Hover().apply {
+            contents = Either.forRight(markupContent)
+            range = hoverRange
+        }
+    }
+}

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/config/ModeResolverTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/config/ModeResolverTest.kt
@@ -1,0 +1,190 @@
+package com.github.albertocavalcante.groovylsp.config
+
+import com.github.albertocavalcante.groovylsp.project.JenkinsCapabilities
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+class ModeResolverTest {
+    private val jenkinsFileUri = URI.create("file:///workspace/Jenkinsfile")
+    private val groovyFileUri = URI.create("file:///workspace/src/Foo.groovy")
+
+    @Test
+    fun `resolveMode returns GROOVY when configured as GROOVY`() {
+        val resolver = ModeResolver(configuredMode = GroovyMode.GROOVY)
+
+        assertThat(resolver.resolveMode(jenkinsFileUri)).isEqualTo(GroovyMode.GROOVY)
+        assertThat(resolver.resolveMode(groovyFileUri)).isEqualTo(GroovyMode.GROOVY)
+    }
+
+    @Test
+    fun `resolveMode returns JENKINS when configured as JENKINS`() {
+        val resolver = ModeResolver(configuredMode = GroovyMode.JENKINS)
+
+        assertThat(resolver.resolveMode(jenkinsFileUri)).isEqualTo(GroovyMode.JENKINS)
+        assertThat(resolver.resolveMode(groovyFileUri)).isEqualTo(GroovyMode.JENKINS)
+    }
+
+    @Test
+    fun `resolveMode auto-detects Jenkins file when AUTO`() {
+        val jenkinsCapabilities = mockk<JenkinsCapabilities> {
+            every { isJenkinsFile(jenkinsFileUri) } returns true
+            every { isJenkinsFile(groovyFileUri) } returns false
+        }
+        val resolver = ModeResolver(
+            configuredMode = GroovyMode.AUTO,
+            jenkinsCapabilities = jenkinsCapabilities,
+        )
+
+        assertThat(resolver.resolveMode(jenkinsFileUri)).isEqualTo(GroovyMode.JENKINS)
+        assertThat(resolver.resolveMode(groovyFileUri)).isEqualTo(GroovyMode.GROOVY)
+    }
+
+    @Test
+    fun `resolveMode returns GROOVY when AUTO and jenkinsCapabilities is null`() {
+        val resolver = ModeResolver(
+            configuredMode = GroovyMode.AUTO,
+            jenkinsCapabilities = null,
+        )
+
+        assertThat(resolver.resolveMode(jenkinsFileUri)).isEqualTo(GroovyMode.GROOVY)
+        assertThat(resolver.resolveMode(groovyFileUri)).isEqualTo(GroovyMode.GROOVY)
+    }
+
+    @Test
+    fun `resolveMode returns GROOVY when AUTO and isJenkinsFile returns false`() {
+        val jenkinsCapabilities = mockk<JenkinsCapabilities> {
+            every { isJenkinsFile(any()) } returns false
+        }
+        val resolver = ModeResolver(
+            configuredMode = GroovyMode.AUTO,
+            jenkinsCapabilities = jenkinsCapabilities,
+        )
+
+        assertThat(resolver.resolveMode(jenkinsFileUri)).isEqualTo(GroovyMode.GROOVY)
+        assertThat(resolver.resolveMode(groovyFileUri)).isEqualTo(GroovyMode.GROOVY)
+    }
+
+    @Test
+    fun `isJenkinsModeEnabled returns true when mode resolves to JENKINS`() {
+        val resolver = ModeResolver(configuredMode = GroovyMode.JENKINS)
+
+        assertThat(resolver.isJenkinsModeEnabled(jenkinsFileUri)).isTrue()
+        assertThat(resolver.isJenkinsModeEnabled(groovyFileUri)).isTrue()
+    }
+
+    @Test
+    fun `isJenkinsModeEnabled returns false when mode resolves to GROOVY`() {
+        val resolver = ModeResolver(configuredMode = GroovyMode.GROOVY)
+
+        assertThat(resolver.isJenkinsModeEnabled(jenkinsFileUri)).isFalse()
+        assertThat(resolver.isJenkinsModeEnabled(groovyFileUri)).isFalse()
+    }
+
+    @Test
+    fun `isJenkinsModeEnabled respects auto-detection`() {
+        val jenkinsCapabilities = mockk<JenkinsCapabilities> {
+            every { isJenkinsFile(jenkinsFileUri) } returns true
+            every { isJenkinsFile(groovyFileUri) } returns false
+        }
+        val resolver = ModeResolver(
+            configuredMode = GroovyMode.AUTO,
+            jenkinsCapabilities = jenkinsCapabilities,
+        )
+
+        assertThat(resolver.isJenkinsModeEnabled(jenkinsFileUri)).isTrue()
+        assertThat(resolver.isJenkinsModeEnabled(groovyFileUri)).isFalse()
+    }
+
+    @Test
+    fun `isGroovyOnlyMode returns true when GROOVY configured`() {
+        val resolver = ModeResolver(configuredMode = GroovyMode.GROOVY)
+
+        assertThat(resolver.isGroovyOnlyMode()).isTrue()
+    }
+
+    @Test
+    fun `isGroovyOnlyMode returns false when JENKINS configured`() {
+        val resolver = ModeResolver(configuredMode = GroovyMode.JENKINS)
+
+        assertThat(resolver.isGroovyOnlyMode()).isFalse()
+    }
+
+    @Test
+    fun `isGroovyOnlyMode returns false when AUTO configured`() {
+        val resolver = ModeResolver(configuredMode = GroovyMode.AUTO)
+
+        assertThat(resolver.isGroovyOnlyMode()).isFalse()
+    }
+
+    @Test
+    fun `fromConfig creates resolver with correct mode`() {
+        val jenkinsCapabilities = mockk<JenkinsCapabilities>()
+        val config = mockk<ServerConfiguration> {
+            every { groovyMode } returns GroovyMode.JENKINS
+        }
+
+        val resolver = ModeResolver.fromConfig(config, jenkinsCapabilities)
+
+        assertThat(resolver.resolveMode(jenkinsFileUri)).isEqualTo(GroovyMode.JENKINS)
+    }
+
+    @Test
+    fun `fromConfig creates resolver with null jenkinsCapabilities`() {
+        val config = mockk<ServerConfiguration> {
+            every { groovyMode } returns GroovyMode.GROOVY
+        }
+
+        val resolver = ModeResolver.fromConfig(config, null)
+
+        assertThat(resolver.resolveMode(jenkinsFileUri)).isEqualTo(GroovyMode.GROOVY)
+    }
+
+    @Test
+    fun `fromConfig creates resolver with AUTO mode and jenkinsCapabilities`() {
+        val jenkinsCapabilities = mockk<JenkinsCapabilities> {
+            every { isJenkinsFile(jenkinsFileUri) } returns true
+        }
+        val config = mockk<ServerConfiguration> {
+            every { groovyMode } returns GroovyMode.AUTO
+        }
+
+        val resolver = ModeResolver.fromConfig(config, jenkinsCapabilities)
+
+        assertThat(resolver.resolveMode(jenkinsFileUri)).isEqualTo(GroovyMode.JENKINS)
+    }
+
+    @Test
+    fun `default constructor uses AUTO mode`() {
+        val resolver = ModeResolver()
+
+        // Without jenkinsCapabilities, AUTO defaults to GROOVY
+        assertThat(resolver.resolveMode(jenkinsFileUri)).isEqualTo(GroovyMode.GROOVY)
+    }
+
+    @Test
+    fun `multiple files can be resolved with same resolver`() {
+        val jenkinsCapabilities = mockk<JenkinsCapabilities> {
+            every { isJenkinsFile(jenkinsFileUri) } returns true
+            every { isJenkinsFile(groovyFileUri) } returns false
+        }
+        val resolver = ModeResolver(
+            configuredMode = GroovyMode.AUTO,
+            jenkinsCapabilities = jenkinsCapabilities,
+        )
+
+        val file1Uri = URI.create("file:///workspace/Jenkinsfile")
+        val file2Uri = URI.create("file:///workspace/src/App.groovy")
+        val file3Uri = URI.create("file:///workspace/vars/myPipeline.groovy")
+
+        every { jenkinsCapabilities.isJenkinsFile(file1Uri) } returns true
+        every { jenkinsCapabilities.isJenkinsFile(file2Uri) } returns false
+        every { jenkinsCapabilities.isJenkinsFile(file3Uri) } returns true
+
+        assertThat(resolver.resolveMode(file1Uri)).isEqualTo(GroovyMode.JENKINS)
+        assertThat(resolver.resolveMode(file2Uri)).isEqualTo(GroovyMode.GROOVY)
+        assertThat(resolver.resolveMode(file3Uri)).isEqualTo(GroovyMode.JENKINS)
+    }
+}

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/strategy/CompletionStrategyTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/completion/strategy/CompletionStrategyTest.kt
@@ -1,0 +1,351 @@
+package com.github.albertocavalcante.groovylsp.providers.completion.strategy
+
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.lsp4j.CompletionItem
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class CompletionStrategyTest {
+
+    @Test
+    fun `aggregate collects completions from all applicable strategies`() {
+        val context = mockk<CompletionStrategyContext>(relaxed = true)
+
+        val strategy1 = CompletionStrategy {
+            CompletionStrategy.found(listOf(CompletionItem().apply { label = "item1" }))
+        }
+        val strategy2 = CompletionStrategy {
+            CompletionStrategy.found(listOf(CompletionItem().apply { label = "item2" }))
+        }
+
+        val aggregated = CompletionStrategy.aggregate(listOf(strategy1, strategy2))
+
+        val result = runBlocking { aggregated.complete(context) }
+
+        assertThat(result.isRight()).isTrue()
+        result.fold(
+            ifLeft = { throw AssertionError("Expected Right, got Left: $it") },
+            ifRight = { items ->
+                assertThat(items).hasSize(2)
+                assertThat(items.map { it.label }).containsExactlyInAnyOrder("item1", "item2")
+            },
+        )
+    }
+
+    @Test
+    fun `aggregate skips strategies that return notApplicable`() {
+        val context = mockk<CompletionStrategyContext>(relaxed = true)
+
+        val applicableStrategy = CompletionStrategy {
+            CompletionStrategy.found(listOf(CompletionItem().apply { label = "item1" }))
+        }
+        val notApplicableStrategy = CompletionStrategy {
+            CompletionStrategy.notApplicable("test")
+        }
+
+        val aggregated = CompletionStrategy.aggregate(listOf(notApplicableStrategy, applicableStrategy))
+
+        val result = runBlocking { aggregated.complete(context) }
+
+        assertThat(result.isRight()).isTrue()
+        result.fold(
+            ifLeft = { throw AssertionError("Expected Right, got Left: $it") },
+            ifRight = { items ->
+                assertThat(items).hasSize(1)
+                assertThat(items.first().label).isEqualTo("item1")
+            },
+        )
+    }
+
+    @Test
+    fun `aggregate handles all strategies returning notApplicable`() {
+        val context = mockk<CompletionStrategyContext>(relaxed = true)
+
+        val strategy1 = CompletionStrategy { CompletionStrategy.notApplicable("test1") }
+        val strategy2 = CompletionStrategy { CompletionStrategy.notApplicable("test2") }
+
+        val aggregated = CompletionStrategy.aggregate(listOf(strategy1, strategy2))
+
+        val result = runBlocking { aggregated.complete(context) }
+
+        // When all strategies are not applicable, aggregate returns empty list (Right)
+        assertThat(result.isRight()).isTrue()
+        result.fold(
+            ifLeft = { throw AssertionError("Expected Right, got Left: $it") },
+            ifRight = { items -> assertThat(items).isEmpty() },
+        )
+    }
+
+    @Test
+    fun `aggregate handles exceptions gracefully`() {
+        val context = mockk<CompletionStrategyContext>(relaxed = true)
+
+        val throwingStrategy = CompletionStrategy {
+            throw RuntimeException("Test exception")
+        }
+        val workingStrategy = CompletionStrategy {
+            CompletionStrategy.found(listOf(CompletionItem().apply { label = "item1" }))
+        }
+
+        val aggregated = CompletionStrategy.aggregate(listOf(throwingStrategy, workingStrategy))
+
+        val result = runBlocking { aggregated.complete(context) }
+
+        // Exception should be caught and treated as notApplicable
+        assertThat(result.isRight()).isTrue()
+        result.fold(
+            ifLeft = { throw AssertionError("Expected Right, got Left: $it") },
+            ifRight = { items ->
+                assertThat(items).hasSize(1)
+                assertThat(items.first().label).isEqualTo("item1")
+            },
+        )
+    }
+
+    @Test
+    fun `aggregate propagates CancellationException`() {
+        val context = mockk<CompletionStrategyContext>(relaxed = true)
+
+        val cancellingStrategy = CompletionStrategy {
+            throw CancellationException("Cancelled")
+        }
+
+        val aggregated = CompletionStrategy.aggregate(listOf(cancellingStrategy))
+
+        assertThrows<CancellationException> {
+            runBlocking { aggregated.complete(context) }
+        }
+    }
+
+    @Test
+    fun `aggregate propagates Error`() {
+        val context = mockk<CompletionStrategyContext>(relaxed = true)
+
+        val errorStrategy = CompletionStrategy {
+            throw OutOfMemoryError("Test error")
+        }
+
+        val aggregated = CompletionStrategy.aggregate(listOf(errorStrategy))
+
+        assertThrows<OutOfMemoryError> {
+            runBlocking { aggregated.complete(context) }
+        }
+    }
+
+    @Test
+    fun `aggregate handles empty strategy list`() {
+        val context = mockk<CompletionStrategyContext>(relaxed = true)
+
+        val aggregated = CompletionStrategy.aggregate(emptyList())
+
+        val result = runBlocking { aggregated.complete(context) }
+
+        assertThat(result.isRight()).isTrue()
+        result.fold(
+            ifLeft = { throw AssertionError("Expected Right, got Left: $it") },
+            ifRight = { items -> assertThat(items).isEmpty() },
+        )
+    }
+
+    @Test
+    fun `aggregate collects multiple items from single strategy`() {
+        val context = mockk<CompletionStrategyContext>(relaxed = true)
+
+        val multiItemStrategy = CompletionStrategy {
+            CompletionStrategy.found(
+                listOf(
+                    CompletionItem().apply { label = "item1" },
+                    CompletionItem().apply { label = "item2" },
+                    CompletionItem().apply { label = "item3" },
+                ),
+            )
+        }
+
+        val aggregated = CompletionStrategy.aggregate(listOf(multiItemStrategy))
+
+        val result = runBlocking { aggregated.complete(context) }
+
+        assertThat(result.isRight()).isTrue()
+        result.fold(
+            ifLeft = { throw AssertionError("Expected Right, got Left: $it") },
+            ifRight = { items ->
+                assertThat(items).hasSize(3)
+                assertThat(items.map { it.label }).containsExactly("item1", "item2", "item3")
+            },
+        )
+    }
+
+    @Test
+    fun `aggregate maintains order of items from strategies`() {
+        val context = mockk<CompletionStrategyContext>(relaxed = true)
+
+        val strategy1 = CompletionStrategy {
+            CompletionStrategy.found(
+                listOf(
+                    CompletionItem().apply { label = "a1" },
+                    CompletionItem().apply { label = "a2" },
+                ),
+            )
+        }
+        val strategy2 = CompletionStrategy {
+            CompletionStrategy.found(
+                listOf(
+                    CompletionItem().apply { label = "b1" },
+                    CompletionItem().apply { label = "b2" },
+                ),
+            )
+        }
+
+        val aggregated = CompletionStrategy.aggregate(listOf(strategy1, strategy2))
+
+        val result = runBlocking { aggregated.complete(context) }
+
+        assertThat(result.isRight()).isTrue()
+        result.fold(
+            ifLeft = { throw AssertionError("Expected Right, got Left: $it") },
+            ifRight = { items ->
+                assertThat(items).hasSize(4)
+                assertThat(items.map { it.label }).containsExactly("a1", "a2", "b1", "b2")
+            },
+        )
+    }
+
+    @Test
+    fun `notApplicable returns Left with correct structure`() {
+        val result = CompletionStrategy.notApplicable("TestStrategy")
+
+        assertThat(result.isLeft()).isTrue()
+        result.fold(
+            ifLeft = { error ->
+                assertThat(error.reason).isEqualTo("Strategy not applicable")
+                assertThat(error.source).isEqualTo("TestStrategy")
+            },
+            ifRight = { throw AssertionError("Expected Left, got Right: $it") },
+        )
+    }
+
+    @Test
+    fun `notApplicable with default strategy name`() {
+        val result = CompletionStrategy.notApplicable()
+
+        assertThat(result.isLeft()).isTrue()
+        result.fold(
+            ifLeft = { error ->
+                assertThat(error.reason).isEqualTo("Strategy not applicable")
+                assertThat(error.source).isEqualTo("unknown")
+            },
+            ifRight = { throw AssertionError("Expected Left, got Right: $it") },
+        )
+    }
+
+    @Test
+    fun `found returns Right with items`() {
+        val items = listOf(
+            CompletionItem().apply { label = "item1" },
+            CompletionItem().apply { label = "item2" },
+        )
+
+        val result = CompletionStrategy.found(items)
+
+        assertThat(result.isRight()).isTrue()
+        result.fold(
+            ifLeft = { throw AssertionError("Expected Right, got Left: $it") },
+            ifRight = { actualItems ->
+                assertThat(actualItems).hasSize(2)
+                assertThat(actualItems).isEqualTo(items)
+            },
+        )
+    }
+
+    @Test
+    fun `found returns Right with empty list`() {
+        val result = CompletionStrategy.found(emptyList())
+
+        assertThat(result.isRight()).isTrue()
+        result.fold(
+            ifLeft = { throw AssertionError("Expected Right, got Left: $it") },
+            ifRight = { items -> assertThat(items).isEmpty() },
+        )
+    }
+
+    @Test
+    fun `error returns Left with correct structure`() {
+        val result = CompletionStrategy.error("Something went wrong", "MyStrategy")
+
+        assertThat(result.isLeft()).isTrue()
+        result.fold(
+            ifLeft = { error ->
+                assertThat(error.reason).isEqualTo("Something went wrong")
+                assertThat(error.source).isEqualTo("MyStrategy")
+            },
+            ifRight = { throw AssertionError("Expected Right, got Right: $it") },
+        )
+    }
+
+    @Test
+    fun `error with default strategy name`() {
+        val result = CompletionStrategy.error("Failed")
+
+        assertThat(result.isLeft()).isTrue()
+        result.fold(
+            ifLeft = { error ->
+                assertThat(error.reason).isEqualTo("Failed")
+                assertThat(error.source).isEqualTo("unknown")
+            },
+            ifRight = { throw AssertionError("Expected Right, got Right: $it") },
+        )
+    }
+
+    @Test
+    fun `strategy can use suspend functions`() {
+        val context = mockk<CompletionStrategyContext>(relaxed = true)
+
+        val suspendingStrategy = CompletionStrategy { ctx ->
+            // Simulate async operation
+            kotlinx.coroutines.delay(10)
+            CompletionStrategy.found(listOf(CompletionItem().apply { label = "async-item" }))
+        }
+
+        val result = runBlocking { suspendingStrategy.complete(context) }
+
+        assertThat(result.isRight()).isTrue()
+        result.fold(
+            ifLeft = { throw AssertionError("Expected Right, got Left: $it") },
+            ifRight = { items ->
+                assertThat(items).hasSize(1)
+                assertThat(items.first().label).isEqualTo("async-item")
+            },
+        )
+    }
+
+    @Test
+    fun `aggregate handles mix of successful and error strategies`() {
+        val context = mockk<CompletionStrategyContext>(relaxed = true)
+
+        val strategy1 = CompletionStrategy {
+            CompletionStrategy.found(listOf(CompletionItem().apply { label = "success1" }))
+        }
+        val strategy2 = CompletionStrategy {
+            CompletionStrategy.error("Failed", "Strategy2")
+        }
+        val strategy3 = CompletionStrategy {
+            CompletionStrategy.found(listOf(CompletionItem().apply { label = "success2" }))
+        }
+
+        val aggregated = CompletionStrategy.aggregate(listOf(strategy1, strategy2, strategy3))
+
+        val result = runBlocking { aggregated.complete(context) }
+
+        assertThat(result.isRight()).isTrue()
+        result.fold(
+            ifLeft = { throw AssertionError("Expected Right, got Left: $it") },
+            ifRight = { items ->
+                assertThat(items).hasSize(2)
+                assertThat(items.map { it.label }).containsExactlyInAnyOrder("success1", "success2")
+            },
+        )
+    }
+}

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/hover/strategies/JenkinsStepHoverStrategyTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/hover/strategies/JenkinsStepHoverStrategyTest.kt
@@ -1,0 +1,394 @@
+package com.github.albertocavalcante.groovylsp.providers.hover.strategies
+
+import com.github.albertocavalcante.groovyjenkins.GlobalVariable
+import com.github.albertocavalcante.groovyjenkins.metadata.MergedJenkinsMetadata
+import com.github.albertocavalcante.groovyjenkins.metadata.MergedParameter
+import com.github.albertocavalcante.groovyjenkins.metadata.MergedStepMetadata
+import com.github.albertocavalcante.groovyjenkins.metadata.enrichment.StepCategory
+import com.github.albertocavalcante.groovyjenkins.metadata.extracted.StepScope
+import com.github.albertocavalcante.groovylsp.config.ModeResolver
+import com.github.albertocavalcante.groovylsp.project.JenkinsCapabilities
+import com.github.albertocavalcante.groovylsp.providers.hover.HoverContext
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.codehaus.groovy.ast.expr.VariableExpression
+import org.eclipse.lsp4j.MarkupKind
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.net.URI
+import java.nio.file.Path
+
+/**
+ * Unit tests for JenkinsStepHoverStrategy.
+ *
+ * Tests the hover functionality for Jenkins Pipeline steps and vars/ global variables.
+ */
+class JenkinsStepHoverStrategyTest {
+
+    private lateinit var jenkinsCapabilities: JenkinsCapabilities
+    private lateinit var modeResolver: ModeResolver
+    private lateinit var strategy: JenkinsStepHoverStrategy
+    private lateinit var context: HoverContext
+
+    private val jenkinsFileUri = URI.create("file:///workspace/Jenkinsfile")
+
+    @BeforeEach
+    fun setup() {
+        jenkinsCapabilities = mockk(relaxed = true)
+        modeResolver = mockk()
+        strategy = JenkinsStepHoverStrategy(jenkinsCapabilities, modeResolver)
+
+        context = HoverContext(
+            moduleNode = null,
+            contentGenerator = mockk(relaxed = true),
+            documentUri = jenkinsFileUri,
+        )
+    }
+
+    @Test
+    fun `canHandle returns true for MethodCallExpression with jenkinsCapabilities`() {
+        val node = mockk<MethodCallExpression>()
+
+        assertThat(strategy.canHandle(node)).isTrue()
+    }
+
+    @Test
+    fun `canHandle returns false for non-MethodCallExpression`() {
+        val node = mockk<VariableExpression>()
+
+        assertThat(strategy.canHandle(node)).isFalse()
+    }
+
+    @Test
+    fun `canHandle returns false when jenkinsCapabilities is null`() {
+        val strategyWithoutCapabilities = JenkinsStepHoverStrategy(null, modeResolver)
+        val node = mockk<MethodCallExpression>()
+
+        assertThat(strategyWithoutCapabilities.canHandle(node)).isFalse()
+    }
+
+    @Test
+    fun `generateHover returns null when Jenkins mode not enabled`() {
+        val node = createMethodCallExpression("echo")
+        every { modeResolver.isJenkinsModeEnabled(jenkinsFileUri) } returns false
+
+        val result = strategy.generateHover(node, context)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `generateHover returns null for non-MethodCallExpression`() {
+        val node = mockk<VariableExpression>()
+        every { modeResolver.isJenkinsModeEnabled(jenkinsFileUri) } returns true
+
+        val result = strategy.generateHover(node, context)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `generateHover returns null when method name cannot be determined`() {
+        val node = mockk<MethodCallExpression>()
+        every { node.methodAsString } returns null
+        every { modeResolver.isJenkinsModeEnabled(jenkinsFileUri) } returns true
+
+        val result = strategy.generateHover(node, context)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `generateHover creates hover for vars global variable with documentation`() {
+        val node = createMethodCallExpression("myCustomStep")
+        val globalVar = GlobalVariable(
+            name = "myCustomStep",
+            path = Path.of("/workspace/vars/myCustomStep.groovy"),
+            documentation = "This is a custom step from shared library.\n\nIt does something useful.",
+            callLineNumber = 5,
+        )
+
+        every { modeResolver.isJenkinsModeEnabled(jenkinsFileUri) } returns true
+        every { jenkinsCapabilities.getGlobalVariables() } returns listOf(globalVar)
+
+        val result = strategy.generateHover(node, context)
+
+        assertThat(result).isNotNull()
+        val markupContent = result!!.contents.right
+        assertThat(markupContent.kind).isEqualTo(MarkupKind.MARKDOWN)
+        assertThat(markupContent.value).contains("Jenkins Shared Library: `myCustomStep`")
+        assertThat(markupContent.value).contains("This is a custom step from shared library")
+        assertThat(markupContent.value).contains("**Source:** `myCustomStep.groovy`")
+
+        // Check hover range
+        assertThat(result.range).isNotNull()
+        assertThat(result.range.start.line).isEqualTo(0)
+        assertThat(result.range.start.character).isEqualTo(0)
+    }
+
+    @Test
+    fun `generateHover creates hover for vars global variable without documentation`() {
+        val node = createMethodCallExpression("undocumentedStep")
+        val globalVar = GlobalVariable(
+            name = "undocumentedStep",
+            path = Path.of("/workspace/vars/undocumentedStep.groovy"),
+            documentation = "",
+            callLineNumber = 1,
+        )
+
+        every { modeResolver.isJenkinsModeEnabled(jenkinsFileUri) } returns true
+        every { jenkinsCapabilities.getGlobalVariables() } returns listOf(globalVar)
+
+        val result = strategy.generateHover(node, context)
+
+        assertThat(result).isNotNull()
+        val markupContent = result!!.contents.right
+        assertThat(markupContent.kind).isEqualTo(MarkupKind.MARKDOWN)
+        assertThat(markupContent.value).contains("Jenkins Shared Library: `undocumentedStep`")
+        assertThat(markupContent.value).contains("No documentation available")
+        assertThat(markupContent.value).contains("Add a `vars/undocumentedStep.txt` file")
+    }
+
+    @Test
+    fun `generateHover creates hover for Jenkins step with metadata`() {
+        val node = createMethodCallExpression("echo")
+        val metadata = createMockMetadata(
+            stepName = "echo",
+            stepDoc = "Prints a message to the console.",
+            plugin = "workflow-basic-steps",
+            params = mapOf(
+                "message" to MergedParameter(
+                    name = "message",
+                    type = "String",
+                    defaultValue = null,
+                    description = "The message to print",
+                    required = true,
+                    validValues = null,
+                    examples = emptyList(),
+                ),
+            ),
+        )
+
+        every { modeResolver.isJenkinsModeEnabled(jenkinsFileUri) } returns true
+        every { jenkinsCapabilities.getGlobalVariables() } returns emptyList()
+        every { jenkinsCapabilities.getAllMetadata() } returns metadata
+
+        val result = strategy.generateHover(node, context)
+
+        assertThat(result).isNotNull()
+        val markupContent = result!!.contents.right
+        assertThat(markupContent.kind).isEqualTo(MarkupKind.MARKDOWN)
+        assertThat(markupContent.value).contains("Jenkins Step: `echo`")
+        assertThat(markupContent.value).contains("Prints a message to the console")
+        assertThat(markupContent.value).contains("**Plugin:** workflow-basic-steps")
+        assertThat(markupContent.value).contains("### Parameters")
+        assertThat(markupContent.value).contains("**`message`**: `String` *(required)*")
+        assertThat(markupContent.value).contains("The message to print")
+    }
+
+    @Test
+    fun `generateHover creates hover for Jenkins step with optional parameters`() {
+        val node = createMethodCallExpression("readFile")
+        val metadata = createMockMetadata(
+            stepName = "readFile",
+            stepDoc = "Read file from workspace.",
+            plugin = "workflow-basic-steps",
+            params = mapOf(
+                "file" to MergedParameter(
+                    name = "file",
+                    type = "String",
+                    defaultValue = null,
+                    description = "Path to the file",
+                    required = true,
+                    validValues = null,
+                    examples = emptyList(),
+                ),
+                "encoding" to MergedParameter(
+                    name = "encoding",
+                    type = "String",
+                    defaultValue = "UTF-8",
+                    description = "File encoding",
+                    required = false,
+                    validValues = null,
+                    examples = emptyList(),
+                ),
+            ),
+        )
+
+        every { modeResolver.isJenkinsModeEnabled(jenkinsFileUri) } returns true
+        every { jenkinsCapabilities.getGlobalVariables() } returns emptyList()
+        every { jenkinsCapabilities.getAllMetadata() } returns metadata
+
+        val result = strategy.generateHover(node, context)
+
+        assertThat(result).isNotNull()
+        val markupContent = result!!.contents.right
+        assertThat(markupContent.value).contains("Jenkins Step: `readFile`")
+        assertThat(markupContent.value).contains("**`file`**: `String` *(required)*")
+        assertThat(markupContent.value).contains("**`encoding`**: `String` (default: `UTF-8`)")
+        assertThat(markupContent.value).doesNotContain("*(required)*\n  - **`encoding`")
+    }
+
+    @Test
+    fun `generateHover returns null when step not found in metadata`() {
+        val node = createMethodCallExpression("unknownStep")
+        val metadata = createMockMetadata(
+            stepName = "echo",
+            stepDoc = "Echo step",
+            plugin = null,
+            params = emptyMap(),
+        )
+
+        every { modeResolver.isJenkinsModeEnabled(jenkinsFileUri) } returns true
+        every { jenkinsCapabilities.getGlobalVariables() } returns emptyList()
+        every { jenkinsCapabilities.getAllMetadata() } returns metadata
+
+        val result = strategy.generateHover(node, context)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `generateHover returns null when getAllMetadata returns null`() {
+        val node = createMethodCallExpression("echo")
+
+        every { modeResolver.isJenkinsModeEnabled(jenkinsFileUri) } returns true
+        every { jenkinsCapabilities.getGlobalVariables() } returns emptyList()
+        every { jenkinsCapabilities.getAllMetadata() } returns null
+
+        val result = strategy.generateHover(node, context)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `generateHover prefers vars global variable over step metadata`() {
+        val node = createMethodCallExpression("echo")
+        val globalVar = GlobalVariable(
+            name = "echo",
+            path = Path.of("/workspace/vars/echo.groovy"),
+            documentation = "Custom echo from shared library",
+            callLineNumber = 1,
+        )
+        val metadata = createMockMetadata(
+            stepName = "echo",
+            stepDoc = "Built-in echo step",
+            plugin = "workflow-basic-steps",
+            params = emptyMap(),
+        )
+
+        every { modeResolver.isJenkinsModeEnabled(jenkinsFileUri) } returns true
+        every { jenkinsCapabilities.getGlobalVariables() } returns listOf(globalVar)
+        every { jenkinsCapabilities.getAllMetadata() } returns metadata
+
+        val result = strategy.generateHover(node, context)
+
+        assertThat(result).isNotNull()
+        val markupContent = result!!.contents.right
+        // Should prefer the vars/ global variable
+        assertThat(markupContent.value).contains("Jenkins Shared Library: `echo`")
+        assertThat(markupContent.value).contains("Custom echo from shared library")
+        assertThat(markupContent.value).doesNotContain("Built-in echo step")
+    }
+
+    @Test
+    fun `generateHover creates hover for step without plugin info`() {
+        val node = createMethodCallExpression("sh")
+        val metadata = createMockMetadata(
+            stepName = "sh",
+            stepDoc = "Execute shell script",
+            plugin = null,
+            params = mapOf(
+                "script" to MergedParameter(
+                    name = "script",
+                    type = "String",
+                    defaultValue = null,
+                    description = "Shell script to execute",
+                    required = true,
+                    validValues = null,
+                    examples = emptyList(),
+                ),
+            ),
+        )
+
+        every { modeResolver.isJenkinsModeEnabled(jenkinsFileUri) } returns true
+        every { jenkinsCapabilities.getGlobalVariables() } returns emptyList()
+        every { jenkinsCapabilities.getAllMetadata() } returns metadata
+
+        val result = strategy.generateHover(node, context)
+
+        assertThat(result).isNotNull()
+        val markupContent = result!!.contents.right
+        assertThat(markupContent.value).contains("Jenkins Step: `sh`")
+        assertThat(markupContent.value).contains("Execute shell script")
+        assertThat(markupContent.value).doesNotContain("**Plugin:**")
+    }
+
+    @Test
+    fun `generateHover creates hover for step without parameters`() {
+        val node = createMethodCallExpression("checkout")
+        val metadata = createMockMetadata(
+            stepName = "checkout",
+            stepDoc = "Check out from version control",
+            plugin = "workflow-scm-step",
+            params = emptyMap(),
+        )
+
+        every { modeResolver.isJenkinsModeEnabled(jenkinsFileUri) } returns true
+        every { jenkinsCapabilities.getGlobalVariables() } returns emptyList()
+        every { jenkinsCapabilities.getAllMetadata() } returns metadata
+
+        val result = strategy.generateHover(node, context)
+
+        assertThat(result).isNotNull()
+        val markupContent = result!!.contents.right
+        assertThat(markupContent.value).contains("Jenkins Step: `checkout`")
+        assertThat(markupContent.value).contains("Check out from version control")
+        assertThat(markupContent.value).doesNotContain("### Parameters")
+    }
+
+    // Helper function to create a mock MethodCallExpression
+    private fun createMethodCallExpression(methodName: String): MethodCallExpression {
+        val methodCall = mockk<MethodCallExpression>(relaxed = true)
+        every { methodCall.methodAsString } returns methodName
+        every { methodCall.lineNumber } returns 1
+        every { methodCall.columnNumber } returns 1
+        every { methodCall.lastLineNumber } returns 1
+        every { methodCall.lastColumnNumber } returns methodName.length + 1
+        return methodCall
+    }
+
+    // Helper function to create mock MergedJenkinsMetadata
+    private fun createMockMetadata(
+        stepName: String,
+        stepDoc: String?,
+        plugin: String?,
+        params: Map<String, MergedParameter>,
+    ): MergedJenkinsMetadata {
+        val stepMetadata = MergedStepMetadata(
+            name = stepName,
+            scope = StepScope.GLOBAL,
+            positionalParams = emptyList(),
+            namedParams = params,
+            extractedDocumentation = null,
+            returnType = null,
+            plugin = plugin,
+            enrichedDescription = stepDoc,
+            documentationUrl = null,
+            category = StepCategory.UTILITY,
+            examples = emptyList(),
+            deprecation = null,
+        )
+
+        return MergedJenkinsMetadata(
+            jenkinsVersion = "2.400",
+            steps = mapOf(stepName to stepMetadata),
+            globalVariables = emptyMap(),
+            sections = emptyMap(),
+            directives = emptyMap(),
+            declarativeOptions = emptyMap(),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Introduce strategy pattern for completion and hover providers to cleanly separate Groovy-only vs Jenkins Pipeline mode. This enables:
- Explicit mode selection via `groovy.mode` config (`groovy`, `jenkins`, `auto`)
- Auto-detection based on file patterns (Jenkinsfile, vars/, shared libraries)
- Clean separation of concerns with independently testable strategies

## Changes

### Mode Configuration (Phase 1)
- Add `GroovyMode` enum (`GROOVY`, `JENKINS`, `AUTO`)
- Add `ModeResolver` for mode detection with auto-detect support
- Add `groovy.mode` configuration option to `ServerConfiguration`

### Completion Strategy Pattern (Phase 2)
- Create `CompletionStrategy` interface with Arrow Either for error handling
- Extract `JenkinsCompletionStrategy` for Jenkins steps, global variables, declarative blocks
- Extract `GroovyCompletionStrategy` for core Groovy symbols and keywords
- Refactor `CompletionProvider` to use strategy aggregation

### Hover Strategy Pattern (Phase 3)
- Create `JenkinsStepHoverStrategy` for Jenkins step and vars hover
- Integrate into `HoverProvider`'s strategy list
- Remove embedded Jenkins logic from `HoverProvider`

### Testing (Phase 4)
- Add `ModeResolverTest` with 16 test cases
- Add `CompletionStrategyTest` with 17 test cases
- Add `JenkinsStepHoverStrategyTest` with 15 test cases

## Files Changed

### New Files (10)
- `groovy-lsp/.../config/GroovyMode.kt` - Mode enum
- `groovy-lsp/.../config/ModeResolver.kt` - Mode resolution logic
- `groovy-lsp/.../completion/strategy/CompletionStrategy.kt` - Strategy interface
- `groovy-lsp/.../completion/strategy/CompletionStrategyContext.kt` - Context classes
- `groovy-lsp/.../completion/strategy/JenkinsCompletionStrategy.kt` - Jenkins completions
- `groovy-lsp/.../completion/strategy/GroovyCompletionStrategy.kt` - Groovy completions
- `groovy-lsp/.../hover/strategies/JenkinsStepHoverStrategy.kt` - Jenkins hover
- `groovy-lsp/.../config/ModeResolverTest.kt` - Tests
- `groovy-lsp/.../completion/strategy/CompletionStrategyTest.kt` - Tests
- `groovy-lsp/.../hover/strategies/JenkinsStepHoverStrategyTest.kt` - Tests

### Modified Files (3)
- `groovy-lsp/.../config/ServerConfiguration.kt` - Add groovyMode field
- `groovy-lsp/.../completion/CompletionProvider.kt` - Use strategies
- `groovy-lsp/.../hover/HoverProvider.kt` - Use strategy

## Test Plan

- [x] All existing tests pass (1789 tests)
- [x] New ModeResolver tests pass (16 tests)
- [x] New CompletionStrategy tests pass (17 tests)
- [x] New JenkinsStepHoverStrategy tests pass (15 tests)
- [x] Lint checks pass
- [ ] Manual verification: Jenkins completions in Jenkinsfile
- [ ] Manual verification: No Jenkins completions in regular Groovy files when mode=groovy

Closes #875

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable mode selection (AUTO, GROOVY, JENKINS) for context-aware language support
  * Implemented automatic detection of Jenkins pipeline files
  * Enhanced code completion with mode-aware strategies tailored to Groovy and Jenkins contexts
  * Improved hover information for Jenkins pipeline steps and global variables with metadata

* **Improvements**
  * Code completion now adapts based on detected file type and configured mode
  * Hover information now displays Jenkins step parameters and documentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->