### PR TITLE
fix: correct hallucinated repository coordinates from GroovyLanguageServer to gvy

### DIFF
--- a/bsp/bsp-core/build.gradle.kts
+++ b/bsp/bsp-core/build.gradle.kts
@@ -46,7 +46,7 @@ publishing {
             pom {
                 name.set("BSP Core")
                 description.set(project.description)
-                url.set("https://github.com/GroovyLanguageServer/groovy-language-server")
+                url.set("https://github.com/albertocavalcante/gvy")
 
                 licenses {
                     license {
@@ -57,15 +57,15 @@ publishing {
 
                 developers {
                     developer {
-                        id.set("groovylsp")
-                        name.set("Groovy Language Server Contributors")
+                        id.set("albertocavalcante")
+                        name.set("Alberto Cavalcante")
                     }
                 }
 
                 scm {
-                    connection.set("scm:git:git://github.com/GroovyLanguageServer/groovy-language-server.git")
-                    developerConnection.set("scm:git:ssh://github.com/GroovyLanguageServer/groovy-language-server.git")
-                    url.set("https://github.com/GroovyLanguageServer/groovy-language-server")
+                    connection.set("scm:git:git://github.com/albertocavalcante/gvy.git")
+                    developerConnection.set("scm:git:ssh://github.com/albertocavalcante/gvy.git")
+                    url.set("https://github.com/albertocavalcante/gvy")
                 }
             }
         }

--- a/groovy-diagnostics/sarif/src/main/kotlin/com/github/albertocavalcante/diagnostics/sarif/SarifWriter.kt
+++ b/groovy-diagnostics/sarif/src/main/kotlin/com/github/albertocavalcante/diagnostics/sarif/SarifWriter.kt
@@ -17,7 +17,7 @@ import java.io.OutputStream
 class SarifWriter(
     private val toolName: String = "groovy-lsp",
     private val toolVersion: String? = null,
-    private val toolUri: String = "https://github.com/GroovyLanguageServer/groovy-language-server",
+    private val toolUri: String = "https://github.com/albertocavalcante/gvy",
 ) {
     private val results = mutableListOf<SarifResult>()
     private val rules = mutableMapOf<String, SarifRule>()

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/cli/CheckCommand.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/cli/CheckCommand.kt
@@ -168,7 +168,7 @@ class CheckCommand : CliktCommand(name = "check") {
         val writer = SarifWriter(
             toolName = "groovy-lsp",
             toolVersion = getVersion(),
-            toolUri = "https://github.com/GroovyLanguageServer/groovy-language-server",
+            toolUri = "https://github.com/albertocavalcante/gvy",
         )
 
         // Register known rules


### PR DESCRIPTION
## Summary
- Fixed bsp-core Maven publishing config URLs and developer info
- Fixed SARIF toolUri defaults in SarifWriter and CheckCommand
- All references to `GroovyLanguageServer/groovy-language-server` → `albertocavalcante/gvy`

## Files Changed
- `bsp/bsp-core/build.gradle.kts`
- `groovy-diagnostics/sarif/.../SarifWriter.kt`
- `groovy-lsp/.../cli/CheckCommand.kt`

## Test plan
- [x] Spotless checks pass (pre-commit hook)
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project metadata and repository references throughout the codebase.
  * Updated diagnostic tool identification metadata to reflect current project information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->