### PR TITLE
fix(vscode): use actual class line for test suite gutter icon position

### DIFF
--- a/editors/code/client/src/features/testing/GroovyTestController.ts
+++ b/editors/code/client/src/features/testing/GroovyTestController.ts
@@ -322,30 +322,20 @@ export class GroovyTestController {
     // Store metadata
     dataCache.set(suiteItem, { kind: "suite", suiteName: suite.suite });
 
-    // Add child test items first to determine suite range
-    let minLine = Number.MAX_SAFE_INTEGER;
+    // Add child test items
     for (const test of suite.tests) {
       const testItem = this.createTestItem(test, suite.suite, uri);
       suiteItem.children.add(testItem);
-      if (test.line < minLine) {
-        minLine = test.line;
-      }
     }
 
-    // Set suite range: estimate class declaration is a few lines before first test
-    // Use line 0 as minimum to avoid negative values
-    const ESTIMATED_LINES_ABOVE_FIRST_TEST = 5;
+    // Set suite range using the actual class line from the LSP
+    // suite.line is 1-indexed, VS Code positions are 0-indexed
+    const classLine = suite.line >= 1 ? suite.line - 1 : 0;
     const APPROXIMATE_LINE_LENGTH = 100;
-    if (minLine !== Number.MAX_SAFE_INTEGER && minLine >= 0) {
-      const estimatedClassLine = Math.max(
-        0,
-        minLine - ESTIMATED_LINES_ABOVE_FIRST_TEST,
-      );
-      suiteItem.range = new vscode.Range(
-        new vscode.Position(estimatedClassLine, 0),
-        new vscode.Position(estimatedClassLine, APPROXIMATE_LINE_LENGTH),
-      );
-    }
+    suiteItem.range = new vscode.Range(
+      new vscode.Position(classLine, 0),
+      new vscode.Position(classLine, APPROXIMATE_LINE_LENGTH),
+    );
 
     return suiteItem;
   }

