### PR TITLE
feat(vscode): add project build JDK configuration

### DIFF
--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -65,8 +65,14 @@ That's it! The extension will find Java automatically from your PATH or `JAVA_HO
 
 ```json
 {
-  // Java configuration (required)
-  "groovy.java.home": "/path/to/your/java17",
+  // Java configuration for Language Server (requires Java 17+)
+  "groovy.languageServer.javaHome": "/path/to/your/java17",
+
+  // Java configuration for Project Build (Maven/Gradle)
+  "groovy.project.javaHome": "/path/to/your/project/java",
+
+  // DEPRECATED: Use groovy.languageServer.javaHome instead
+  // "groovy.java.home": "/path/to/your/java17",
 
   // Enable/disable code formatting
   "groovy.format.enable": true,
@@ -75,6 +81,18 @@ That's it! The extension will find Java automatically from your PATH or `JAVA_HO
   "groovy.trace.server": "off"
 }
 ```
+
+#### Java Settings Explained
+
+- **`groovy.languageServer.javaHome`**: Java installation for running the Groovy Language Server. Requires Java 17 or
+  higher. If not set, the extension will auto-detect Java from your system.
+
+- **`groovy.project.javaHome`**: Java installation for project build and test execution (Maven/Gradle). This can be
+  different from the Language Server Java. If not set, uses your system's `JAVA_HOME`.
+
+- **`groovy.java.home`**: **DEPRECATED**. This setting is replaced by `groovy.languageServer.javaHome` and will be
+  removed in a future version. For backward compatibility, it still works but you should migrate to the new setting
+  names.
 
 ### CodeNarc Static Analysis
 

--- a/editors/code/client/src/configuration/settings.ts
+++ b/editors/code/client/src/configuration/settings.ts
@@ -14,7 +14,9 @@ export function getConfiguration(): GroovyConfiguration {
   const config = workspace.getConfiguration("groovy");
 
   return {
-    javaHome: config.get<string>("java.home"),
+    javaHome:
+      config.get<string>("languageServer.javaHome") ||
+      config.get<string>("java.home"),
     traceServer: config.get<"off" | "messages" | "verbose">(
       "trace.server",
       "off",
@@ -40,7 +42,10 @@ export function affectsConfiguration(
 export function affectsJavaConfiguration(
   event: ConfigurationChangeEvent,
 ): boolean {
-  return affectsConfiguration(event, "java.home");
+  return (
+    affectsConfiguration(event, "languageServer.javaHome") ||
+    affectsConfiguration(event, "java.home")
+  );
 }
 
 /**

--- a/editors/code/client/src/features/testing/LSPTestExecutionService.ts
+++ b/editors/code/client/src/features/testing/LSPTestExecutionService.ts
@@ -169,7 +169,7 @@ export class LSPTestExecutionService implements ITestExecutionService {
       resolvedEnv = {
         ...resolvedEnv,
         JAVA_HOME: projectJavaHome,
-        PATH: `${projectJavaHome}/bin${path.delimiter}${resolvedEnv.PATH}`,
+        PATH: `${projectJavaHome}/bin${path.delimiter}${resolvedEnv.PATH || ""}`,
       };
       this.logger.appendLine(`[Test] Using project JDK: ${projectJavaHome}`);
     }

--- a/editors/code/client/src/features/testing/LSPTestExecutionService.ts
+++ b/editors/code/client/src/features/testing/LSPTestExecutionService.ts
@@ -144,6 +144,11 @@ export class LSPTestExecutionService implements ITestExecutionService {
     );
   }
 
+  private getProjectJavaHome(): string | undefined {
+    const config = vscode.workspace.getConfiguration("groovy");
+    return config.get<string>("project.javaHome");
+  }
+
   private async executeCommand(
     cmd: TestCommand,
     consumer: TestEventConsumer,
@@ -154,6 +159,20 @@ export class LSPTestExecutionService implements ITestExecutionService {
     this.logger.appendLine(
       `[LSP] Executing: ${executable} ${args.join(" ")} (in ${cwd})`,
     );
+
+    // Get project build JDK from settings
+    const projectJavaHome = this.getProjectJavaHome();
+
+    // Build environment with explicit JAVA_HOME if configured
+    let resolvedEnv = { ...process.env, ...env };
+    if (projectJavaHome) {
+      resolvedEnv = {
+        ...resolvedEnv,
+        JAVA_HOME: projectJavaHome,
+        PATH: `${projectJavaHome}/bin${path.delimiter}${resolvedEnv.PATH}`,
+      };
+      this.logger.appendLine(`[Test] Using project JDK: ${projectJavaHome}`);
+    }
 
     // Detect Build Tool by executable name
     const isGradle = executable.includes("gradle");
@@ -186,7 +205,7 @@ export class LSPTestExecutionService implements ITestExecutionService {
     return new Promise((resolve) => {
       const proc = cp.spawn(executable, finalArgs, {
         cwd,
-        env: { ...process.env, ...env },
+        env: resolvedEnv,
         // Shell usage:
         // - Maven Wrapper (mvnw): shell: false (executable script)
         // - Global Maven (mvn): shell: true (needed for Windows batch/cmd shims)

--- a/editors/code/client/src/java/commands.ts
+++ b/editors/code/client/src/java/commands.ts
@@ -168,17 +168,7 @@ async function configureProjectJava(minimumVersion?: number): Promise<boolean> {
     return false;
   }
 
-  const config = vscode.workspace.getConfiguration("groovy");
-  await config.update(
-    "project.javaHome",
-    jdk.path,
-    vscode.ConfigurationTarget.Workspace,
-  );
-
-  vscode.window.showInformationMessage(
-    `Project build JDK set to Java ${jdk.version}. Tests will use this JDK.`,
-  );
-  return true;
+  return await setProjectJavaHome(jdk.path, jdk.version);
 }
 
 /**
@@ -271,17 +261,7 @@ async function browseAndSetProjectJavaHome(): Promise<boolean> {
       return false;
     }
 
-    const config = vscode.workspace.getConfiguration("groovy");
-    await config.update(
-      "project.javaHome",
-      runtime.homedir,
-      vscode.ConfigurationTarget.Workspace,
-    );
-
-    vscode.window.showInformationMessage(
-      `Project build JDK set to Java ${runtime.version.major}. Tests will use this JDK.`,
-    );
-    return true;
+    return await setProjectJavaHome(runtime.homedir, runtime.version.major);
   } catch (error) {
     vscode.window.showErrorMessage(
       `Failed to validate JDK at ${jdkPath}: ${error instanceof Error ? error.message : String(error)}`,
@@ -319,6 +299,31 @@ async function setLspJavaHomeAndRestart(
     await vscode.commands.executeCommand("groovy.restartServer");
   }
 
+  return true;
+}
+
+/**
+ * Sets the Project Build Java home in workspace settings.
+ * Updates groovy.project.javaHome in .vscode/settings.json (workspace scope).
+ *
+ * @param jdkPath Absolute path to the JDK home directory
+ * @param version Major Java version number
+ * @returns true if settings were updated successfully
+ */
+async function setProjectJavaHome(
+  jdkPath: string,
+  version: number,
+): Promise<boolean> {
+  const config = vscode.workspace.getConfiguration("groovy");
+  await config.update(
+    "project.javaHome",
+    jdkPath,
+    vscode.ConfigurationTarget.Workspace,
+  );
+
+  vscode.window.showInformationMessage(
+    `Project build JDK set to Java ${version}. Tests will use this JDK.`,
+  );
   return true;
 }
 

--- a/editors/code/client/src/java/commands.ts
+++ b/editors/code/client/src/java/commands.ts
@@ -34,15 +34,60 @@ const KOTLIN_PLUGIN_PATTERN = new RegExp(
 /**
  * Command: groovy.configureJava
  *
- * Shows a picker with detected JDKs and allows manual path selection.
- * Sets the selected JDK path in the workspace settings (.vscode/settings.json).
+ * Main entry point for Java configuration. Shows a purpose picker to let the user
+ * choose between configuring LSP Runtime (Java 17+ for language server) or
+ * Project Build JDK (for Maven/Gradle test execution).
  *
  * @param requiredVersion Optional version to prioritize (e.g., from toolchain error)
+ * @param purpose Optional purpose to skip picker ("lsp" or "project")
  * @returns true if a JDK was selected and configured, false otherwise
  */
 export async function configureJava(
   requiredVersion?: number,
+  purpose?: "lsp" | "project",
 ): Promise<boolean> {
+  if (!purpose) {
+    const picked = await vscode.window.showQuickPick(
+      [
+        {
+          label: "$(server) Language Server Runtime",
+          description: "Java for running the Groovy LSP (requires 17+)",
+          detail: "Sets groovy.languageServer.javaHome",
+          purpose: "lsp" as const,
+        },
+        {
+          label: "$(tools) Project Build JDK",
+          description: "Java for Maven/Gradle test and build execution",
+          detail: "Sets groovy.project.javaHome",
+          purpose: "project" as const,
+        },
+      ],
+      {
+        title: "Configure Java Runtime",
+        placeHolder: "What do you want to configure?",
+      },
+    );
+
+    if (!picked) return false;
+    purpose = picked.purpose;
+  }
+
+  if (purpose === "lsp") {
+    return await configureLspJava(requiredVersion);
+  } else {
+    return await configureProjectJava(requiredVersion);
+  }
+}
+
+/**
+ * Configures the Language Server runtime Java.
+ * Shows a picker with detected JDKs and allows manual path selection.
+ * Sets the selected JDK path in workspace settings (groovy.languageServer.javaHome).
+ *
+ * @param requiredVersion Optional version to prioritize (e.g., from toolchain error)
+ * @returns true if a JDK was selected and configured, false otherwise
+ */
+async function configureLspJava(requiredVersion?: number): Promise<boolean> {
   // Find all JDKs with progress indicator
   const jdks = await vscode.window.withProgress(
     {
@@ -61,7 +106,7 @@ export async function configureJava(
     placeHolder: requiredVersion
       ? `Select a JDK (LSP needs 17+, project targets Java ${requiredVersion})`
       : `Select a JDK for the Groovy Language Server (requires Java ${MINIMUM_JAVA_VERSION}+)`,
-    title: "Configure Java Runtime",
+    title: "Configure Language Server Runtime",
   });
 
   if (!selected || selected.kind === vscode.QuickPickItemKind.Separator) {
@@ -70,7 +115,7 @@ export async function configureJava(
 
   // Handle browse action
   if (selected.action === "browse") {
-    return await browseAndSetJavaHome();
+    return await browseAndSetLspJavaHome();
   }
 
   // Handle JDK selection
@@ -79,16 +124,70 @@ export async function configureJava(
     return false;
   }
 
-  return await setJavaHomeAndRestart(jdk.path, jdk.version);
+  return await setLspJavaHomeAndRestart(jdk.path, jdk.version);
 }
 
 /**
- * Opens a folder browser for manual JDK selection.
+ * Configures the Project Build JDK.
+ * Shows all detected JDKs without LSP filtering - any JDK version can be used
+ * for project builds. Sets groovy.project.javaHome in workspace settings.
+ *
+ * @param minimumVersion Optional minimum version required by the project
+ * @returns true if a JDK was selected and configured, false otherwise
+ */
+async function configureProjectJava(minimumVersion?: number): Promise<boolean> {
+  const jdks = await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: "Detecting JDKs...",
+    },
+    () => findAllJdks(),
+  );
+
+  const items = buildProjectJdkItems(jdks, minimumVersion);
+
+  const selected = await vscode.window.showQuickPick(items, {
+    title: "Select Project Build JDK",
+    placeHolder: minimumVersion
+      ? `Project requires at least Java ${minimumVersion}`
+      : "Select JDK for Maven/Gradle execution",
+  });
+
+  if (!selected || selected.kind === vscode.QuickPickItemKind.Separator) {
+    return false;
+  }
+
+  // Handle browse action
+  if (selected.action === "browse") {
+    return await browseAndSetProjectJavaHome();
+  }
+
+  // Handle JDK selection
+  const jdk = selected.jdk;
+  if (!jdk) {
+    return false;
+  }
+
+  const config = vscode.workspace.getConfiguration("groovy");
+  await config.update(
+    "project.javaHome",
+    jdk.path,
+    vscode.ConfigurationTarget.Workspace,
+  );
+
+  vscode.window.showInformationMessage(
+    `Project build JDK set to Java ${jdk.version}. Tests will use this JDK.`,
+  );
+  return true;
+}
+
+/**
+ * Opens a folder browser for manual LSP JDK selection.
  * Validates the selected path is a valid JDK and warns if below minimum version.
  *
  * @returns true if a valid JDK was selected and configured, false otherwise
  */
-async function browseAndSetJavaHome(): Promise<boolean> {
+async function browseAndSetLspJavaHome(): Promise<boolean> {
   const { getRuntime } = await import("jdk-utils");
 
   const selected = await vscode.window.showOpenDialog({
@@ -96,7 +195,7 @@ async function browseAndSetJavaHome(): Promise<boolean> {
     canSelectFolders: true,
     canSelectMany: false,
     openLabel: "Select JDK",
-    title: "Select Java Home Directory",
+    title: "Select Language Server Java Home",
   });
 
   if (!selected || selected.length === 0) {
@@ -127,7 +226,10 @@ async function browseAndSetJavaHome(): Promise<boolean> {
       }
     }
 
-    return await setJavaHomeAndRestart(runtime.homedir, runtime.version.major);
+    return await setLspJavaHomeAndRestart(
+      runtime.homedir,
+      runtime.version.major,
+    );
   } catch (error) {
     vscode.window.showErrorMessage(
       `Failed to validate JDK at ${jdkPath}: ${error instanceof Error ? error.message : String(error)}`,
@@ -137,27 +239,79 @@ async function browseAndSetJavaHome(): Promise<boolean> {
 }
 
 /**
- * Sets the Java home in workspace settings and offers to restart the server.
- * Updates groovy.java.home in .vscode/settings.json (workspace scope).
+ * Opens a folder browser for manual Project Build JDK selection.
+ * Validates the selected path is a valid JDK (any version).
+ *
+ * @returns true if a valid JDK was selected and configured, false otherwise
+ */
+async function browseAndSetProjectJavaHome(): Promise<boolean> {
+  const { getRuntime } = await import("jdk-utils");
+
+  const selected = await vscode.window.showOpenDialog({
+    canSelectFiles: false,
+    canSelectFolders: true,
+    canSelectMany: false,
+    openLabel: "Select JDK",
+    title: "Select Project Build Java Home",
+  });
+
+  if (!selected || selected.length === 0) {
+    return false;
+  }
+
+  const jdkPath = selected[0].fsPath;
+
+  // Validate the selected path is a valid JDK
+  try {
+    const runtime = await getRuntime(jdkPath, { withVersion: true });
+    if (!runtime?.version?.major) {
+      vscode.window.showErrorMessage(
+        `The selected folder is not a valid JDK: ${jdkPath}`,
+      );
+      return false;
+    }
+
+    const config = vscode.workspace.getConfiguration("groovy");
+    await config.update(
+      "project.javaHome",
+      runtime.homedir,
+      vscode.ConfigurationTarget.Workspace,
+    );
+
+    vscode.window.showInformationMessage(
+      `Project build JDK set to Java ${runtime.version.major}. Tests will use this JDK.`,
+    );
+    return true;
+  } catch (error) {
+    vscode.window.showErrorMessage(
+      `Failed to validate JDK at ${jdkPath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Sets the LSP Java home in workspace settings and offers to restart the server.
+ * Updates groovy.languageServer.javaHome in .vscode/settings.json (workspace scope).
  *
  * @param jdkPath Absolute path to the JDK home directory
  * @param version Major Java version number
  * @returns true if settings were updated successfully
  */
-async function setJavaHomeAndRestart(
+async function setLspJavaHomeAndRestart(
   jdkPath: string,
   version: number,
 ): Promise<boolean> {
   const config = vscode.workspace.getConfiguration("groovy");
   await config.update(
-    "java.home",
+    "languageServer.javaHome",
     jdkPath,
     vscode.ConfigurationTarget.Workspace,
   );
 
   const restartAction = "Restart Server";
   const result = await vscode.window.showInformationMessage(
-    `Java home set to Java ${version} in workspace settings. Restart the server to apply.`,
+    `Language Server Java set to Java ${version} in workspace settings. Restart the server to apply.`,
     restartAction,
   );
 
@@ -330,6 +484,75 @@ function createJdkItem(
 }
 
 /**
+ * Builds QuickPick items for Project Build JDK selection.
+ * Groups JDKs into two sections: those meeting minimum version (if specified)
+ * and those below minimum. Shows all JDKs regardless of version since any
+ * JDK can be used for project builds (unlike LSP which requires Java 17+).
+ *
+ * @param jdks Array of detected JDKs
+ * @param minimumVersion Optional minimum version required by the project
+ * @returns Array of QuickPickItem including separators and browse option
+ */
+function buildProjectJdkItems(
+  jdks: JavaResolutionExtended[],
+  minimumVersion?: number,
+): QuickPickItem[] {
+  const items: QuickPickItem[] = [];
+
+  // Group JDKs: meets minimum vs below minimum
+  const meetsMinimum = minimumVersion
+    ? jdks.filter((j) => j.version >= minimumVersion)
+    : jdks;
+  const belowMinimum = minimumVersion
+    ? jdks.filter((j) => j.version < minimumVersion)
+    : [];
+
+  if (meetsMinimum.length > 0) {
+    if (minimumVersion) {
+      items.push({
+        label: `Meets Project Requirement (Java ${minimumVersion}+)`,
+        kind: vscode.QuickPickItemKind.Separator,
+      });
+    }
+    for (const jdk of meetsMinimum) {
+      items.push({
+        label: `$(coffee) Java ${jdk.version}`,
+        description: jdk.path,
+        detail: `From: ${jdk.sourceDescription}`,
+        jdk,
+      });
+    }
+  }
+
+  if (belowMinimum.length > 0) {
+    items.push({
+      label: `Below Project Minimum (Java < ${minimumVersion})`,
+      kind: vscode.QuickPickItemKind.Separator,
+    });
+    for (const jdk of belowMinimum) {
+      items.push({
+        label: `$(coffee) Java ${jdk.version} $(warning)`,
+        description: jdk.path,
+        detail: `From: ${jdk.sourceDescription} - Below project minimum`,
+        jdk,
+      });
+    }
+  }
+
+  // Browse option
+  if (items.length > 0) {
+    items.push({ label: "", kind: vscode.QuickPickItemKind.Separator });
+  }
+  items.push({
+    label: "$(folder) Browse...",
+    detail: "Select a JDK folder manually",
+    action: "browse",
+  });
+
+  return items;
+}
+
+/**
  * Command: groovy.addFoojayResolver
  *
  * Adds the foojay-resolver plugin to settings.gradle(.kts) to enable
@@ -485,7 +708,8 @@ export function registerJavaCommands(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       "groovy.configureJava",
-      (requiredVersion?: number) => configureJava(requiredVersion),
+      (requiredVersion?: number, purpose?: "lsp" | "project") =>
+        configureJava(requiredVersion, purpose),
     ),
   );
 

--- a/editors/code/client/src/java/validator.ts
+++ b/editors/code/client/src/java/validator.ts
@@ -83,9 +83,10 @@ export async function showJavaError(
   }
 
   // Configured path is invalid
-  const settingsJavaHome = workspace
-    .getConfiguration("groovy")
-    .get<string>("java.home");
+  const config = workspace.getConfiguration("groovy");
+  const settingsJavaHome =
+    config.get<string>("languageServer.javaHome") ||
+    config.get<string>("java.home");
   if (settingsJavaHome && result.error) {
     await showConfiguredPathError(settingsJavaHome, result.error);
     return;
@@ -108,7 +109,7 @@ async function showLoginShellMessage(
     "VS Code cannot access it directly without configuration.",
     "",
     'To fix this permanently, click "Use This Path" to set:',
-    `  groovy.java.home = "${resolution.path}"`,
+    `  groovy.languageServer.javaHome = "${resolution.path}"`,
   ].join("\n");
 
   const selection = await window.showWarningMessage(
@@ -121,9 +122,9 @@ async function showLoginShellMessage(
   if (selection === "Use This Path") {
     await workspace
       .getConfiguration("groovy")
-      .update("java.home", resolution.path, true);
+      .update("languageServer.javaHome", resolution.path, true);
     const reloadSelection = await window.showInformationMessage(
-      `groovy.java.home set to "${resolution.path}". Reload window to apply?`,
+      `groovy.languageServer.javaHome set to "${resolution.path}". Reload window to apply?`,
       "Reload Now",
       "Later",
     );
@@ -133,7 +134,7 @@ async function showLoginShellMessage(
   } else if (selection === "Open Settings") {
     commands.executeCommand(
       "workbench.action.openSettings",
-      "groovy.java.home",
+      "groovy.languageServer.javaHome",
     );
   }
 }
@@ -156,7 +157,7 @@ async function showVersionError(
     "Update your Java installation:",
     ...installHints,
     "",
-    `Or configure a different Java in Settings → groovy.java.home`,
+    `Or configure a different Java in Settings → groovy.languageServer.javaHome`,
   ].join("\n");
 
   const selection = await window.showErrorMessage(
@@ -170,7 +171,7 @@ async function showVersionError(
 }
 
 /**
- * Shows error when configured groovy.java.home path is invalid
+ * Shows error when configured groovy.languageServer.javaHome path is invalid
  */
 async function showConfiguredPathError(
   configuredPath: string,
@@ -179,7 +180,7 @@ async function showConfiguredPathError(
   const message = `The configured Java path is invalid`;
 
   const detail = [
-    `groovy.java.home is set to: ${configuredPath}`,
+    `groovy.languageServer.javaHome is set to: ${configuredPath}`,
     "",
     `Error: ${error}`,
     "",
@@ -211,7 +212,7 @@ async function showNotFoundError(platform: string): Promise<void> {
     "",
     "After installing, either:",
     "  • Restart VS Code, or",
-    "  • Set the path in Settings → groovy.java.home",
+    "  • Set the path in Settings → groovy.languageServer.javaHome",
   ].join("\n");
 
   const selection = await window.showErrorMessage(
@@ -259,7 +260,7 @@ function getInstallHints(platform: string): string[] {
 function getSourceHint(resolution: JavaResolution): string {
   switch (resolution.source) {
     case "setting":
-      return `Found via groovy.java.home setting: ${resolution.path}`;
+      return `Found via groovy.languageServer.javaHome setting: ${resolution.path}`;
     case "java_home":
       return `Found via JAVA_HOME: ${resolution.path}`;
     case "jdk_manager":
@@ -279,7 +280,7 @@ function handleErrorAction(selection: string | undefined): void {
   if (selection === "Open Settings") {
     commands.executeCommand(
       "workbench.action.openSettings",
-      "groovy.java.home",
+      "groovy.languageServer.javaHome",
     );
   } else if (selection === "Download Java") {
     commands.executeCommand("vscode.open", "https://adoptium.net/");

--- a/editors/code/client/src/ui/languageStatus.ts
+++ b/editors/code/client/src/ui/languageStatus.ts
@@ -182,7 +182,7 @@ export class LanguageStatusManager implements vscode.Disposable {
     this.javaRuntimeItem.command = {
       title: "Configure Java",
       command: "workbench.action.openSettings",
-      arguments: ["groovy.java.home"],
+      arguments: ["groovy.languageServer.javaHome"],
     };
   }
 
@@ -192,7 +192,7 @@ export class LanguageStatusManager implements vscode.Disposable {
   private getJavaSourceDetail(resolution: JavaResolution): string {
     switch (resolution.source) {
       case "setting":
-        return `From groovy.java.home: ${resolution.path}`;
+        return `From groovy.languageServer.javaHome: ${resolution.path}`;
       case "java_home":
         return `From JAVA_HOME: ${resolution.path}`;
       case "jdk_manager":

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -212,69 +212,191 @@
       {
         "language": "groovy",
         "scopes": {
-          "namespace": ["entity.name.namespace"],
-          "type": ["entity.name.type"],
-          "class": ["entity.name.type.class", "support.class"],
-          "enum": ["entity.name.type.enum"],
-          "interface": ["entity.name.type.interface"],
-          "struct": ["entity.name.type.struct"],
-          "typeParameter": ["entity.name.type.parameter"],
-          "parameter": ["variable.parameter"],
-          "variable": ["variable.other"],
-          "property": ["variable.other.property"],
-          "enumMember": ["variable.other.enummember"],
-          "function": ["entity.name.function"],
-          "method": ["entity.name.function.member"],
-          "macro": ["entity.name.tag.pipeline.jenkins"],
-          "keyword": ["keyword"],
-          "modifier": ["storage.modifier"],
-          "comment": ["comment"],
-          "string": ["string"],
-          "number": ["constant.numeric"],
-          "regexp": ["string.regexp"],
-          "operator": ["keyword.operator"],
-          "decorator": ["entity.name.function.decorator"],
-          "class.declaration": ["entity.name.type.class.declaration", "support.class", "entity.name.type"],
-          "*.declaration": ["entity.name.function.definition"],
-          "*.definition": ["entity.name.function.definition"],
-          "*.readonly": ["variable.other.constant"],
-          "*.static": ["entity.name.function.static"],
-          "*.deprecated": ["invalid.deprecated"],
-          "*.unnecessary": ["meta.unnecessary"]
+          "namespace": [
+            "entity.name.namespace"
+          ],
+          "type": [
+            "entity.name.type"
+          ],
+          "class": [
+            "entity.name.type.class",
+            "support.class"
+          ],
+          "enum": [
+            "entity.name.type.enum"
+          ],
+          "interface": [
+            "entity.name.type.interface"
+          ],
+          "struct": [
+            "entity.name.type.struct"
+          ],
+          "typeParameter": [
+            "entity.name.type.parameter"
+          ],
+          "parameter": [
+            "variable.parameter"
+          ],
+          "variable": [
+            "variable.other"
+          ],
+          "property": [
+            "variable.other.property"
+          ],
+          "enumMember": [
+            "variable.other.enummember"
+          ],
+          "function": [
+            "entity.name.function"
+          ],
+          "method": [
+            "entity.name.function.member"
+          ],
+          "macro": [
+            "entity.name.tag.pipeline.jenkins"
+          ],
+          "keyword": [
+            "keyword"
+          ],
+          "modifier": [
+            "storage.modifier"
+          ],
+          "comment": [
+            "comment"
+          ],
+          "string": [
+            "string"
+          ],
+          "number": [
+            "constant.numeric"
+          ],
+          "regexp": [
+            "string.regexp"
+          ],
+          "operator": [
+            "keyword.operator"
+          ],
+          "decorator": [
+            "entity.name.function.decorator"
+          ],
+          "class.declaration": [
+            "entity.name.type.class.declaration",
+            "support.class",
+            "entity.name.type"
+          ],
+          "*.declaration": [
+            "entity.name.function.definition"
+          ],
+          "*.definition": [
+            "entity.name.function.definition"
+          ],
+          "*.readonly": [
+            "variable.other.constant"
+          ],
+          "*.static": [
+            "entity.name.function.static"
+          ],
+          "*.deprecated": [
+            "invalid.deprecated"
+          ],
+          "*.unnecessary": [
+            "meta.unnecessary"
+          ]
         }
       },
       {
         "language": "jenkinsfile",
         "scopes": {
-          "namespace": ["entity.name.namespace"],
-          "type": ["entity.name.type"],
-          "class": ["entity.name.type.class", "support.class"],
-          "enum": ["entity.name.type.enum"],
-          "interface": ["entity.name.type.interface"],
-          "struct": ["entity.name.type.struct"],
-          "typeParameter": ["entity.name.type.parameter"],
-          "parameter": ["variable.parameter"],
-          "variable": ["variable.other"],
-          "property": ["variable.other.property"],
-          "enumMember": ["variable.other.enummember"],
-          "function": ["entity.name.function"],
-          "method": ["entity.name.function.member"],
-          "macro": ["entity.name.tag.pipeline.jenkins"],
-          "keyword": ["keyword"],
-          "modifier": ["storage.modifier"],
-          "comment": ["comment"],
-          "string": ["string"],
-          "number": ["constant.numeric"],
-          "regexp": ["string.regexp"],
-          "operator": ["keyword.operator"],
-          "decorator": ["entity.name.function.decorator"],
-          "class.declaration": ["entity.name.type.class.declaration", "support.class", "entity.name.type"],
-          "*.declaration": ["entity.name.function.definition"],
-          "*.definition": ["entity.name.function.definition"],
-          "*.readonly": ["variable.other.constant"],
-          "*.static": ["entity.name.function.static"],
-          "*.deprecated": ["invalid.deprecated"],
-          "*.unnecessary": ["meta.unnecessary"]
+          "namespace": [
+            "entity.name.namespace"
+          ],
+          "type": [
+            "entity.name.type"
+          ],
+          "class": [
+            "entity.name.type.class",
+            "support.class"
+          ],
+          "enum": [
+            "entity.name.type.enum"
+          ],
+          "interface": [
+            "entity.name.type.interface"
+          ],
+          "struct": [
+            "entity.name.type.struct"
+          ],
+          "typeParameter": [
+            "entity.name.type.parameter"
+          ],
+          "parameter": [
+            "variable.parameter"
+          ],
+          "variable": [
+            "variable.other"
+          ],
+          "property": [
+            "variable.other.property"
+          ],
+          "enumMember": [
+            "variable.other.enummember"
+          ],
+          "function": [
+            "entity.name.function"
+          ],
+          "method": [
+            "entity.name.function.member"
+          ],
+          "macro": [
+            "entity.name.tag.pipeline.jenkins"
+          ],
+          "keyword": [
+            "keyword"
+          ],
+          "modifier": [
+            "storage.modifier"
+          ],
+          "comment": [
+            "comment"
+          ],
+          "string": [
+            "string"
+          ],
+          "number": [
+            "constant.numeric"
+          ],
+          "regexp": [
+            "string.regexp"
+          ],
+          "operator": [
+            "keyword.operator"
+          ],
+          "decorator": [
+            "entity.name.function.decorator"
+          ],
+          "class.declaration": [
+            "entity.name.type.class.declaration",
+            "support.class",
+            "entity.name.type"
+          ],
+          "*.declaration": [
+            "entity.name.function.definition"
+          ],
+          "*.definition": [
+            "entity.name.function.definition"
+          ],
+          "*.readonly": [
+            "variable.other.constant"
+          ],
+          "*.static": [
+            "entity.name.function.static"
+          ],
+          "*.deprecated": [
+            "invalid.deprecated"
+          ],
+          "*.unnecessary": [
+            "meta.unnecessary"
+          ]
         }
       }
     ],
@@ -289,9 +411,19 @@
     "configuration": {
       "title": "Groovy Language Server",
       "properties": {
+        "groovy.languageServer.javaHome": {
+          "type": "string",
+          "description": "Path to Java home for running the Groovy Language Server (requires Java 17+). If not set, auto-detected."
+        },
         "groovy.java.home": {
           "type": "string",
-          "description": "Path to Java home (requires Java 17+)"
+          "deprecationMessage": "Use 'groovy.languageServer.javaHome' instead. This setting will be removed in a future version.",
+          "description": "DEPRECATED: Use groovy.languageServer.javaHome"
+        },
+        "groovy.project.javaHome": {
+          "type": "string",
+          "scope": "resource",
+          "description": "Path to Java home for project build/test execution (Maven, Gradle). If not set, uses system JAVA_HOME."
         },
         "groovy.jdk.suppressMismatchWarning": {
           "type": "boolean",


### PR DESCRIPTION
## Summary

- Rename `groovy.java.home` → `groovy.languageServer.javaHome` (with backward compat)
- Add `groovy.project.javaHome` for Maven/Gradle test execution
- Add purpose picker to `configureJava` command (LSP Runtime vs Project Build)
- Wire project JDK to test execution via JAVA_HOME injection

This allows users to use a different JDK version for building/testing their project than the one running the language server (which requires 17+).

## Motivation

Tests fail with `Unsupported class file major version 69` (Java 25) when:
- Project targets Java 8 (via `maven.compiler.source/target`)
- But system default Java is 25
- Groovy 3.0.18's ASM can't parse Java 25 class files

**Root cause:** No explicit project build JDK configuration; system default is too new.

## Resolution Priority

```
1. groovy.project.javaHome (explicit user selection)
   ↓ if not set
2. Process environment JAVA_HOME
   ↓ if not set
3. System default java on PATH
```

## Test plan

- [ ] Configure project JDK via command palette → "Configure Java Runtime" → "Project Build JDK"
- [ ] Verify tests use configured JDK (check JAVA_HOME in output)
- [ ] Verify backward compatibility: `groovy.java.home` still works for LSP
- [ ] Verify LSP starts correctly with `groovy.languageServer.javaHome`

## Related

- Closes #879 (deferred BSP `jvmBuildTarget.javaHome` integration noted in issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added groovy.languageServer.javaHome and groovy.project.javaHome settings.
  * Configure-Java flow now distinguishes Language Server vs Project Build JDK.

* **Bug Fixes / Behavior**
  * Test execution and project tasks honor the project JDK setting (JAVA_HOME/PATH).

* **Documentation**
  * README updated with "Java Settings Explained", example JSON, and migration guidance.

* **Deprecation**
  * groovy.java.home marked deprecated; migrate to groovy.languageServer.javaHome.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->