### PR TITLE
feat(reports): create reports/coverage module and move JaCoCo parser

### DIFF
--- a/groovy-lsp/build.gradle.kts
+++ b/groovy-lsp/build.gradle.kts
@@ -123,7 +123,7 @@ dependencies {
     implementation(project(":parser:rewrite"))
     implementation(project(":semantics:core"))
     implementation(project(":semantics-native"))
-    implementation(project(":reports:api"))
+    implementation(project(":reports:coverage"))
 }
 
 // Avoid the older Groovy jars that Gradle's groovy plugin adds implicitly;

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/GroovyLanguageServer.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/GroovyLanguageServer.kt
@@ -16,7 +16,6 @@ import com.github.albertocavalcante.groovylsp.project.ProjectStrategyRegistry
 import com.github.albertocavalcante.groovylsp.providers.ast.AstParams
 import com.github.albertocavalcante.groovylsp.providers.ast.AstRequestHandler
 import com.github.albertocavalcante.groovylsp.providers.ast.AstResult
-import com.github.albertocavalcante.groovylsp.providers.coverage.CoverageResponse
 import com.github.albertocavalcante.groovylsp.providers.coverage.GetCoverageParams
 import com.github.albertocavalcante.groovylsp.providers.dependencies.DependenciesResult
 import com.github.albertocavalcante.groovylsp.providers.dependencies.DependencyRequestHandler
@@ -44,6 +43,7 @@ import com.github.albertocavalcante.groovytesting.registry.TestFrameworkRegistry
 import com.github.albertocavalcante.groovytesting.spock.SpockTestDetector
 import com.github.albertocavalcante.gvy.viz.converters.CoreAstConverter
 import com.github.albertocavalcante.gvy.viz.converters.NativeAstConverter
+import com.github.albertocavalcante.reports.coverage.model.CoverageResponse
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/coverage/GetCoverageParams.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/coverage/GetCoverageParams.kt
@@ -1,0 +1,8 @@
+package com.github.albertocavalcante.groovylsp.providers.coverage
+
+/**
+ * Parameters for the `groovy/getCoverage` LSP request.
+ *
+ * @property workspaceUri URI of the workspace root
+ */
+data class GetCoverageParams(val workspaceUri: String)

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/testing/TestRequestDelegate.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/testing/TestRequestDelegate.kt
@@ -4,10 +4,10 @@ import com.github.albertocavalcante.groovylsp.async.future
 import com.github.albertocavalcante.groovylsp.buildtool.BuildToolManager
 import com.github.albertocavalcante.groovylsp.buildtool.TestCommand
 import com.github.albertocavalcante.groovylsp.compilation.GroovyCompilationService
-import com.github.albertocavalcante.groovylsp.providers.coverage.CoverageResponse
 import com.github.albertocavalcante.groovylsp.providers.coverage.GetCoverageParams
-import com.github.albertocavalcante.groovylsp.providers.coverage.parsers.JacocoXmlParser
 import com.github.albertocavalcante.groovylsp.providers.testing.parsers.SurefireXmlParser
+import com.github.albertocavalcante.reports.coverage.model.CoverageResponse
+import com.github.albertocavalcante.reports.coverage.parsers.JacocoParser
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -175,7 +175,7 @@ class TestRequestDelegate(
         return coroutineScope.future {
             withContext(ioDispatcher) {
                 val workspaceRoot = resolveWorkspaceRoot(params.workspaceUri)
-                JacocoXmlParser.parseWorkspace(workspaceRoot)
+                JacocoParser.parseWorkspace(workspaceRoot)
             }
         }
     }

