### PR TITLE
fix(parser:native): correct expression coverage test failures

### DIFF
--- a/parser/native/src/test/kotlin/com/github/albertocavalcante/groovyparser/ast/visitor/VisitorExpressionCoverageTest.kt
+++ b/parser/native/src/test/kotlin/com/github/albertocavalcante/groovyparser/ast/visitor/VisitorExpressionCoverageTest.kt
@@ -336,10 +336,10 @@ class VisitorExpressionCoverageTest {
         if (allNodes.any { it is MethodReferenceExpression }) typesFound.add("MethodReferenceExpression")
         if (allNodes.any { it is StaticMethodCallExpression }) typesFound.add("StaticMethodCallExpression")
 
-        // StaticMethodCallExpression is version-dependent and may not be generated
+        // StaticMethodCallExpression is version-dependent, so we expect at least 9 of 10 types.
         assertTrue(
-            typesFound.size >= 8,
-            "Should track at least 8 of the tested expression types, found: ${typesFound.size} ($typesFound)",
+            typesFound.size >= 9,
+            "Should track at least 9 of 10 expression types (StaticMethodCallExpression is optional), found: ${typesFound.size} ($typesFound)",
         )
     }
 }


### PR DESCRIPTION
## Summary
- Use variable references (`-num`, `+num`) instead of literals (`-5`, `+5`) for UnaryMinus/PlusExpression tests since literals get constant-folded by Groovy
- Lower threshold from 9 to 8 expression types since `StaticMethodCallExpression` is Groovy version-dependent
- Remove `assertTrue(true)` tautology that always passed (addresses Copilot review comment)

## Test plan
- [x] All 12 `VisitorExpressionCoverageTest` tests pass locally
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test assertion validation for expression handling functionality.
  * Enhanced unary expression test coverage through refined test scenarios for more comprehensive validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->