### PR TITLE
refactor(lsp): extract removeFromSetMap helper in DependencyGraph

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/compilation/DependencyGraph.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/compilation/DependencyGraph.kt
@@ -30,13 +30,13 @@ class DependencyGraph {
          *
          * This helper maintains map hygiene by removing empty sets, which is important
          * for both memory efficiency and correct behavior of methods like hasInfo().
+         *
+         * Uses computeIfPresent for atomic updates on ConcurrentHashMap.
          */
         private fun <K, V> removeFromSetMap(map: MutableMap<K, MutableSet<V>>, key: K, value: V) {
-            map[key]?.let { set ->
+            map.computeIfPresent(key) { _, set ->
                 set.remove(value)
-                if (set.isEmpty()) {
-                    map.remove(key)
-                }
+                set.ifEmpty { null }
             }
         }
     }


### PR DESCRIPTION
## Summary

Extract duplicated bidirectional map cleanup logic into a reusable helper method in `DependencyGraph.kt`.

The pattern that was duplicated:
```kotlin
map[key]?.remove(value)
if (map[key]?.isEmpty() == true) {
    map.remove(key)
}
```

Was appearing in 3 places:
- `removeFile()` for cleaning dependents map
- `removeFile()` for cleaning dependencies map  
- `setDependencies()` for cleaning old dependents

The new `removeFromSetMap()` helper:
- Maintains map hygiene by removing empty sets
- Important for memory efficiency
- Ensures correct behavior of `hasInfo()` method

## Test plan

- [x] All `DependencyGraphTest` tests pass (12 tests)
- [x] Compilation passes with no warnings
- [x] Pre-commit hooks pass