### PR TITLE
docs: add Starlight documentation website

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,69 @@
+name: Deploy docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/website/**"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: docs/website/package-lock.json
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+
+      - name: Install dependencies
+        working-directory: docs/website
+        run: npm ci
+
+      - name: Build
+        working-directory: docs/website
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: docs/website/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/docs/website/.gitignore
+++ b/docs/website/.gitignore
@@ -1,0 +1,17 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+.astro/
+
+# Environment
+.env
+.env.*
+
+# Editor
+.vscode/
+.idea/
+
+# OS
+.DS_Store

--- a/docs/website/astro.config.ts
+++ b/docs/website/astro.config.ts
@@ -1,0 +1,40 @@
+import starlight from "@astrojs/starlight";
+import { defineConfig } from "astro/config";
+
+export default defineConfig({
+  site: "https://albertocavalcante.github.io",
+  base: "/gvy",
+  integrations: [
+    starlight({
+      title: "Groovy Devtools",
+      description:
+        "Developer tooling for Apache Groovy: Language Server, Diagnostics, Formatting, and more.",
+      social: [
+        {
+          icon: "github",
+          label: "GitHub",
+          href: "https://github.com/albertocavalcante/gvy",
+        },
+      ],
+      editLink: {
+        baseUrl: "https://github.com/albertocavalcante/gvy/edit/main/docs/website/",
+      },
+      lastUpdated: true,
+      customCss: ["./src/styles/custom.css"],
+      sidebar: [
+        {
+          label: "Overview",
+          autogenerate: { directory: "overview" },
+        },
+        {
+          label: "Language Server",
+          autogenerate: { directory: "lsp" },
+        },
+        {
+          label: "Architecture",
+          autogenerate: { directory: "architecture" },
+        },
+      ],
+    }),
+  ],
+});

--- a/docs/website/package.json
+++ b/docs/website/package.json
@@ -10,10 +10,12 @@
     "check": "astro check"
   },
   "dependencies": {
-    "@astrojs/check": "^0.9.4",
     "@astrojs/starlight": "^0.32.2",
     "astro": "^5.1.8",
-    "sharp": "^0.33.5",
+    "sharp": "^0.33.5"
+  },
+  "devDependencies": {
+    "@astrojs/check": "^0.9.4",
     "typescript": "^5.7.3"
   }
 }

--- a/docs/website/package.json
+++ b/docs/website/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "gvy-docs",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "check": "astro check"
+  },
+  "dependencies": {
+    "@astrojs/check": "^0.9.4",
+    "@astrojs/starlight": "^0.32.2",
+    "astro": "^5.1.8",
+    "sharp": "^0.33.5",
+    "typescript": "^5.7.3"
+  }
+}

--- a/docs/website/public/favicon.svg
+++ b/docs/website/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <text x="4" y="24" font-family="system-ui, sans-serif" font-size="24" font-weight="bold" fill="#2563eb">G</text>
+</svg>

--- a/docs/website/src/content/docs/architecture/semanticdb.mdx
+++ b/docs/website/src/content/docs/architecture/semanticdb.mdx
@@ -1,0 +1,88 @@
+---
+title: SemanticDB Design
+description: Semantic analysis architecture based on SemanticDB
+sidebar:
+  order: 1
+---
+
+The `semantics` module provides semantic analysis for Groovy source code based on the **SemanticDB** specification.
+
+## Architecture
+
+```
+┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
+│  Groovy Source  │────▶│  Type Inference  │────▶│ SemanticDocument│
+│     Files       │     │   & Analysis     │     │   (per-file)    │
+└─────────────────┘     └──────────────────┘     └────────┬────────┘
+                                                          │
+                                                          ▼
+                                                ┌─────────────────┐
+                                                │ GroovySemanticDB│
+                                                │  (workspace DB) │
+                                                └────────┬────────┘
+                                                          │
+                        ┌─────────────────────────────────┼─────────────────────────────────┐
+                        │                                 │                                 │
+                        ▼                                 ▼                                 ▼
+               ┌────────────────┐              ┌─────────────────┐              ┌─────────────────┐
+               │ Go-to-Definition│              │ Find References │              │  Hover / Types  │
+               └────────────────┘              └─────────────────┘              └─────────────────┘
+```
+
+## What is SemanticDB?
+
+**SemanticDB is a data model and specification for semantic information about programs.**
+
+It was created by the [Scalameta](https://scalameta.org/) project and is used by:
+- [Metals](https://scalameta.org/metals/) (Scala LSP)
+- [Scalafix](https://scalacenter.github.io/scalafix/) (refactoring)
+- [SCIP](https://sourcegraph.com/docs/code-search/code-navigation/writing_an_indexer) (Sourcegraph code intelligence)
+
+### Specification
+
+- [SemanticDB Guide](https://scalameta.org/docs/semanticdb/guide.html)
+- [SemanticDB Specification](https://scalameta.org/docs/semanticdb/specification.html)
+- [Protobuf Schema](https://github.com/scalameta/scalameta/blob/main/semanticdb/semanticdb/semanticdb.proto)
+
+### Core Concepts
+
+| Concept | Description | Example |
+|---------|-------------|---------|
+| **Symbol** | Unique identifier for a definition | `com/example/MyClass#myMethod().` |
+| **SymbolInformation** | Metadata about a symbol | Method `myMethod` returns `String` |
+| **SymbolOccurrence** | Location where a symbol appears | Line 42, columns 10-18, role=REFERENCE |
+
+## Why SemanticDB?
+
+1. **Decoupling**: Clear boundary between producers (compilers) and consumers (IDEs)
+2. **Per-file granularity**: Incremental updates, parallel processing, low memory
+3. **Cross-language**: Navigate between Groovy and Java seamlessly
+4. **Well-defined spec**: Documented schema, versioning, existing ecosystem
+
+## Module Structure
+
+```
+semantics/
+├── core/           # Core SemanticDB implementation
+│   └── db/         # GroovySemanticDB, SemanticDocument
+│   └── calculator/ # Type inference
+├── dsl/            # DSL-specific semantic extensions
+├── native/         # Native (GraalVM) integration
+└── openrewrite/    # OpenRewrite type mapping
+```
+
+## LSP Integration
+
+| Feature | SemanticDB Usage |
+|---------|------------------|
+| **Go to Definition** | `findSymbolDefinition(symbolId)` |
+| **Find References** | `findAllOccurrences(symbolId)` |
+| **Hover** | `SymbolInfo.type` → display type |
+| **Document Symbols** | `SemanticDocument.symbols` |
+| **Workspace Symbols** | Query across all documents |
+
+## References
+
+- [SemanticDB Guide](https://scalameta.org/docs/semanticdb/guide.html)
+- [SemanticDB Specification](https://scalameta.org/docs/semanticdb/specification.html)
+- [SCIP-Java Design](https://github.com/sourcegraph/scip-java/blob/main/docs/design.md)

--- a/docs/website/src/content/docs/index.mdx
+++ b/docs/website/src/content/docs/index.mdx
@@ -1,0 +1,55 @@
+---
+title: Groovy Devtools
+description: Developer tooling for Apache Groovy
+template: splash
+hero:
+  tagline: A monorepo of Apache Groovy tooling. The Language Server is the primary component, with support for Jenkins pipelines and Spock tests.
+  actions:
+    - text: Get Started
+      link: /gvy/overview/
+      icon: right-arrow
+    - text: GitHub
+      link: https://github.com/albertocavalcante/gvy
+      icon: external
+      variant: minimal
+---
+
+import { Card, CardGrid } from "@astrojs/starlight/components";
+
+## Status
+
+The Groovy Language Server is **work in progress** but already provides core editor features.
+
+<CardGrid>
+  <Card title="Core LSP" icon="laptop">
+    Completion, hover, navigation, formatting, diagnostics, code actions,
+    rename, folding, semantic tokens.
+  </Card>
+  <Card title="Jenkins" icon="rocket">
+    Metadata-driven completion and diagnostics for Jenkins pipelines.
+  </Card>
+  <Card title="Spock" icon="puzzle">
+    Spec detection and block awareness for Spock tests.
+  </Card>
+  <Card title="Editors" icon="document">
+    VS Code/Cursor/VSCodium extension available.
+  </Card>
+</CardGrid>
+
+## Requirements
+
+- Java 17 or higher
+- Groovy 4.0+
+
+## Quick Start
+
+```bash
+# Build
+./gradlew build
+
+# Run (stdio mode)
+java -jar build/libs/groovy-lsp-<version>.jar
+
+# Run (socket mode)
+java -jar build/libs/groovy-lsp-<version>.jar socket 8080
+```

--- a/docs/website/src/content/docs/lsp/feature-support.mdx
+++ b/docs/website/src/content/docs/lsp/feature-support.mdx
@@ -1,0 +1,85 @@
+---
+title: Feature Support
+description: LSP feature support matrix
+sidebar:
+  order: 2
+---
+
+Groovy LSP targets Language Server Protocol (LSP) 3.17. The matrix below is based on the official specification and the
+current server capabilities and implementations.
+
+**Legend:**
+- **yes**: Supported and advertised to clients
+- **partial**: Implemented but limited or not advertised yet
+- **no**: Not implemented
+
+## Lifecycle
+
+| Method | Support | Notes |
+|--------|---------|-------|
+| `initialize` | yes | Initializes server capabilities |
+| `initialized` | yes | Kicks off background setup |
+| `shutdown` | yes | Graceful shutdown |
+| `exit` | yes | Process exit |
+
+## Text Document Sync
+
+| Method | Support | Notes |
+|--------|---------|-------|
+| `textDocument/didOpen` | yes | Triggers compilation and diagnostics |
+| `textDocument/didChange` | yes | Full sync only |
+| `textDocument/didSave` | yes | |
+| `textDocument/didClose` | yes | Clears diagnostics |
+| `textDocument/willSave` | no | |
+| `textDocument/willSaveWaitUntil` | no | |
+
+## Language Features
+
+| Method | Support | Notes |
+|--------|---------|-------|
+| `textDocument/completion` | yes | Keywords + AST-based symbols |
+| `completion/resolve` | no | |
+| `textDocument/hover` | yes | Type info + documentation |
+| `textDocument/signatureHelp` | yes | Method parameter hints |
+| `textDocument/definition` | yes | |
+| `textDocument/typeDefinition` | yes | |
+| `textDocument/implementation` | partial | Implemented; capability not advertised yet |
+| `textDocument/references` | yes | |
+| `textDocument/documentSymbol` | yes | |
+| `textDocument/documentHighlight` | yes | |
+| `textDocument/rename` | yes | No `prepareRename` support |
+| `textDocument/codeAction` | yes | Quick fixes + formatting |
+| `textDocument/codeLens` | yes | Test run/debug lenses |
+| `textDocument/foldingRange` | yes | |
+| `textDocument/formatting` | yes | OpenRewrite |
+| `textDocument/semanticTokens/full` | partial | Jenkins pipeline focus |
+| `textDocument/inlayHint` | no | |
+| `textDocument/selectionRange` | no | |
+| `textDocument/documentLink` | no | |
+
+## Diagnostics
+
+| Method | Support | Notes |
+|--------|---------|-------|
+| `textDocument/publishDiagnostics` | yes | Push-based diagnostics |
+| `textDocument/diagnostic` | no | Pull diagnostics not implemented |
+| `workspace/diagnostic` | no | Pull diagnostics not implemented |
+
+## Workspace
+
+| Method | Support | Notes |
+|--------|---------|-------|
+| `workspace/symbol` | yes | |
+| `workspace/executeCommand` | partial | `groovy.version` handler only; not advertised |
+| `workspace/didChangeConfiguration` | yes | |
+| `workspace/didChangeWatchedFiles` | yes | Registered dynamically when supported |
+| `workspace/didChangeWorkspaceFolders` | no | |
+
+## Window
+
+| Method | Support | Notes |
+|--------|---------|-------|
+| `window/showMessage` | yes | Startup and error notifications |
+| `window/workDoneProgress/create` | yes | Dependency resolution progress |
+| `$/progress` | yes | WorkDoneProgress updates |
+| `telemetry/event` | yes | Formatting + definition telemetry |

--- a/docs/website/src/content/docs/lsp/usage.mdx
+++ b/docs/website/src/content/docs/lsp/usage.mdx
@@ -1,0 +1,38 @@
+---
+title: Usage
+description: How to build and run the Groovy Language Server
+sidebar:
+  order: 1
+---
+
+## Requirements
+
+- Java 17 or newer
+- Groovy 4.0+
+
+## Build
+
+```bash
+./gradlew build
+```
+
+This produces a fat JAR under `build/libs/`.
+
+## Run
+
+### Stdio mode (default)
+
+```bash
+java -jar build/libs/groovy-lsp-<version>.jar
+```
+
+### Socket mode
+
+```bash
+java -jar build/libs/groovy-lsp-<version>.jar socket 8080
+```
+
+## Editors
+
+- **VS Code extension**: See the [editors/code](https://github.com/albertocavalcante/gvy/tree/main/editors/code) directory
+- **Jupyter kernels**: Early WIP in `jupyter/`

--- a/docs/website/src/content/docs/overview/index.mdx
+++ b/docs/website/src/content/docs/overview/index.mdx
@@ -1,0 +1,34 @@
+---
+title: Overview
+description: Groovy Devtools monorepo overview
+sidebar:
+  order: 1
+---
+
+Groovy Devtools is a monorepo of developer tooling for Apache Groovy. The Groovy Language Server (LSP) is the main
+component and remains a work in progress, while the surrounding modules provide parsing, diagnostics, formatting,
+Jenkins metadata, test discovery, and editor integrations.
+
+## Components
+
+| Module | Description |
+|--------|-------------|
+| `gls/` | Language Server (Kotlin/JVM) |
+| `semantics/` | Semantic analysis based on [SemanticDB](https://scalameta.org/docs/semanticdb/guide.html) |
+| `parser/` | Parsing libraries (`api`, `native`, `core`) |
+| `diagnostics/` | Compiler + CodeNarc diagnostics |
+| `fmt/` | OpenRewrite-based formatting |
+| `jenkins/` | Jenkins pipeline metadata + completions |
+| `ext/spock/` | Spock framework awareness |
+| `ext/testing/`, `ext/junit/` | Test discovery + adapters |
+| `jupyter/` | Groovy and Jenkins Jupyter kernels |
+| `editors/code/` | VS Code/Cursor/VSCodium extension |
+| `tools/jenkins-extractor/` | Jenkins metadata extractor |
+| `tests/` | End-to-end LSP scenarios |
+
+## Technology
+
+- **Kotlin 2.0** for implementation
+- **LSP4J 0.24.0** for protocol implementation
+- **Gradle** for builds
+- **LSP 3.17** target specification

--- a/docs/website/src/content/docs/overview/roadmap.mdx
+++ b/docs/website/src/content/docs/overview/roadmap.mdx
@@ -1,0 +1,25 @@
+---
+title: Roadmap
+description: Development roadmap and current status
+sidebar:
+  order: 2
+---
+
+Groovy Devtools is under active development. The language server is usable for core Groovy projects today, while the
+broader monorepo is expanding to cover Jenkins pipelines, Spock, testing, and notebooks.
+
+## Current Status
+
+| Area | Status |
+|------|--------|
+| Core LSP | Completion, hover, navigation, formatting, diagnostics, code actions, rename, semantic tokens (Jenkins) |
+| Jenkins pipelines | Metadata-driven completion and diagnostics; deeper context support in progress |
+| Spock | Spec detection and block awareness; richer DSL support in progress |
+| Testing | CodeLens run/debug for tests, shared test discovery utilities |
+| Jupyter | Early kernel prototypes for Groovy and Jenkins |
+
+## Near-term Focus
+
+- Stability and performance for indexing and compilation
+- Workspace-scale features (config refresh, file watching, symbol accuracy)
+- Editor polish in VS Code and other clients

--- a/docs/website/src/styles/custom.css
+++ b/docs/website/src/styles/custom.css
@@ -1,0 +1,13 @@
+/* Minimal custom styles for Groovy Devtools docs */
+
+:root {
+  --sl-color-accent-low: #1a365d;
+  --sl-color-accent: #2563eb;
+  --sl-color-accent-high: #60a5fa;
+}
+
+:root[data-theme="light"] {
+  --sl-color-accent-low: #dbeafe;
+  --sl-color-accent: #2563eb;
+  --sl-color-accent-high: #1e40af;
+}