--- a/editors/code/client/src/features/testing/TestService.ts
+++ b/editors/code/client/src/features/testing/TestService.ts
@@ -9,6 +9,8 @@ export interface Test {
 export interface TestSuite {
   uri: string;
   suite: string;
+  /** 1-indexed line number where the test class is declared */
+  line: number;
   tests: Test[];
 }
 

--- a/editors/code/client/test/unit/features/testing/GroovyTestController.test.ts
+++ b/editors/code/client/test/unit/features/testing/GroovyTestController.test.ts
@@ -239,6 +239,7 @@ describe("GroovyTestController", () => {
         {
           uri: workspaceUri,
           suite: suiteName,
+          line: 5,
           tests: [{ test: testName, line: 10 }],
         },
       ]);
@@ -336,11 +337,13 @@ describe("GroovyTestController", () => {
         {
           uri: workspaceUri,
           suite: suiteAName,
+          line: 5,
           tests: [{ test: workspaceTestName, line: 10 }],
         },
         {
           uri: "file:///workspace/TestB.groovy",
           suite: suiteBName,
+          line: 8,
           tests: [{ test: "other test", line: 20 }],
         },
       ]);
@@ -428,6 +431,7 @@ describe("GroovyTestController", () => {
         {
           uri: suiteUri,
           suite: suiteName,
+          line: 3,
           tests: [
             { test: "test one", line: 10 },
             { test: "test two", line: 20 },
@@ -490,6 +494,7 @@ describe("GroovyTestController", () => {
         {
           uri: suiteUri,
           suite: suiteName,
+          line: 3,
           tests: [{ test: testName, line: 10 }],
         },
       ]);
@@ -519,6 +524,93 @@ describe("GroovyTestController", () => {
       assert.ok(
         !vscodeMock.window.showErrorMessage.called,
         "Should not show error for valid test name",
+      );
+    });
+  });
+
+  describe("suite range positioning (gutter icon location)", () => {
+    let _controller: any;
+
+    it("should position suite gutter icon at actual class line, not estimated from test methods", async () => {
+      // Regression test for gutter icon positioning bug
+      // The class is at line 8, but the first test method is at line 19
+      // The suite gutter icon should be at line 8 (0-indexed: 7), not line 14 (19 - 5)
+      const suiteUri = "file:///workspace/PublishReportsStepTests.groovy";
+      const suiteName = "PublishReportsStepTests";
+      const classLine = 8; // Class declared at line 8
+      const firstTestLine = 19; // First test method at line 19
+
+      testServiceMock.discoverTestsInWorkspace.resolves([
+        {
+          uri: suiteUri,
+          suite: suiteName,
+          line: classLine, // LSP now provides actual class line
+          tests: [
+            { test: "test_without_trusted_infra", line: firstTestLine },
+            { test: "test_with_trusted_infra", line: 35 },
+          ],
+        },
+      ]);
+
+      _controller = new GroovyTestController(
+        contextMock,
+        executionServiceMock,
+        testServiceMock,
+      );
+
+      // Trigger discovery
+      await testControllerMock.resolveHandler(undefined);
+
+      // Get the suite item
+      const suiteItem = testControllerMock.items.get(suiteName);
+      assert.ok(suiteItem, "Suite item should be created");
+
+      // Verify the suite range uses the actual class line (1-indexed to 0-indexed)
+      // Line 8 (1-indexed) should become Position(7, 0) (0-indexed)
+      const expectedLine = classLine - 1; // Convert 1-indexed to 0-indexed
+      assert.strictEqual(
+        suiteItem.range.start.line,
+        expectedLine,
+        `Suite range should start at line ${expectedLine} (0-indexed from class line ${classLine}), ` +
+          `not ${suiteItem.range.start.line}`,
+      );
+    });
+
+    it("should position test method gutter icon at correct line", async () => {
+      const suiteUri = "file:///workspace/MySpec.groovy";
+      const suiteName = "com.example.MySpec";
+      const testMethodLine = 15;
+
+      testServiceMock.discoverTestsInWorkspace.resolves([
+        {
+          uri: suiteUri,
+          suite: suiteName,
+          line: 3,
+          tests: [{ test: "should work", line: testMethodLine }],
+        },
+      ]);
+
+      _controller = new GroovyTestController(
+        contextMock,
+        executionServiceMock,
+        testServiceMock,
+      );
+
+      // Trigger discovery
+      await testControllerMock.resolveHandler(undefined);
+
+      // Get the test item
+      const suiteItem = testControllerMock.items.get(suiteName);
+      const testItem = suiteItem.children.get(`${suiteName}.should work`);
+
+      assert.ok(testItem, "Test item should be created");
+
+      // Test line should be converted from 1-indexed to 0-indexed
+      const expectedLine = testMethodLine - 1;
+      assert.strictEqual(
+        testItem.range.start.line,
+        expectedLine,
+        `Test range should start at line ${expectedLine} (0-indexed from test line ${testMethodLine})`,
       );
     });
   });

--- a/editors/code/client/test/unit/features/testing/TestService.test.ts
+++ b/editors/code/client/test/unit/features/testing/TestService.test.ts
@@ -29,6 +29,7 @@ describe("TestService", () => {
       {
         uri: "file:///path/to/workspace/MySpec.groovy",
         suite: "MySpec",
+        line: 3,
         tests: [{ test: "should do something", line: 5 }],
       },
     ];

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/testing/TestDiscoveryDtos.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/testing/TestDiscoveryDtos.kt
@@ -10,9 +10,10 @@ data class DiscoverTestsParams(val workspaceUri: String)
  *
  * @property uri File URI (e.g., "file:///path/to/MySpec.groovy")
  * @property suite Fully qualified class name (e.g., "com.example.MySpec")
+ * @property line 1-indexed line number where the test class is declared
  * @property tests List of test methods in this suite
  */
-data class TestSuite(val uri: String, val suite: String, val tests: List<Test>)
+data class TestSuite(val uri: String, val suite: String, val line: Int, val tests: List<Test>)
 
 /**
  * Represents a single test method.

--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/testing/TestDiscoveryProvider.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/testing/TestDiscoveryProvider.kt
@@ -83,17 +83,24 @@ class TestDiscoveryProvider(
             val testItems = registry.extractTests(classNode, ast, classLoader)
             if (testItems.isEmpty()) return@mapNotNull null
 
+            // Extract class line from the CLASS test item
+            val classItem = testItems.find { it.kind == TestItemKind.CLASS }
+            val classLine = classItem?.line ?: classNode.lineNumber.coerceAtLeast(1)
+
             val tests = testItems
                 .filter { it.kind == TestItemKind.METHOD }
                 .map { Test(test = it.name, line = it.line) }
             if (tests.isEmpty()) return@mapNotNull null
 
             val framework = testItems.firstOrNull()?.framework
-            logger.debug { "Found $framework test suite: ${classNode.name} with ${tests.size} tests" }
+            logger.debug {
+                "Found $framework test suite: ${classNode.name} at line $classLine with ${tests.size} tests"
+            }
 
             TestSuite(
                 uri = uri.toString(),
                 suite = classNode.name,
+                line = classLine,
                 tests = tests,
             )
         }

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/testing/TestDiscoveryProviderTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/testing/TestDiscoveryProviderTest.kt
@@ -59,6 +59,49 @@ class TestDiscoveryProviderTest {
     }
 
     @Test
+    fun `should return correct class line for test suite`() = runBlocking {
+        // Test with multiple lines between class and first test method
+        // to ensure we use the actual class line, not an estimate from test methods
+        val uri = URI.create("file:///TestWithSetup.groovy")
+        val content = """
+            package com.example
+            import spock.lang.Specification
+            class TestWithSetup extends Specification {
+                // Line 4: comment
+                // Line 5: more comments
+                def setup() {
+                    // Line 7: setup code
+                }
+                // Line 9: blank
+                // Line 10: more comments
+                def "first test"() {
+                    expect: true
+                }
+            }
+        """.trimIndent()
+
+        val realService = GroovyCompilationService(TestDiscoveryProviderTest::class.java.classLoader)
+        realService.compile(uri, content, compilePhase = Phases.CONVERSION)
+        val parseResult = realService.getParseResult(uri)!!
+
+        val mockService = mockk<GroovyCompilationService>()
+        val mockWorkspaceManager = mockk<com.github.albertocavalcante.groovylsp.compilation.WorkspaceManager>()
+
+        every { mockService.workspaceManager } returns mockWorkspaceManager
+        every { mockWorkspaceManager.getWorkspaceSourceUris() } returns listOf(uri)
+        coEvery { mockService.getValidParseResult(uri) } returns parseResult
+
+        val testProvider = TestDiscoveryProvider(mockService, registry)
+        val suites = testProvider.discoverTests("file:///")
+
+        assertEquals(1, suites.size)
+        // Class is declared at line 3 (1-indexed)
+        assertEquals(3, suites[0].line, "Class line should be the actual class declaration line")
+        // First test method is at line 11 (1-indexed)
+        assertEquals(11, suites[0].tests[0].line, "Test method line should be correct")
+    }
+
+    @Test
     fun `should skip non-Spock classes`() = runBlocking {
         val uri = URI.create("file:///RegularClass.groovy")
         val content = """

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/testing/TestDiscoveryProviderTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/testing/TestDiscoveryProviderTest.kt
@@ -85,7 +85,7 @@ class TestDiscoveryProviderTest {
         val parseResult = realService.getParseResult(uri)!!
 
         val mockService = mockk<GroovyCompilationService>()
-        val mockWorkspaceManager = mockk<com.github.albertocavalcante.groovylsp.compilation.WorkspaceManager>()
+        val mockWorkspaceManager = mockk<WorkspaceManager>()
 
         every { mockService.workspaceManager } returns mockWorkspaceManager
         every { mockWorkspaceManager.getWorkspaceSourceUris() } returns listOf(uri)


### PR DESCRIPTION
## Summary

- Fixed the class runner gutter icon appearing at the wrong line in Test Explorer
- The bug occurred because `TestSuite` DTO didn't include the class line, causing the client to estimate it by subtracting 5 from the first test method's line
- For example, with a class at line 8 and first test at line 19, the icon appeared at ~line 14 instead of line 8

## Changes

**Server-side (Kotlin):**
- Add `line` field to `TestSuite` data class
- Extract actual class line from `TestItemKind.CLASS` in `TestDiscoveryProvider`

**Client-side (TypeScript):**
- Add `line` property to `TestSuite` interface
- Use actual line in `GroovyTestController` instead of estimation

## Test plan

- [x] Added server-side test: `TestDiscoveryProviderTest.should return correct class line for test suite`
- [x] Added client-side test: `GroovyTestController.test.ts` - "should position suite gutter icon at actual class line"
- [x] Verified all 392 TypeScript tests pass
- [x] Verified server-side tests pass
- [ ] Manual verification: Open a test file with setup methods between class declaration and first test, verify gutter icon appears at class line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed test suite gutter icon positioning to use actual class declaration lines from the language server instead of estimated line numbers, improving accuracy of icon placement in the editor.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->