### PR TITLE
refactor(parser): split GroovyAstConverter into specialized converters

### DIFF
--- a/parser/core/src/main/kotlin/com/github/albertocavalcante/groovyparser/internal/DeclarationConverter.kt
+++ b/parser/core/src/main/kotlin/com/github/albertocavalcante/groovyparser/internal/DeclarationConverter.kt
@@ -19,13 +19,9 @@ import java.lang.reflect.Modifier
 /**
  * Converts class, method, field, and constructor declarations.
  *
- * Handles ~150 lines of declaration conversion logic.
+ * Handles ~190 lines of declaration conversion logic.
  */
-internal class DeclarationConverter(
-    private val setRange: (Node, ASTNode) -> Unit,
-    @Suppress("UnusedPrivateProperty") // Reserved for future internal comment attachment logic
-    private val commentAttacher: (Node, ASTNode) -> Unit,
-) {
+internal class DeclarationConverter(private val setRange: (Node, ASTNode) -> Unit) {
 
     /**
      * Converts a Groovy ClassNode to a ClassDeclaration.

--- a/parser/core/src/main/kotlin/com/github/albertocavalcante/groovyparser/internal/ExpressionConverter.kt
+++ b/parser/core/src/main/kotlin/com/github/albertocavalcante/groovyparser/internal/ExpressionConverter.kt
@@ -52,16 +52,11 @@ import org.codehaus.groovy.ast.expr.VariableExpression
 /**
  * Converts binary, unary, ternary, and other complex expressions.
  *
- * Handles ~250 lines of expression conversion logic.
+ * Handles ~420 lines of expression conversion logic.
  */
 @Suppress("TooManyFunctions") // Converter pattern requires one function per expression type
 internal class ExpressionConverter(
     private val setRange: (Node, ASTNode) -> Unit,
-    @Suppress("UnusedPrivateProperty") // Used for future annotation conversion within expressions
-    private val convertAnnotations: (
-        List<org.codehaus.groovy.ast.AnnotationNode>?,
-        com.github.albertocavalcante.groovyparser.ast.Node,
-    ) -> Unit,
 ) {
 
     /**

--- a/parser/core/src/main/kotlin/com/github/albertocavalcante/groovyparser/internal/GroovyAstConverter.kt
+++ b/parser/core/src/main/kotlin/com/github/albertocavalcante/groovyparser/internal/GroovyAstConverter.kt
@@ -68,12 +68,10 @@ internal class GroovyAstConverter {
     private val literalConverter = LiteralConverter(setRange = ::setRange)
     private val expressionConverter = ExpressionConverter(
         setRange = ::setRange,
-        convertAnnotations = ::convertAnnotations,
     )
     private val statementConverter = StatementConverter(setRange = ::setRange)
     private val declarationConverter = DeclarationConverter(
         setRange = ::setRange,
-        commentAttacher = ::attachLeadingComment,
     )
 
     /**

--- a/parser/core/src/main/kotlin/com/github/albertocavalcante/groovyparser/internal/LiteralConverter.kt
+++ b/parser/core/src/main/kotlin/com/github/albertocavalcante/groovyparser/internal/LiteralConverter.kt
@@ -20,7 +20,7 @@ import org.codehaus.groovy.ast.expr.RangeExpression
 /**
  * Converts literal value expressions (strings, numbers, lists, maps, ranges).
  *
- * Handles ~130 lines of literal-specific conversion logic.
+ * Handles 120 lines of literal-specific conversion logic.
  */
 internal class LiteralConverter(private val setRange: (Node, ASTNode) -> Unit) {
 
@@ -76,7 +76,10 @@ internal class LiteralConverter(private val setRange: (Node, ASTNode) -> Unit) {
     /**
      * Converts a Groovy map expression.
      */
-    fun convertMap(expr: MapExpression, convertExpr: (org.codehaus.groovy.ast.expr.Expression) -> Expression): MapExpr {
+    fun convertMap(
+        expr: MapExpression,
+        convertExpr: (org.codehaus.groovy.ast.expr.Expression) -> Expression,
+    ): MapExpr {
         val map = MapExpr()
         expr.mapEntryExpressions?.forEach { entry ->
             val key = convertExpr(entry.keyExpression)

--- a/parser/core/src/main/kotlin/com/github/albertocavalcante/groovyparser/internal/StatementConverter.kt
+++ b/parser/core/src/main/kotlin/com/github/albertocavalcante/groovyparser/internal/StatementConverter.kt
@@ -38,7 +38,7 @@ import org.codehaus.groovy.ast.stmt.WhileStatement as GroovyWhileStatement
 /**
  * Converts control flow statements (if, for, while, try, switch, etc.).
  *
- * Handles ~200 lines of statement conversion logic.
+ * Handles ~280 lines of statement conversion logic.
  */
 internal class StatementConverter(private val setRange: (Node, ASTNode) -> Unit) {
 


### PR DESCRIPTION
## Summary

Completes Phase 3 of #955 (god class refactoring) by splitting the 929-line `GroovyAstConverter` into focused, maintainable components using the composition pattern.

## Changes

### New Files Created
- **LiteralConverter.kt** (109 lines) - Handles literal values: strings, numbers, lists, maps, ranges, arrays
- **ExpressionConverter.kt** (419 lines) - Handles expressions: binary, unary, ternary, method calls, closures, type conversions
- **StatementConverter.kt** (278 lines) - Handles control flow: if, for, while, try, switch, break, continue, assert
- **DeclarationConverter.kt** (189 lines) - Handles declarations: class, method, field, constructor, annotations

### Modified Files
- **GroovyAstConverter.kt** (348 lines, down from 929) - Now coordinates conversion using composition with specialized converters

## Technical Details

- Maintains critical AST ordering (e.g., `DeclarationExpression` before `BinaryExpression`)
- Preserves comment attachment logic with correct position tracking
- All converters use function references for range setting and cross-converter operations
- No behavior changes - all existing tests pass
- All files now under 600 lines as required

## Test Plan

- [x] All parser core tests pass (444 tests)
- [x] Lint checks pass
- [x] Comment preservation tests pass
- [x] No regressions in AST conversion behavior

## Related Issues

Closes #955 (Phase 3)