### PR TITLE
fix(semantics): start method name search from declaration column

### DIFF
--- a/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/semantictokens/GroovySemanticTokenProvider.kt
+++ b/groovy-lsp/src/main/kotlin/com/github/albertocavalcante/groovylsp/providers/semantictokens/GroovySemanticTokenProvider.kt
@@ -845,11 +845,14 @@ object GroovySemanticTokenProvider {
 
         // Find the method name followed by '(' to avoid false matches
         // Regex.escape handles any special characters in the method name
+        // Start searching from declaration column to avoid matching earlier occurrences
+        // (e.g., method name appearing in a comment before the actual declaration)
         val namePattern = Regex("""\b${Regex.escape(methodName)}\s*\(""")
-        val match = namePattern.find(sourceLine) ?: return null
+        val declStartIndex = declCol - 1 // Convert 1-based to 0-based
+        val match = namePattern.find(sourceLine, declStartIndex) ?: return null
 
-        // Calculate offset: declCol is 1-based, match.range.first is 0-based
-        return match.range.first - (declCol - 1)
+        // Calculate offset: declStartIndex is 0-based, match.range.first is 0-based
+        return match.range.first - declStartIndex
     }
 
     /**

--- a/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/semantictokens/GroovySemanticTokenProviderTest.kt
+++ b/groovy-lsp/src/test/kotlin/com/github/albertocavalcante/groovylsp/providers/semantictokens/GroovySemanticTokenProviderTest.kt
@@ -1140,4 +1140,43 @@ class GroovySemanticTokenProviderTest {
         assertEquals(1, getMapToken.line, "getMap should be on line 1")
         assertEquals(25, getMapToken.startChar, "getMap should start at column 25")
     }
+
+    @Test
+    fun `should handle method name appearing in comment before declaration on same line`(): Unit = runBlocking {
+        // Regression test: If method name appears in a comment before the actual declaration,
+        // the regex should not match the comment occurrence.
+        // See: https://github.com/albertocavalcante/groovy-lsp/pull/.../files#r... (Copilot review)
+        val code = """
+            class MyClass {
+                /* getMap() doc */ Map<String, Integer> getMap() { [:] }
+            }
+        """.trimIndent()
+
+        val uri = tempWorkspace.resolve("MyClass.groovy").toUri()
+        compilationService.compile(uri, code)
+
+        val astModel = compilationService.getAstModel(uri)!!
+
+        val tokens = GroovySemanticTokenProvider.getSemanticTokens(astModel, uri, sourceText = code)
+
+        // Should have METHOD token for getMap
+        val methodTokens = tokens.filter {
+            it.tokenType == GroovySemanticTokenProvider.TokenTypes.METHOD
+        }
+
+        val getMapToken = assertNotNull(
+            methodTokens.find { it.length == "getMap".length },
+            "Should have METHOD token for getMap",
+        )
+
+        // Line 1: "    /* getMap() doc */ Map<String, Integer> getMap() { [:] }"
+        // The method declaration starts at "Map<String, Integer>" position
+        // 4 spaces + "/* getMap() doc */ " (19) + "Map<String, Integer> " (21) = 44
+        // "getMap" should be at column 44, NOT at column 7 (inside the comment)
+        assertEquals(1, getMapToken.line, "getMap should be on line 1")
+        assertTrue(
+            getMapToken.startChar >= 40,
+            "getMap should start at actual declaration column (>=40), not in comment. Got ${getMapToken.startChar}",
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Fix regex search for method names to start from declaration column instead of line start
- Prevents incorrect token positioning when method name appears in comments before declaration
- Adds regression test for edge case (method name in comment on same line as declaration)

## Problem
The `findMethodNameOffsetFromSource` function was searching for the method name pattern from the beginning of the source line. If the method name appeared earlier in the line (e.g., in a comment like `/* getMap() doc */`), the regex would match that occurrence first, resulting in incorrect (potentially negative) offset calculation.

Example problematic code:
```groovy
/* getMap() doc */ Map<String, Integer> getMap() { [:] }
```
Before fix: Token position = column 7 (inside comment)
After fix: Token position = column 44 (actual method declaration)

## Fix
Use `find(sourceLine, declStartIndex)` to start the search from the declaration column position, avoiding false matches in comments/strings.

## Test plan
- [x] Added regression test `should handle method name appearing in comment before declaration on same line`
- [x] Verified all existing semantic token tests pass