### PR TITLE
refactor: DRY repository URLs in publishing configs

### DIFF
--- a/bsp/bsp-core/build.gradle.kts
+++ b/bsp/bsp-core/build.gradle.kts
@@ -39,6 +39,9 @@ tasks.test {
 
 // Maven Central publishing configuration
 publishing {
+    val repoPath = "albertocavalcante/gvy"
+    val repoUrl = "https://github.com/$repoPath"
+
     publications {
         create<MavenPublication>("maven") {
             from(components["java"])
@@ -46,7 +49,7 @@ publishing {
             pom {
                 name.set("BSP Core")
                 description.set(project.description)
-                url.set("https://github.com/albertocavalcante/gvy")
+                url.set(repoUrl)
 
                 licenses {
                     license {
@@ -63,9 +66,9 @@ publishing {
                 }
 
                 scm {
-                    connection.set("scm:git:git://github.com/albertocavalcante/gvy.git")
-                    developerConnection.set("scm:git:ssh://github.com/albertocavalcante/gvy.git")
-                    url.set("https://github.com/albertocavalcante/gvy")
+                    connection.set("scm:git:git://github.com/$repoPath.git")
+                    developerConnection.set("scm:git:ssh://github.com/$repoPath.git")
+                    url.set(repoUrl)
                 }
             }
         }

--- a/bsp/maven-bsp/build.gradle.kts
+++ b/bsp/maven-bsp/build.gradle.kts
@@ -71,6 +71,9 @@ tasks.register<Jar>("fatJar") {
 
 // Maven Central publishing configuration
 publishing {
+    val repoPath = "albertocavalcante/gvy"
+    val repoUrl = "https://github.com/$repoPath"
+
     publications {
         create<MavenPublication>("maven") {
             from(components["java"])
@@ -78,7 +81,7 @@ publishing {
             pom {
                 name.set("Maven BSP Server")
                 description.set(project.description)
-                url.set("https://github.com/albertocavalcante/gvy")
+                url.set(repoUrl)
 
                 licenses {
                     license {
@@ -95,9 +98,9 @@ publishing {
                 }
 
                 scm {
-                    connection.set("scm:git:git://github.com/albertocavalcante/gvy.git")
-                    developerConnection.set("scm:git:ssh://github.com/albertocavalcante/gvy.git")
-                    url.set("https://github.com/albertocavalcante/gvy")
+                    connection.set("scm:git:git://github.com/$repoPath.git")
+                    developerConnection.set("scm:git:ssh://github.com/$repoPath.git")
+                    url.set(repoUrl)
                 }
             }
         }

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/cli/CheckCommand.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/cli/CheckCommand.kt
@@ -168,7 +168,6 @@ class CheckCommand : CliktCommand(name = "check") {
         val writer = SarifWriter(
             toolName = "groovy-lsp",
             toolVersion = getVersion(),
-            toolUri = "https://github.com/albertocavalcante/gvy",
         )
 
         // Register known rules

--- a/parser/core/build.gradle.kts
+++ b/parser/core/build.gradle.kts
@@ -54,6 +54,9 @@ java {
 
 // Publishing configuration for GitHub Packages
 publishing {
+    val repoPath = "albertocavalcante/gvy"
+    val repoUrl = "https://github.com/$repoPath"
+
     publications {
         create<MavenPublication>("maven") {
             artifactId = "groovyparser-core"
@@ -66,7 +69,7 @@ publishing {
                         "Provides a type-safe AST representation of Groovy code with visitor pattern, " +
                         "position tracking, and Jenkins CPS analysis support.",
                 )
-                url.set("https://github.com/albertocavalcante/gvy")
+                url.set(repoUrl)
 
                 licenses {
                     license {
@@ -83,9 +86,9 @@ publishing {
                 }
 
                 scm {
-                    connection.set("scm:git:git://github.com/albertocavalcante/gvy.git")
-                    developerConnection.set("scm:git:ssh://github.com/albertocavalcante/gvy.git")
-                    url.set("https://github.com/albertocavalcante/gvy")
+                    connection.set("scm:git:git://github.com/$repoPath.git")
+                    developerConnection.set("scm:git:ssh://github.com/$repoPath.git")
+                    url.set(repoUrl)
                 }
             }
         }
@@ -94,7 +97,7 @@ publishing {
     repositories {
         maven {
             name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/albertocavalcante/gvy")
+            url = uri("https://maven.pkg.github.com/$repoPath")
             credentials {
                 username = System.getenv("GITHUB_ACTOR") ?: project.findProperty("gpr.user") as String?
                 password = System.getenv("GITHUB_TOKEN") ?: project.findProperty("gpr.key") as String?


### PR DESCRIPTION
## Summary
Addresses review feedback from #911:

- **bsp-core, maven-bsp, parser/core**: Extract `repoPath`/`repoUrl` constants to avoid hardcoded URL repetition (DRY principle)
- **CheckCommand**: Remove redundant `toolUri` parameter since `SarifWriter` now has the correct default

## Files Changed
- `bsp/bsp-core/build.gradle.kts`
- `bsp/maven-bsp/build.gradle.kts`
- `parser/core/build.gradle.kts`
- `groovy-lsp/.../cli/CheckCommand.kt`

## Test plan
- [x] Spotless checks pass
- [ ] CI passes