--- a/reports/coverage/build.gradle.kts
+++ b/reports/coverage/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    kotlin("jvm")
+}
+
+base {
+    archivesName.set("reports-coverage")
+}
+
+dependencies {
+    // Internal dependencies
+    api(project(":reports:api"))
+
+    // Logging
+    implementation(libs.kotlin.logging)
+    implementation(libs.slf4j.api)
+
+    // Testing
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.mockk)
+    testRuntimeOnly(libs.junit.platform.launcher)
+
+    detektPlugins(libs.detekt.formatting)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/reports/coverage/src/main/kotlin/com/github/albertocavalcante/reports/coverage/model/CoverageModel.kt
+++ b/reports/coverage/src/main/kotlin/com/github/albertocavalcante/reports/coverage/model/CoverageModel.kt
@@ -1,11 +1,4 @@
-package com.github.albertocavalcante.groovylsp.providers.coverage
-
-/**
- * Parameters for the `groovy/getCoverage` LSP request.
- *
- * @property workspaceUri URI of the workspace root
- */
-data class GetCoverageParams(val workspaceUri: String)
+package com.github.albertocavalcante.reports.coverage.model
 
 /**
  * Branch coverage information for a line.

--- a/reports/coverage/src/main/kotlin/com/github/albertocavalcante/reports/coverage/parsers/CoverageParser.kt
+++ b/reports/coverage/src/main/kotlin/com/github/albertocavalcante/reports/coverage/parsers/CoverageParser.kt
@@ -1,0 +1,29 @@
+package com.github.albertocavalcante.reports.coverage.parsers
+
+import com.github.albertocavalcante.reports.coverage.model.CoverageResponse
+import com.github.albertocavalcante.reports.coverage.model.FileCoverageData
+import java.io.File
+
+/**
+ * Interface for parsing coverage reports.
+ *
+ * Implementations should support specific coverage report formats (JaCoCo, Cobertura, LCOV, etc.).
+ */
+interface CoverageParser {
+    /**
+     * Parse all coverage reports in a workspace.
+     *
+     * @param workspaceRoot Root directory of the workspace
+     * @return Aggregated coverage data from all found reports
+     */
+    fun parseWorkspace(workspaceRoot: File): CoverageResponse
+
+    /**
+     * Parse a single coverage report file.
+     *
+     * @param file The coverage report file
+     * @param workspaceRoot Workspace root for resolving file URIs
+     * @return List of file coverage data from the report
+     */
+    fun parseReportFile(file: File, workspaceRoot: File): List<FileCoverageData>
+}

--- a/reports/coverage/src/main/kotlin/com/github/albertocavalcante/reports/coverage/parsers/JacocoParser.kt
+++ b/reports/coverage/src/main/kotlin/com/github/albertocavalcante/reports/coverage/parsers/JacocoParser.kt
@@ -1,11 +1,11 @@
-package com.github.albertocavalcante.groovylsp.providers.coverage.parsers
+package com.github.albertocavalcante.reports.coverage.parsers
 
