### PR TITLE
fix(ci): output proper JSON in failure summary

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -106,7 +106,7 @@ jobs:
               echo "### Execution Details"
               echo '```json'
               if jq -e . "$LOG_FILE" >/dev/null 2>&1; then
-                jq -r 'if .type == "result" then {type, subtype, is_error, duration_ms, num_turns, total_cost_usd, permission_denials} else {type, subtype, message} end' "$LOG_FILE" | head -200
+                jq 'if .type == "result" then {type, subtype, is_error, duration_ms, num_turns, total_cost_usd, permission_denials} else {type, subtype, message} end' "$LOG_FILE" | head -200
               else
                 echo "# Warning: Log is not valid JSON, showing raw content:"
                 head -200 "$LOG_FILE"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -77,7 +77,7 @@ jobs:
               echo "### Execution Details"
               echo '```json'
               if jq -e . "$LOG_FILE" >/dev/null 2>&1; then
-                jq -r 'if .type == "result" then {type, subtype, is_error, duration_ms, num_turns, total_cost_usd, permission_denials} else {type, subtype, message} end' "$LOG_FILE" | head -200
+                jq 'if .type == "result" then {type, subtype, is_error, duration_ms, num_turns, total_cost_usd, permission_denials} else {type, subtype, message} end' "$LOG_FILE" | head -200
               else
                 echo "# Warning: Log is not valid JSON, showing raw content:"
                 head -200 "$LOG_FILE"


### PR DESCRIPTION
## Summary
- Remove `-r` flag from jq in both Claude workflow failure summaries
- Output will now be valid JSON with indentation instead of raw key-value pairs
- Fixes mismatch between ` ```json ` code block and actual output format

## Test plan
- [ ] Trigger a workflow failure and verify JSON output is properly formatted