--- a/docs/website/tsconfig.json
+++ b/docs/website/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "strictNullChecks": true
+  }
+}


### PR DESCRIPTION
## Summary

Add initial documentation website using [Astro Starlight](https://starlight.astro.build/).

## Structure

```
docs/website/
├── astro.config.ts
├── package.json
├── src/content/docs/
│   ├── index.mdx              # Homepage
│   ├── overview/
│   │   ├── index.mdx          # Project overview
│   │   └── roadmap.mdx        # Current status
│   ├── lsp/
│   │   ├── usage.mdx          # Build & run
│   │   └── feature-support.mdx # LSP 3.17 matrix
│   └── architecture/
│       └── semanticdb.mdx     # SemanticDB design
└── .github/workflows/docs.yml  # GitHub Pages deploy
```

## Research

Studied best practices from:
- [Biome](https://biomejs.dev) - enterprise-grade, i18n, blog
- [Knip](https://knip.dev) - clean autogenerate sidebar
- [Starlight](https://starlight.astro.build) - official docs

## Approach

- All content sourced from existing `docs/*.md` files
- No slop - only documented, implemented features
- Minimal config, autogenerate sidebar
- GitHub Pages deployment on push to main

## Test plan

- [ ] `npm install && npm run build` in `docs/website/`
- [ ] Enable GitHub Pages in repo settings (source: GitHub Actions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated documentation website deployment to GitHub Pages on main branch updates.
  * Launched comprehensive documentation website covering architecture, LSP feature support, usage guides, and project overview.

* **Documentation**
  * SemanticDB architecture documentation with diagrams and concepts.
  * LSP feature support matrix and integration guide.
  * Project overview and development roadmap.

* **Chores**
  * Documentation website build configuration and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->