-import com.github.albertocavalcante.groovylsp.providers.coverage.BranchInfo
-import com.github.albertocavalcante.groovylsp.providers.coverage.CoverageResponse
-import com.github.albertocavalcante.groovylsp.providers.coverage.CoverageSummary
-import com.github.albertocavalcante.groovylsp.providers.coverage.FileCoverageData
-import com.github.albertocavalcante.groovylsp.providers.coverage.FileCoverageSummary
-import com.github.albertocavalcante.groovylsp.providers.coverage.LineCoverage
+import com.github.albertocavalcante.reports.coverage.model.BranchInfo
+import com.github.albertocavalcante.reports.coverage.model.CoverageResponse
+import com.github.albertocavalcante.reports.coverage.model.CoverageSummary
+import com.github.albertocavalcante.reports.coverage.model.FileCoverageData
+import com.github.albertocavalcante.reports.coverage.model.FileCoverageSummary
+import com.github.albertocavalcante.reports.coverage.model.LineCoverage
 import com.github.albertocavalcante.reports.discovery.ProjectDiscovery
 import com.github.albertocavalcante.reports.xml.XmlUtils
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -31,7 +31,7 @@ import java.net.URI
  * ```
  */
 @Suppress("TooManyFunctions") // Cohesive coverage parsing
-object JacocoXmlParser {
+object JacocoParser : CoverageParser {
     private val logger = KotlinLogging.logger {}
 
     /**
@@ -52,7 +52,7 @@ object JacocoXmlParser {
      * @param workspaceRoot Root directory of the workspace
      * @return Aggregated coverage data from all found reports
      */
-    fun parseWorkspace(workspaceRoot: File): CoverageResponse {
+    override fun parseWorkspace(workspaceRoot: File): CoverageResponse {
         val reportFiles = discoverJacocoReports(workspaceRoot)
         logger.info { "Found ${reportFiles.size} JaCoCo report files" }
 
@@ -132,7 +132,7 @@ object JacocoXmlParser {
      * @param file The JaCoCo XML report file
      * @param workspaceRoot Workspace root for resolving file URIs
      */
-    fun parseReportFile(file: File, workspaceRoot: File): List<FileCoverageData> {
+    override fun parseReportFile(file: File, workspaceRoot: File): List<FileCoverageData> {
         val dBuilder = XmlUtils.createSecureDocumentBuilder()
         val doc = dBuilder.parse(file)
         doc.documentElement.normalize()

--- a/reports/coverage/src/test/kotlin/com/github/albertocavalcante/reports/coverage/parsers/JacocoParserTest.kt
+++ b/reports/coverage/src/test/kotlin/com/github/albertocavalcante/reports/coverage/parsers/JacocoParserTest.kt
@@ -1,5 +1,7 @@
-package com.github.albertocavalcante.groovylsp.providers.coverage.parsers
+package com.github.albertocavalcante.reports.coverage.parsers
 
+import com.github.albertocavalcante.reports.coverage.model.CoverageResponse
+import com.github.albertocavalcante.reports.coverage.model.CoverageSummary
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -9,7 +11,7 @@ import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import java.nio.file.Path
 
-class JacocoXmlParserTest {
+class JacocoParserTest {
 
     @Test
     fun `should parse valid JaCoCo XML report`() {
@@ -19,7 +21,7 @@ class JacocoXmlParserTest {
         )
         val workspaceRoot = xmlFile.parentFile.parentFile.parentFile // resources dir parent
 
-        val results = JacocoXmlParser.parseReportFile(xmlFile, workspaceRoot)
+        val results = JacocoParser.parseReportFile(xmlFile, workspaceRoot)
 
         assertEquals(3, results.size)
 
@@ -74,10 +76,10 @@ class JacocoXmlParserTest {
         )
         val workspaceRoot = xmlFile.parentFile.parentFile.parentFile
 
-        val response = JacocoXmlParser.parseReportFile(xmlFile, workspaceRoot)
-        val coverage = com.github.albertocavalcante.groovylsp.providers.coverage.CoverageResponse(
+        val response = JacocoParser.parseReportFile(xmlFile, workspaceRoot)
+        val coverage = CoverageResponse(
             files = response,
-            summary = com.github.albertocavalcante.groovylsp.providers.coverage.CoverageSummary(
+            summary = CoverageSummary(
                 lineCoveragePercent = 0.0,
                 branchCoveragePercent = 0.0,
                 linesCovered = response.sumOf { it.summary.linesCovered },
@@ -98,7 +100,7 @@ class JacocoXmlParserTest {
 
     @Test
     fun `should handle empty JaCoCo report`(@TempDir tempDir: Path) {
-        val response = JacocoXmlParser.parseWorkspace(tempDir.toFile())
+        val response = JacocoParser.parseWorkspace(tempDir.toFile())
 
         assertEquals(0, response.files.size)
         assertEquals(0.0, response.summary.lineCoveragePercent)
@@ -123,7 +125,7 @@ class JacocoXmlParserTest {
         File(gradleDir, "jacocoTestReport.xml").writeText(testXmlContent)
         File(mavenDir, "jacoco.xml").writeText(testXmlContent)
 
-        val response = JacocoXmlParser.parseWorkspace(tempDir.toFile())
+        val response = JacocoParser.parseWorkspace(tempDir.toFile())
 
         // Should find and merge coverage from both locations
         assertEquals(3, response.files.size)
@@ -152,7 +154,7 @@ class JacocoXmlParserTest {
             ?.readText() ?: error("Test resource not found")
         File(jacocoDir, "jacoco.xml").writeText(testXmlContent)
 
-        val response = JacocoXmlParser.parseWorkspace(tempDir.toFile())
+        val response = JacocoParser.parseWorkspace(tempDir.toFile())
 
         assertEquals(3, response.files.size)
     }
@@ -173,7 +175,7 @@ class JacocoXmlParserTest {
             ?.readText() ?: error("Test resource not found")
         File(jacocoDir, "jacocoTestReport.xml").writeText(testXmlContent)
 
-        val response = JacocoXmlParser.parseWorkspace(tempDir.toFile())
+        val response = JacocoParser.parseWorkspace(tempDir.toFile())
 
         assertEquals(3, response.files.size)
     }
@@ -187,7 +189,7 @@ class JacocoXmlParserTest {
         File(jacocoDir, "jacoco.xml").writeText("<invalid>xml")
 
         // Should not throw, just log warning and continue
-        val response = JacocoXmlParser.parseWorkspace(tempDir.toFile())
+        val response = JacocoParser.parseWorkspace(tempDir.toFile())
 
         assertEquals(0, response.files.size)
     }
@@ -245,7 +247,7 @@ class JacocoXmlParserTest {
         File(dir1, "jacoco.xml").writeText(xml1)
         File(dir2, "jacoco.xml").writeText(xml2)
 
-        val response = JacocoXmlParser.parseWorkspace(tempDir.toFile())
+        val response = JacocoParser.parseWorkspace(tempDir.toFile())
 
         // Should have one file with merged coverage
         assertEquals(1, response.files.size)
@@ -271,7 +273,7 @@ class JacocoXmlParserTest {
             ?.readText() ?: error("Test resource not found")
         File(jacocoDir, "jacoco.xml").writeText(testXmlContent)
 
-        val response = JacocoXmlParser.parseWorkspace(tempDir.toFile())
+        val response = JacocoParser.parseWorkspace(tempDir.toFile())
 
         // 6 covered out of 7 total lines = 85.71%
         assertEquals(85.71, response.summary.lineCoveragePercent, 0.01)
@@ -297,7 +299,7 @@ class JacocoXmlParserTest {
 
         File(jacocoDir, "jacoco.xml").writeText(xmlContent)
 
-        val response = JacocoXmlParser.parseWorkspace(tempDir.toFile())
+        val response = JacocoParser.parseWorkspace(tempDir.toFile())
 
         // Should skip files with no lines
         assertEquals(0, response.files.size)
@@ -326,7 +328,7 @@ class JacocoXmlParserTest {
 
         File(jacocoDir, "jacoco.xml").writeText(xmlContent)
 
-        val response = JacocoXmlParser.parseWorkspace(tempDir.toFile())
+        val response = JacocoParser.parseWorkspace(tempDir.toFile())
 
         assertEquals(1, response.files.size)
         val file = response.files[0]

--- a/reports/coverage/src/test/resources/jacoco/jacoco.xml
+++ b/reports/coverage/src/test/resources/jacoco/jacoco.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report name="test-project">
+  <sessioninfo id="session1" start="1234567890" dump="1234567999"/>
+  <package name="com/example">
+    <sourcefile name="MyClass.groovy">
+      <line nr="10" mi="0" ci="3" mb="0" cb="0"/>
+      <line nr="11" mi="5" ci="0" mb="0" cb="0"/>
+      <line nr="12" mi="0" ci="2" mb="2" cb="1"/>
+      <line nr="13" mi="0" ci="1" mb="0" cb="2"/>
+    </sourcefile>
+    <sourcefile name="AnotherClass.groovy">
+      <line nr="5" mi="0" ci="10" mb="0" cb="0"/>
+      <line nr="6" mi="0" ci="5" mb="0" cb="0"/>
+    </sourcefile>
+  </package>
+  <package name="com/example/sub">
+    <sourcefile name="SubClass.groovy">
+      <line nr="1" mi="0" ci="1" mb="0" cb="0"/>
+    </sourcefile>
+  </package>
+</report>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -68,3 +68,5 @@ project(":bsp:maven-bsp").projectDir = file("bsp/maven-bsp")
 // Reports modules - shared utilities for report parsing
 include("reports:api")
 project(":reports:api").projectDir = file("reports/api")
+include("reports:coverage")
+project(":reports:coverage").projectDir = file("reports/coverage")


### PR DESCRIPTION
## Summary
- Create `reports/coverage` submodule
- Move coverage DTOs to `reports/coverage/model/`
- Move JacocoXmlParser to `reports/coverage/parsers/`
- Add CoverageParser interface for extensibility
- Update groovy-lsp to depend on reports/coverage

## Motivation
Consolidates coverage-related code into dedicated module. Prepares for adding Cobertura/LCOV parsers.

## Changes

### Module Structure
Created `reports/coverage` submodule with standard Gradle/Kotlin layout:
```
reports/coverage/
├── build.gradle.kts
└── src/main/kotlin/com/github/albertocavalcante/reports/coverage/
    ├── model/
    │   └── CoverageModel.kt
    └── parsers/
        ├── CoverageParser.kt
        └── JacocoParser.kt
