### PR TITLE
fix(semantics): implement cache eviction for ReflectionAccess caches

### DIFF
--- a/semantics/core/src/main/kotlin/com/github/albertocavalcante/gvy/semantics/calculator/ReflectionAccess.kt
+++ b/semantics/core/src/main/kotlin/com/github/albertocavalcante/gvy/semantics/calculator/ReflectionAccess.kt
@@ -31,10 +31,19 @@ internal object ReflectionAccess {
 
     fun invokeNoArg(target: Any, methodName: String): Any? = runCatching {
         // A 'get' on an access-ordered LinkedHashMap is a write operation, so we need a write lock.
-        // We check for the key and return if present, all within a brief write lock.
+        // Check if key exists in cache first to handle cached null values correctly.
         val key = target::class.java to methodName
-        methodCacheLock.write {
-            methodCache[key]?.let { return@runCatching it.invoke(target) }
+        val cachedMethod = methodCacheLock.write {
+            if (methodCache.containsKey(key)) {
+                methodCache[key]
+            } else {
+                null
+            }
+        }
+
+        // If key was in cache (even if value is null), use the cached value
+        if (methodCache.containsKey(key)) {
+            return@runCatching cachedMethod?.invoke(target)
         }
 
         // If not in cache, compute the result outside of any lock
@@ -43,19 +52,28 @@ internal object ReflectionAccess {
         // After computing, acquire the write lock again to put the result into the cache.
         // Use getOrPut to handle the race condition where another thread might have
         // computed and inserted the same key while we were working.
-        val cachedMethod = methodCacheLock.write {
+        val finalMethod = methodCacheLock.write {
             methodCache.getOrPut(key) { method }
         }
 
-        cachedMethod?.invoke(target)
+        finalMethod?.invoke(target)
     }.getOrNull()
 
     fun getField(target: Any, fieldName: String): Any? = runCatching {
         // A 'get' on an access-ordered LinkedHashMap is a write operation, so we need a write lock.
-        // We check for the key and return if present, all within a brief write lock.
+        // Check if key exists in cache first to handle cached null values correctly.
         val key = target::class.java to fieldName
-        fieldCacheLock.write {
-            fieldCache[key]?.let { return@runCatching it.get(target) }
+        val cachedField = fieldCacheLock.write {
+            if (fieldCache.containsKey(key)) {
+                fieldCache[key]
+            } else {
+                null
+            }
+        }
+
+        // If key was in cache (even if value is null), use the cached value
+        if (fieldCache.containsKey(key)) {
+            return@runCatching cachedField?.get(target)
         }
 
         // If not in cache, compute the result outside of any lock
@@ -68,11 +86,11 @@ internal object ReflectionAccess {
         // After computing, acquire the write lock again to put the result into the cache.
         // Use getOrPut to handle the race condition where another thread might have
         // computed and inserted the same key while we were working.
-        val cachedField = fieldCacheLock.write {
+        val finalField = fieldCacheLock.write {
             fieldCache.getOrPut(key) { field }
         }
 
-        cachedField?.get(target)
+        finalField?.get(target)
     }.getOrNull()
 
     fun getProperty(target: Any, propertyName: String): Any? {

--- a/semantics/core/src/test/kotlin/com/github/albertocavalcante/gvy/semantics/calculator/ReflectionAccessTest.kt
+++ b/semantics/core/src/test/kotlin/com/github/albertocavalcante/gvy/semantics/calculator/ReflectionAccessTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import kotlin.concurrent.write
 
 class ReflectionAccessTest {
 
@@ -96,6 +97,18 @@ class ReflectionAccessTest {
         return field.get(ReflectionAccess) as MutableMap<*, *>
     }
 
+    private fun getMethodCacheLock(): java.util.concurrent.locks.ReentrantReadWriteLock {
+        val field = ReflectionAccess::class.java.getDeclaredField("methodCacheLock")
+        field.isAccessible = true
+        return field.get(ReflectionAccess) as java.util.concurrent.locks.ReentrantReadWriteLock
+    }
+
+    private fun getFieldCacheLock(): java.util.concurrent.locks.ReentrantReadWriteLock {
+        val field = ReflectionAccess::class.java.getDeclaredField("fieldCacheLock")
+        field.isAccessible = true
+        return field.get(ReflectionAccess) as java.util.concurrent.locks.ReentrantReadWriteLock
+    }
+
     private fun readPrivateIntConstant(clazz: Class<*>, fieldName: String): Int {
         val field = clazz.getDeclaredField(fieldName)
         field.isAccessible = true
@@ -105,8 +118,8 @@ class ReflectionAccessTest {
     @AfterEach
     fun clearCaches() {
         // Clear the caches after each test to avoid interference
-        getMethodCache().clear()
-        getFieldCache().clear()
+        getMethodCacheLock().write { getMethodCache().clear() }
+        getFieldCacheLock().write { getFieldCache().clear() }
     }
 
     @Test
@@ -115,7 +128,7 @@ class ReflectionAccessTest {
         val cache = getMethodCache()
 
         // Clear cache first
-        cache.clear()
+        getMethodCacheLock().write { cache.clear() }
 
         // Create test objects with unique classes to populate the cache
         // We'll create (maxSize + 100) unique method lookups
@@ -132,7 +145,7 @@ class ReflectionAccessTest {
         }
 
         // Cache size should not exceed max size
-        val finalSize = cache.size
+        val finalSize = getMethodCacheLock().write { cache.size }
         assertTrue(
             finalSize <= maxSize,
             "Method cache size $finalSize should not exceed MAX_METHOD_CACHE_SIZE $maxSize",
@@ -145,7 +158,7 @@ class ReflectionAccessTest {
         val cache = getFieldCache()
 
         // Clear cache first
-        cache.clear()
+        getFieldCacheLock().write { cache.clear() }
 
         // Create test objects with unique classes to populate the cache
         // We'll create (maxSize + 100) unique field lookups
@@ -163,7 +176,7 @@ class ReflectionAccessTest {
         }
 
         // Cache size should not exceed max size
-        val finalSize = cache.size
+        val finalSize = getFieldCacheLock().write { cache.size }
         assertTrue(
             finalSize <= maxSize,
             "Field cache size $finalSize should not exceed MAX_FIELD_CACHE_SIZE $maxSize",
@@ -176,7 +189,7 @@ class ReflectionAccessTest {
         val cache = getMethodCache()
 
         // Clear cache first
-        cache.clear()
+        getMethodCacheLock().write { cache.clear() }
 
         // Create a reusable test class for hot entries
         class HotClass {
@@ -225,15 +238,15 @@ class ReflectionAccessTest {
         }
 
         // Check that recently accessed hot entries are still in cache
-        val keysInCache = cache.keys.map { it.toString() }
+        val keysInCache = getMethodCacheLock().write { cache.keys.toSet() }
         val retainedCount = hotMethods.count { methodName ->
-            keysInCache.any { key -> key.contains(methodName) }
+            (hotObject::class.java to methodName) in keysInCache
         }
 
-        // At least some of the hot entries should still be in cache
+        // All hot entries should be retained in LRU cache (deterministic in single-threaded test)
         assertTrue(
-            retainedCount >= 2,
-            "Recently accessed hot entries should be retained in LRU cache, but found $retainedCount out of 3 retained",
+            retainedCount == hotMethods.size,
+            "All recently accessed hot entries should be retained in LRU cache, but found $retainedCount out of ${hotMethods.size} retained",
         )
     }
 
@@ -243,7 +256,7 @@ class ReflectionAccessTest {
         val cache = getFieldCache()
 
         // Clear cache first
-        cache.clear()
+        getFieldCacheLock().write { cache.clear() }
 
         // Create a reusable test class for hot entries
         class HotFieldClass {
@@ -299,15 +312,15 @@ class ReflectionAccessTest {
         }
 
         // Check that recently accessed hot entries are still in cache
-        val keysInCache = cache.keys.map { it.toString() }
+        val keysInCache = getFieldCacheLock().write { cache.keys.toSet() }
         val retainedCount = hotFields.count { fieldName ->
-            keysInCache.any { key -> key.contains(fieldName) }
+            (hotObject::class.java to fieldName) in keysInCache
         }
 
-        // At least some of the hot entries should still be in cache
+        // All hot entries should be retained in LRU cache (deterministic in single-threaded test)
         assertTrue(
-            retainedCount >= 2,
-            "Recently accessed hot entries should be retained in LRU cache, but found $retainedCount out of 3 retained",
+            retainedCount == hotFields.size,
+            "All recently accessed hot entries should be retained in LRU cache, but found $retainedCount out of ${hotFields.size} retained",
         )
     }
 }


### PR DESCRIPTION
## Summary
- Replaced ConcurrentHashMap with LRU LinkedHashMap (max 1000 entries per cache)
- Added ReentrantReadWriteLock for thread-safe cache access
- Prevents unbounded memory growth in long-running LSP sessions
- Added comprehensive tests for cache eviction and LRU behavior

## Context
Implements cache eviction for `methodCache` and `fieldCache` in `ReflectionAccess.kt` to prevent memory leaks in long-running Language Server Process instances, especially when classes are dynamically loaded or there are many unique class/method combinations.

Follows the LRU eviction pattern established in PRs #932 and #933.

## Test plan
- Existing tests pass
- New tests verify cache eviction when exceeding max size (1000 entries)
- New tests verify LRU behavior - recently accessed entries are retained
- Thread-safe cache access with write locks for access-ordered LinkedHashMap

Closes #921