### PR TITLE
ci(claude): add execution logging and failure diagnostics

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -83,6 +83,9 @@ jobs:
             --allowed-tools "Read,Glob,Grep,Bash(gh issue view:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(./gradlew test)"
             --max-turns 5
 
+      # Log path is hardcoded because claude-code-action doesn't expose an output variable.
+      # This is the standard path used by the action on GitHub-hosted runners.
+      # See: https://github.com/anthropics/claude-code-action
       - name: Upload Claude execution log
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -54,6 +54,9 @@ jobs:
             --disallowed-tools "Bash(git add .),Bash(git push --force),Bash(rm -rf:*),Bash(curl :*),Bash(wget :*)"
             --max-turns 10
 
+      # Log path is hardcoded because claude-code-action doesn't expose an output variable.
+      # This is the standard path used by the action on GitHub-hosted runners.
+      # See: https://github.com/anthropics/claude-code-action
       - name: Upload Claude execution log
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
## Summary

- Upload Claude execution logs as artifacts on every run (success or failure)
- Display key execution details in job summary when workflow fails
- Add `gh pr checks` to allowed tools in review workflow (was causing permission denials)

## Changes

### `claude-code-review.yml`
- Added `actions/upload-artifact` step to save execution logs
- Added failure summary step with `$GITHUB_STEP_SUMMARY` 
- Added `Bash(gh pr checks:*)` to allowed tools list

### `claude.yml`
- Added `actions/upload-artifact` step to save execution logs
- Added failure summary step with `$GITHUB_STEP_SUMMARY`

## Context

When the Claude review workflow fails (e.g., hitting max turns or permission denials), there was no easy way to see the execution details. This change:

1. **Artifacts**: Logs are uploaded as `claude-review-log-pr-{PR#}` or `claude-log-{issue/PR#}-{run_id}` with 7-day retention
2. **Job Summary**: On failure, shows type, subtype, duration, cost, and permission denials directly in the Actions UI
3. **Permission fix**: The workflow was failing because `gh pr checks` wasn't in the allowed tools list

## Test plan

- [ ] Verify workflow runs successfully on this PR
- [ ] Manually trigger a failure scenario to confirm logs are uploaded and summary is displayed