```

### Coverage Model
Moved coverage DTOs from `groovy-lsp/.../CoverageDtos.kt` to `reports/coverage/model/CoverageModel.kt`:
- `BranchInfo` - Branch coverage information
- `LineCoverage` - Line coverage information
- `FileCoverageSummary` - Coverage summary for a single file
- `FileCoverageData` - Coverage data for a single file
- `CoverageSummary` - Overall coverage summary
- `CoverageResponse` - Response for the getCoverage LSP request

Kept `GetCoverageParams` in groovy-lsp since it's LSP-specific.

### Parser Abstraction
Created `CoverageParser` interface to support multiple coverage formats:
```kotlin
interface CoverageParser {
    fun parseWorkspace(workspaceRoot: File): CoverageResponse
    fun parseReportFile(file: File, workspaceRoot: File): List<FileCoverageData>
}
```

Renamed `JacocoXmlParser` to `JacocoParser` and implemented the `CoverageParser` interface.

### Dependencies
- Updated groovy-lsp to depend on `reports:coverage` instead of `reports:api`
- groovy-lsp now transitively includes `reports:api` through `reports:coverage`
- `reports:coverage` depends on `reports:api` for shared utilities (`ProjectDiscovery`, `XmlUtils`)

### Tests
- Moved `JacocoXmlParserTest` to `reports/coverage` as `JacocoParserTest`
- Updated test imports and package references
- Copied test resources (jacoco.xml)
- All tests pass ✅

## Test plan
- [x] `./gradlew :reports:coverage:build` passes
- [x] `./gradlew :reports:coverage:test` passes (11/11 tests)
- [x] `./gradlew :groovy-lsp:test` passes
- [x] Existing coverage functionality works unchanged

## Related
Follows the same pattern established in PRs #935 and #937 for reports/api module.

Prepares for future PRs to add:
- Cobertura parser
- LCOV parser